### PR TITLE
Support metadata in tool results

### DIFF
--- a/common/src/emcie/common/plugin.py
+++ b/common/src/emcie/common/plugin.py
@@ -5,6 +5,7 @@ import inspect
 from types import TracebackType
 from typing import (
     Any,
+    Awaitable,
     Callable,
     NamedTuple,
     Optional,
@@ -19,24 +20,54 @@ from fastapi import FastAPI
 from pydantic import BaseModel
 import uvicorn
 
-from emcie.common.tools import Tool, ToolId, ToolParameter, ToolParameterType
+from emcie.common.tools import (
+    Tool,
+    ToolContext,
+    ToolId,
+    ToolParameter,
+    ToolParameterType,
+    ToolResult,
+)
 from emcie.common.types import JSONSerializable
 
 
-class ToolContext:
-    pass
-
-
 ToolFunction = Union[
-    Callable[[ToolContext], Any],
-    Callable[[ToolContext, Any], Any],
-    Callable[[ToolContext, Any, Any], Any],
-    Callable[[ToolContext, Any, Any, Any], Any],
-    Callable[[ToolContext, Any, Any, Any, Any], Any],
-    Callable[[ToolContext, Any, Any, Any, Any, Any], Any],
-    Callable[[ToolContext, Any, Any, Any, Any, Any, Any], Any],
-    Callable[[ToolContext, Any, Any, Any, Any, Any, Any, Any], Any],
-    Callable[[ToolContext, Any, Any, Any, Any, Any, Any, Any, Any], Any],
+    Callable[
+        [ToolContext],
+        Union[ToolResult, Awaitable[ToolResult]],
+    ],
+    Callable[
+        [ToolContext, Any],
+        Union[ToolResult, Awaitable[ToolResult]],
+    ],
+    Callable[
+        [ToolContext, Any, Any],
+        Union[Awaitable[ToolResult], ToolResult],
+    ],
+    Callable[
+        [ToolContext, Any, Any, Any],
+        Union[ToolResult, Awaitable[ToolResult]],
+    ],
+    Callable[
+        [ToolContext, Any, Any, Any, Any],
+        Union[ToolResult, Awaitable[ToolResult]],
+    ],
+    Callable[
+        [ToolContext, Any, Any, Any, Any, Any],
+        Union[ToolResult, Awaitable[ToolResult]],
+    ],
+    Callable[
+        [ToolContext, Any, Any, Any, Any, Any, Any],
+        Union[ToolResult, Awaitable[ToolResult]],
+    ],
+    Callable[
+        [ToolContext, Any, Any, Any, Any, Any, Any, Any],
+        Union[ToolResult, Awaitable[ToolResult]],
+    ],
+    Callable[
+        [ToolContext, Any, Any, Any, Any, Any, Any, Any, Any],
+        Union[ToolResult, Awaitable[ToolResult]],
+    ],
 ]
 
 
@@ -85,9 +116,8 @@ def _tool_decorator_impl(
         ), "A tool function's first parameter must be 'context: ToolContext'"
 
         assert (
-            (signature.return_annotation in get_args(JSONSerializable))
-            or signature.return_annotation == JSONSerializable
-        ), "A tool function must return a JSON-serializable type"
+            signature.return_annotation == ToolResult
+        ), "A tool function must return a ToolResult object"
 
         for param in parameters[1:]:
             param_type = _resolve_param_type(param)

--- a/common/src/emcie/common/tools.py
+++ b/common/src/emcie/common/tools.py
@@ -1,7 +1,9 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime
-from typing import Literal, NewType, TypedDict, Union
+from typing import Literal, Mapping, NewType, TypedDict, Union
 from typing_extensions import NotRequired
+
+from emcie.common.types import JSONSerializable
 
 
 ToolId = NewType("ToolId", str)
@@ -18,6 +20,16 @@ class ToolParameter(TypedDict):
     type: ToolParameterType
     description: NotRequired[str]
     enum: NotRequired[list[Union[str, int, float, bool]]]
