### PR TITLE
Allow a decorated tool to be called as-is

### DIFF
--- a/server/tests/core/services/test_plugins.py
+++ b/server/tests/core/services/test_plugins.py
@@ -22,6 +22,20 @@ async def test_that_a_plugin_with_no_configured_tools_returns_no_tools() -> None
             assert not tools
 
 
+async def test_that_a_decorated_tool_can_be_called_directly() -> None:
+    @tool
+    def my_tool(context: ToolContext, arg_1: int, arg_2: Optional[int]) -> ToolResult:
+        """My tool's description"""
+        return ToolResult(arg_1 * (arg_2 or 0))
+
+    context = ToolContext()
+
+    assert my_tool(context, 2, None).data == 0
+    assert my_tool(context, 2, 1).data == 2
+    assert my_tool(context, 2, 2).data == 4
+    assert my_tool(context, arg_1=2, arg_2=3).data == 6
+
+
 async def test_that_a_plugin_with_one_configured_tool_returns_that_tool() -> None:
     @tool
     def my_tool(context: ToolContext, arg_1: int, arg_2: Optional[int]) -> ToolResult:


### PR DESCRIPTION
### **PR Type**
enhancement, tests


___

### **Description**
- Converted `ToolEntry` from a `NamedTuple` to a frozen `dataclass` and added a `__call__` method, allowing it to be called directly.
- Enhanced the `decorator` function to return a `ToolEntry` instance.
- Added a new test to verify that a decorated tool can be invoked directly, covering multiple argument scenarios.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>plugin.py</strong><dd><code>Make `ToolEntry` callable by converting to dataclass</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

common/src/emcie/common/plugin.py

<li>Converted <code>ToolEntry</code> from <code>NamedTuple</code> to a frozen <code>dataclass</code>.<br> <li> Added <code>__call__</code> method to <code>ToolEntry</code> to allow direct invocation.<br> <li> Refactored the <code>decorator</code> function to return a <code>ToolEntry</code> instance.<br>


</details>


  </td>
  <td><a href="https://github.com/emcie-co/emcie/pull/65/files#diff-37215b6f613a0ae8122deb2e3bec5ae48616bdba1dc789ede82f1a2fc1dbad5c">+9/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_plugins.py</strong><dd><code>Add test for direct invocation of decorated tool</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

server/tests/core/services/test_plugins.py

<li>Added a test to verify that a decorated tool can be called directly.<br> <li> Tested various scenarios of calling the tool with different arguments.<br> <br>


</details>


  </td>
  <td><a href="https://github.com/emcie-co/emcie/pull/65/files#diff-4cffc31a4bbbe39acd32329b18dd942e58dc0896486fd044c9dc485cf4b81999">+14/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

