### PR TITLE
Fix wait_for_update not respecting user messages

### DIFF
--- a/server/src/emcie/server/core/sessions.py
+++ b/server/src/emcie/server/core/sessions.py
@@ -350,7 +350,6 @@ class PollingSessionListener(SessionListener):
             events = list(
                 await self._session_store.list_events(
                     session_id,
-                    source="server",
                     min_offset=min_offset,
                 )
             )

--- a/server/tests/test_mc.py
+++ b/server/tests/test_mc.py
@@ -128,3 +128,20 @@ async def test_that_when_a_client_event_is_posted_then_new_server_events_are_pro
     events = list(await context.container[SessionStore].list_events(session.id))
 
     assert len(events) > 1
+
+
+async def test_that_a_session_update_is_detected_as_soon_as_a_client_event_is_posted(
+    context: _TestContext,
+    session: Session,
+) -> None:
+    event = await context.mc.post_client_event(
+        session_id=session.id,
+        kind=Event.MESSAGE_KIND,
+        data={"message": "Hey there"},
+    )
+
+    assert await context.mc.wait_for_update(
+        session_id=session.id,
+        min_offset=event.offset,
+        timeout=Timeout.none(),
+    )


### PR DESCRIPTION
### **PR Type**
bug_fix, tests


___

### **Description**
- Fixed a bug in `wait_for_events` by removing the `source="server"` filter, ensuring user messages are included.
- Added a new test to verify that session updates are detected as soon as a client event is posted, improving test coverage.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>sessions.py</strong><dd><code>Fix event listing to respect user messages</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

server/src/emcie/server/core/sessions.py

<li>Removed the <code>source="server"</code> parameter from the <code>list_events</code> method <br>call.<br> <li> This change ensures that user messages are respected in the event <br>listing.<br>


</details>


  </td>
  <td><a href="https://github.com/emcie-co/emcie/pull/58/files#diff-74513919c30dc39e0b32cb4e97c80ad7c1d4390efffa78e3d8e58f59b4f82c12">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_mc.py</strong><dd><code>Add test for session update detection on client event</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

server/tests/test_mc.py

<li>Added a new test to verify session updates are detected when a client <br>event is posted.<br> <li> Ensures that the <code>wait_for_update</code> function works correctly with user <br>messages.<br>


</details>


  </td>
  <td><a href="https://github.com/emcie-co/emcie/pull/58/files#diff-1e2f1cddbf916b582a07d9dcbaa0a99f45ef96703585a0f534525f714f9b4931">+17/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