+
+
+class ToolContext:
+    pass
+
+
+@dataclass(frozen=True)
+class ToolResult:
+    data: JSONSerializable
+    metadata: Mapping[str, JSONSerializable] = field(default_factory=dict)
 
 
 @dataclass(frozen=True)

--- a/server/src/emcie/server/core/plugins.py
+++ b/server/src/emcie/server/core/plugins.py
@@ -1,12 +1,11 @@
 from __future__ import annotations
 import dateutil.parser
 from types import TracebackType
-from typing import Optional, Sequence, Type, cast
+from typing import Optional, Sequence, Type
 import httpx
 from urllib.parse import urljoin
 
-from emcie.common.tools import Tool, ToolId, ToolParameter
-from emcie.server.core.common import JSONSerializable
+from emcie.common.tools import Tool, ToolId, ToolResult
 from emcie.server.core.tools import ToolService
 
 
@@ -64,7 +63,7 @@ class PluginClient(ToolService):
         self,
         tool_id: ToolId,
         arguments: dict[str, object],
-    ) -> JSONSerializable:
+    ) -> ToolResult:
         response = await self._http_client.post(
             self._get_url(f"/tools/{tool_id}/calls"),
             json={
@@ -72,7 +71,7 @@ class PluginClient(ToolService):
             },
         )
         content = response.json()
-        return cast(JSONSerializable, content["result"])
+        return ToolResult(**content["result"])
 
     def _get_url(self, path: str) -> str:
         return urljoin(f"{self.url}", path)

--- a/server/src/emcie/server/core/sessions.py
+++ b/server/src/emcie/server/core/sessions.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from datetime import datetime, timezone
-from typing import Any, Literal, NewType, Optional, Sequence, TypedDict
+from typing import Any, Literal, Mapping, NewType, Optional, Sequence, TypedDict
 
 from emcie.server.async_utils import Timeout
 from emcie.server.core import common
@@ -36,14 +36,19 @@ class MessageEventData(TypedDict):
     message: str
 
 
-class _ToolResult(TypedDict):
+class ToolResult(TypedDict):
+    data: JSONSerializable
+    metadata: Mapping[str, JSONSerializable]
+
+
+class _ToolCallResult(TypedDict):
     tool_name: str
     arguments: dict[str, object]
-    result: JSONSerializable
+    result: ToolResult
 
 
 class ToolEventData(TypedDict):
-    tool_results: list[_ToolResult]
+    tool_results: list[_ToolCallResult]
 
 
 ConsumerId = Literal["client"]

--- a/server/tests/core/test_plugins.py
+++ b/server/tests/core/test_plugins.py
@@ -1,7 +1,8 @@
 from contextlib import asynccontextmanager
 from typing import AsyncIterator, Optional
 
-from emcie.common.plugin import PluginServer, ToolContext, ToolEntry, tool
+from emcie.common.tools import ToolContext, ToolResult
+from emcie.common.plugin import PluginServer, ToolEntry, tool
 from emcie.server.core.plugins import PluginClient
 
 
@@ -23,9 +24,9 @@ async def test_that_a_plugin_with_no_configured_tools_returns_no_tools() -> None
 
 async def test_that_a_plugin_with_one_configured_tool_returns_that_tool() -> None:
     @tool
-    def my_tool(context: ToolContext, arg_1: int, arg_2: Optional[int]) -> int:
+    def my_tool(context: ToolContext, arg_1: int, arg_2: Optional[int]) -> ToolResult:
         """My tool's description"""
-        return arg_1 * (arg_2 or 0)
+        return ToolResult(arg_1 * (arg_2 or 0))
 
     async with run_plugin_server([my_tool]) as server:
         async with PluginClient(server.url) as client:
@@ -36,9 +37,9 @@ async def test_that_a_plugin_with_one_configured_tool_returns_that_tool() -> Non
 
 async def test_that_a_plugin_reads_a_tool() -> None:
     @tool
