### PR TITLE
Add MultiplexedToolService

### DIFF
--- a/server/tests/conftest.py
+++ b/server/tests/conftest.py
@@ -22,7 +22,7 @@ from emcie.server.core.sessions import (
     SessionListener,
     SessionStore,
 )
-from emcie.server.core.tools import LocalToolService, ToolService
+from emcie.server.core.tools import MultiplexedToolService, LocalToolService, ToolService
 from emcie.server.engines.alpha.engine import AlphaEngine
 from emcie.server.core.terminology import TerminologyChromaStore, TerminologyStore
 from emcie.server.engines.common import Engine
@@ -58,7 +58,10 @@ async def container() -> AsyncIterator[Container]:
     container[GuidelineStore] = Singleton(GuidelineDocumentStore)
     container[GuidelineConnectionStore] = Singleton(GuidelineConnectionDocumentStore)
     container[LocalToolService] = Singleton(LocalToolService)
-    container[ToolService] = lambda c: c[LocalToolService]
+    container[MultiplexedToolService] = MultiplexedToolService(
+        services={"local": container[LocalToolService]}
+    )
+    container[ToolService] = lambda c: c[MultiplexedToolService]
     container[SessionStore] = Singleton(SessionDocumentStore)
     container[ContextVariableStore] = Singleton(ContextVariableDocumentStore)
     container[EndUserStore] = Singleton(EndUserDocumentStore)


### PR DESCRIPTION
### **PR Type**
Enhancement, Tests


___

### **Description**
- Introduced `MultiplexedToolService` to handle multiple tool services.
- Implemented methods for listing, reading, and calling tools across different services.
- Updated container configuration to use `MultiplexedToolService` instead of `LocalToolService`.
- Modified tests to utilize `MultiplexedToolService` for tool creation and retrieval.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>tools.py</strong><dd><code>Introduce <code>MultiplexedToolService</code> for handling multiple tool services</code></dd></summary>
<hr>

server/src/emcie/server/core/tools.py

<li>Added <code>MultiplexedToolService</code> class to handle multiple tool services.<br> <li> Implemented methods for listing, reading, and calling tools across <br>services.<br> <li> Added helper methods for multiplexing and demultiplexing tool <br>identifiers.<br>


</details>


  </td>
  <td><a href="https://github.com/emcie-co/emcie/pull/45/files#diff-a615812a45754ecc3ff8f5f3f77f87f9dd00c54d14950f4667e8e01bebf8c0e2">+65/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>conftest.py</strong><dd><code>Update container configuration to use `MultiplexedToolService`</code></dd></summary>
<hr>

server/tests/conftest.py

<li>Imported <code>MultiplexedToolService</code>.<br> <li> Updated container configuration to use <code>MultiplexedToolService</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/emcie-co/emcie/pull/45/files#diff-dd9c38840c14d9cc476d66287ba75aa454850ee048c04d4ea3f48e6748ad509e">+5/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>test_engine_advanced.py</strong><dd><code>Modify tests to use `MultiplexedToolService` for tool operations</code></dd></summary>
<hr>

server/tests/engines/alpha/test_engine_advanced.py

<li>Imported <code>MultiplexedToolService</code>.<br> <li> Modified test setup to use <code>MultiplexedToolService</code> for tool creation <br>and retrieval.<br>


</details>


  </td>
  <td><a href="https://github.com/emcie-co/emcie/pull/45/files#diff-432d243900c01f92d3d2c2e70994e68f6b228d698b51ff9210a32674e126769c">+9/-18</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

