### PR TITLE
Touch up the definition of JSONSerializable

### DIFF
--- a/common/src/emcie/common/types.py
+++ b/common/src/emcie/common/types.py
@@ -1,4 +1,10 @@
-from typing import Mapping, Sequence, Union, TypeAlias
+from typing import (
+    Mapping,
+    Optional,
+    Sequence,
+    TypeAlias,
+    Union,
+)
 
 
 JSONSerializable: TypeAlias = Union[
@@ -9,4 +15,11 @@ JSONSerializable: TypeAlias = Union[
     None,
     Mapping[str, "JSONSerializable"],
     Sequence["JSONSerializable"],
+    Optional[str],
+    Optional[int],
+    Optional[float],
+    Optional[bool],
+    Optional[None],
+    Optional[Mapping[str, "JSONSerializable"]],
+    Optional[Sequence["JSONSerializable"]],
 ]

--- a/server/src/emcie/server/core/common.py
+++ b/server/src/emcie/server/core/common.py
@@ -1,9 +1,9 @@
-from typing import NewType, Optional
+from typing import NewType, Optional, TypeAlias
 import nanoid  # type: ignore
 
 import emcie.common.types
 
-JSONSerializable = emcie.common.types.JSONSerializable
+JSONSerializable: TypeAlias = emcie.common.types.JSONSerializable
 
 UniqueId = NewType("UniqueId", str)
 


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Enhanced the `JSONSerializable` type alias by including `Optional` types for better flexibility.
- Improved code readability by reformatting import statements.
- Updated the usage of `JSONSerializable` to utilize `TypeAlias` for clarity.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>types.py</strong><dd><code>Enhance JSONSerializable with Optional types</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

common/src/emcie/common/types.py

<li>Added <code>Optional</code> types to the <code>JSONSerializable</code> type alias.<br> <li> Reformatted import statements for better readability.<br>


</details>


  </td>
  <td><a href="https://github.com/emcie-co/emcie/pull/61/files#diff-2b814ba9cae4080d792d90e721e5c73519fcd15355b80caeee87d49df63ac00c">+14/-1</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>common.py</strong><dd><code>Update JSONSerializable with TypeAlias usage</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

server/src/emcie/server/core/common.py

<li>Added <code>TypeAlias</code> to the import statements.<br> <li> Updated <code>JSONSerializable</code> to use <code>TypeAlias</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/emcie-co/emcie/pull/61/files#diff-ae8c67fa57e4c3f34afe93eac90637a05743a2eaba537a39628fde852b70c745">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