-    def my_tool(context: ToolContext, arg_1: int, arg_2: Optional[int]) -> int:
+    def my_tool(context: ToolContext, arg_1: int, arg_2: Optional[int]) -> ToolResult:
         """My tool's description"""
-        return arg_1 * (arg_2 or 0)
+        return ToolResult(arg_1 * (arg_2 or 0))
 
     async with run_plugin_server([my_tool]) as server:
         async with PluginClient(server.url) as client:
@@ -48,8 +49,8 @@ async def test_that_a_plugin_reads_a_tool() -> None:
 
 async def test_that_a_plugin_calls_a_tool() -> None:
     @tool
-    def my_tool(context: ToolContext, arg_1: int, arg_2: int) -> int:
-        return arg_1 * arg_2
+    def my_tool(context: ToolContext, arg_1: int, arg_2: int) -> ToolResult:
+        return ToolResult(arg_1 * arg_2)
 
     async with run_plugin_server([my_tool]) as server:
         async with PluginClient(server.url) as client:
@@ -57,13 +58,13 @@ async def test_that_a_plugin_calls_a_tool() -> None:
                 my_tool.tool.id,
                 arguments={"arg_1": 2, "arg_2": 4},
             )
-            assert result == 8
+            assert result.data == 8
 
 
 async def test_that_a_plugin_calls_an_async_tool() -> None:
     @tool
-    async def my_tool(context: ToolContext, arg_1: int, arg_2: int) -> int:
-        return arg_1 * arg_2
+    async def my_tool(context: ToolContext, arg_1: int, arg_2: int) -> ToolResult:
+        return ToolResult(arg_1 * arg_2)
 
     async with run_plugin_server([my_tool]) as server:
         async with PluginClient(server.url) as client:
@@ -71,4 +72,4 @@ async def test_that_a_plugin_calls_an_async_tool() -> None:
                 my_tool.tool.id,
                 arguments={"arg_1": 2, "arg_2": 4},
             )
-            assert result == 8
+            assert result.data == 8

--- a/server/tests/e2e/test_server_cli.py
+++ b/server/tests/e2e/test_server_cli.py
@@ -4,7 +4,8 @@ import signal
 import traceback
 import httpx
 
