### PR TITLE
Support async tools

### DIFF
--- a/common/src/emcie/common/plugin.py
+++ b/common/src/emcie/common/plugin.py
@@ -251,7 +251,12 @@ class PluginServer:
             request: CallToolRequest,
         ) -> CallToolResponse:
             stub_context = ToolContext()
+
             result = self.tools[tool_id].function(stub_context, **request.arguments)  # type: ignore
+
+            if inspect.isawaitable(result):
+                result = await result
+
             return CallToolResponse(result=result)
 
         return app

--- a/server/tests/core/test_plugins.py
+++ b/server/tests/core/test_plugins.py
@@ -58,3 +58,17 @@ async def test_that_a_plugin_calls_a_tool() -> None:
                 arguments={"arg_1": 2, "arg_2": 4},
             )
             assert result == 8
+
+
+async def test_that_a_plugin_calls_an_async_tool() -> None:
+    @tool
+    async def my_tool(context: ToolContext, arg_1: int, arg_2: int) -> int:
+        return arg_1 * arg_2
+
+    async with run_plugin_server([my_tool]) as server:
+        async with PluginClient(server.host, server.port) as client:
+            result = await client.call_tool(
+                my_tool.tool.id,
+                arguments={"arg_1": 2, "arg_2": 4},
+            )
+            assert result == 8


### PR DESCRIPTION
### **PR Type**
Enhancement, Tests


___

### **Description**
- Added support for async tool functions in the plugin system by checking if the result is awaitable and awaiting it if necessary.
- Added a test case to ensure async tool functions are correctly called and awaited, returning the expected result.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>plugin.py</strong><dd><code>Add support for async tool functions in plugin system</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

common/src/emcie/common/plugin.py

<li>Added support for async tool functions.<br> <li> Checked if the result is awaitable and awaited it if necessary.<br>


</details>


  </td>
  <td><a href="https://github.com/emcie-co/emcie/pull/47/files#diff-37215b6f613a0ae8122deb2e3bec5ae48616bdba1dc789ede82f1a2fc1dbad5c">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_plugins.py</strong><dd><code>Add test case for async tool function in plugins</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

server/tests/core/test_plugins.py

<li>Added a test case for calling an async tool.<br> <li> Ensured the async tool is correctly awaited and returns the expected <br>result.<br>


</details>


  </td>
  <td><a href="https://github.com/emcie-co/emcie/pull/47/files#diff-7410048f672c5ba4916fe220a1205721038f055609009c8808ec9b184ecaf567">+14/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