-from emcie.common.plugin import PluginServer, ToolContext, tool
+from emcie.common.tools import ToolContext, ToolResult
+from emcie.common.plugin import PluginServer, tool
 
 from emcie.server.core.sessions import Event
 from tests.e2e.test_utilities import (
@@ -126,9 +127,9 @@ async def test_that_the_server_loads_and_interacts_with_a_plugin(
     context: _TestContext,
 ) -> None:
     @tool(id="about_dor", name="about_dor")
-    def about_dor(context: ToolContext) -> str:
+    def about_dor(context: ToolContext) -> ToolResult:
         """Gets information about Dor"""
-        return "Dor makes great pizza"
+        return ToolResult("Dor makes great pizza", {"metadata_item": 123})
 
     plugin_port = 8090
 

--- a/server/tests/features/engines/alpha/tools/single_tool_event.feature
+++ b/server/tests/features/engines/alpha/tools/single_tool_event.feature
@@ -100,7 +100,7 @@ Feature: Single Tool Event
         And the tool "get_account_balance"
         And an association between "retrieve_account_information" and "get_account_balance"
         And a user message, "What is the balance of Larry David's account?"
-        And a tool event with data, [{ "tool_calls": { "tool_name": "get_account_balance", "parameters": { "account_name": "Larry David"}, "result": 450000000}}]
+        And a tool event with data, [{ "tool_calls": { "tool_name": "get_account_balance", "parameters": { "account_name": "Larry David"}, "result": { "data": 451000000, "metadata": {} }}}]
         And a server message, "Larry David currently has 451 million dollars."
         And a user message, "And what about now?"
         When processing is triggered

--- a/server/tests/tool_utilities.py
+++ b/server/tests/tool_utilities.py
@@ -1,56 +1,58 @@
 from typing import Literal
 
-
-def get_available_drinks() -> list[str]:
-    return ["Sprite", "Coca Cola"]
+from emcie.common.tools import ToolResult
 
 
-def get_available_toppings() -> list[str]:
-    return ["Pepperoni", "Mushrooms", "Olives"]
+def get_available_drinks() -> ToolResult:
+    return ToolResult(["Sprite", "Coca Cola"])
 
 
-def expert_answer(user_query: str) -> str:
+def get_available_toppings() -> ToolResult:
+    return ToolResult(["Pepperoni", "Mushrooms", "Olives"])
+
+
+def expert_answer(user_query: str) -> ToolResult:
     answers = {"Hey, where are your offices located?": "Our Offices located in Tel Aviv"}
-    return answers[user_query]
+    return ToolResult(answers[user_query])
 
 
-def get_available_product_by_type(product_type: Literal["drinks", "toppings"]) -> list[str]:
+def get_available_product_by_type(product_type: Literal["drinks", "toppings"]) -> ToolResult:
     if product_type == "drinks":
         return get_available_drinks()
     elif product_type == "toppings":
         return get_available_toppings()
     else:
-        return []
+        return ToolResult([])
 
 
-def add(first_number: int, second_number: int) -> int:
-    return first_number + second_number
+def add(first_number: int, second_number: int) -> ToolResult:
+    return ToolResult(first_number + second_number)
 
 
-def multiply(first_number: int, second_number: int) -> int:
-    return first_number * second_number
+def multiply(first_number: int, second_number: int) -> ToolResult:
+    return ToolResult(first_number * second_number)
 
 
-def get_account_balance(account_name: str) -> int:
+def get_account_balance(account_name: str) -> ToolResult:
     balances = {
         "Jerry Seinfeld": 1000000000,
         "Larry David": 450000000,
         "John Smith": 100,
     }
-    return balances.get(account_name, -1)
+    return ToolResult(balances.get(account_name, -1))
 
 
-def get_account_loans(account_name: str) -> int:
+def get_account_loans(account_name: str) -> ToolResult:
     portfolios = {
         "Jerry Seinfeld": 100,
         "Larry David": 50,
     }
-    return portfolios[account_name]
+    return ToolResult(portfolios[account_name])
 
 
-def transfer_money(from_account: str, to_account: str) -> bool:
-    return True
+def transfer_money(from_account: str, to_account: str) -> ToolResult:
+    return ToolResult(True)
 
 
-def get_terrys_offering() -> str:
-    return "Terry offers leaf"
+def get_terrys_offering() -> ToolResult:
+    return ToolResult("Terry offers leaf")


### PR DESCRIPTION
### **PR Type**
Enhancement, Tests


___

### **Description**
- Introduced `ToolResult` class to encapsulate tool outputs with `data` and `metadata`.
- Updated tool function signatures to return `ToolResult` or `Awaitable[ToolResult]`.
- Modified various components to handle `ToolResult` instead of raw JSON-serializable types.
- Updated tests and utility functions to align with the new `ToolResult` structure.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>7 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>plugin.py</strong><dd><code>Update tool function signatures to return ToolResult</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

common/src/emcie/common/plugin.py

<li>Added <code>Awaitable</code> to typing imports.<br> <li> Updated <code>ToolFunction</code> to return <code>ToolResult</code> or <code>Awaitable[ToolResult]</code>.<br> <li> Modified <code>_ensure_valid_tool_signature</code> to check for <code>ToolResult</code> return <br>type.<br>


</details>


  </td>
  <td><a href="https://github.com/emcie-co/emcie/pull/50/files#diff-37215b6f613a0ae8122deb2e3bec5ae48616bdba1dc789ede82f1a2fc1dbad5c">+47/-17</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>tools.py</strong><dd><code>Introduce ToolResult class for tool outputs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

common/src/emcie/common/tools.py

<li>Added <code>ToolResult</code> class with <code>data</code> and <code>metadata</code>.<br> <li> Updated <code>ToolContext</code> class.<br>


</details>


  </td>
  <td><a href="https://github.com/emcie-co/emcie/pull/50/files#diff-85ea3d59c7382ccb1ee1345c77840680c335b50d4578b1be2b5b7d637cf4c556">+14/-2</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>plugins.py</strong><dd><code>Modify PluginClient to return ToolResult</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

server/src/emcie/server/core/plugins.py

- Changed `call_tool` method to return `ToolResult`.



</details>


  </td>
  <td><a href="https://github.com/emcie-co/emcie/pull/50/files#diff-7492dbf6a6c24524bbc0f857aebe2196a80f53fe20c3a609d53cfa88d254b285">+4/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>sessions.py</strong><dd><code>Update session handling with ToolResult</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

server/src/emcie/server/core/sessions.py

- Updated `ToolResult` and `_ToolCallResult` TypedDicts.



</details>


  </td>
  <td><a href="https://github.com/emcie-co/emcie/pull/50/files#diff-74513919c30dc39e0b32cb4e97c80ad7c1d4390efffa78e3d8e58f59b4f82c12">+9/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>tools.py</strong><dd><code>Ensure tool services return ToolResult</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

server/src/emcie/server/core/tools.py

<li>Changed <code>call_tool</code> methods to return <code>ToolResult</code>.<br> <li> Added validation for <code>ToolResult</code> type.<br>


</details>


  </td>
  <td><a href="https://github.com/emcie-co/emcie/pull/50/files#diff-a615812a45754ecc3ff8f5f3f77f87f9dd00c54d14950f4667e8e01bebf8c0e2">+10/-11</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>tool_caller.py</strong><dd><code>Implement ToolCallResult for tool caller</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

server/src/emcie/server/engines/alpha/tool_caller.py

<li>Introduced <code>ToolCallResult</code> class.<br> <li> Updated tool call methods to use <code>ToolCallResult</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/emcie-co/emcie/pull/50/files#diff-14d9d234229aef70b64e33c13512727830ab55b32593ce7d1cc133bba0ebf643">+9/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>tool_utilities.py</strong><dd><code>Update tool utilities to return ToolResult</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

server/tests/tool_utilities.py

- Updated utility functions to return `ToolResult`.



</details>


  </td>
  <td><a href="https://github.com/emcie-co/emcie/pull/50/files#diff-e56adb731649d47661d7202f61171b4ec960e436c892e0aaa685f4e088016a53">+22/-20</a>&nbsp; </td>

</tr>                    
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>test_plugins.py</strong><dd><code>Update plugin tests for ToolResult</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

server/tests/core/test_plugins.py

- Updated test tools to return `ToolResult`.



</details>


  </td>
  <td><a href="https://github.com/emcie-co/emcie/pull/50/files#diff-7410048f672c5ba4916fe220a1205721038f055609009c8808ec9b184ecaf567">+12/-11</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>test_server_cli.py</strong><dd><code>Modify server CLI tests for ToolResult</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

server/tests/e2e/test_server_cli.py

- Updated test tools to return `ToolResult`.



</details>


  </td>
  <td><a href="https://github.com/emcie-co/emcie/pull/50/files#diff-e6f2d7d227ac27edff52442695e4684151bd26639c88c5cf4b17e0962cb49f51">+4/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>single_tool_event.feature</strong><dd><code>Update feature tests for ToolResult</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

server/tests/features/engines/alpha/tools/single_tool_event.feature

- Updated feature file to reflect `ToolResult` structure.



</details>


  </td>
  <td><a href="https://github.com/emcie-co/emcie/pull/50/files#diff-8d6e2cc7865bf56a5d45cd834b2175825f14ec7838c8d4a06c4b6c5a240db0dc">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

