### PR TITLE
Add session_id to the response for the list_events GET request

### DIFF
--- a/server/src/emcie/server/api/sessions.py
+++ b/server/src/emcie/server/api/sessions.py
@@ -69,6 +69,7 @@ class EventDTO(DefaultBaseModel):
 
 
 class ListEventsResponse(DefaultBaseModel):
+    session_id: SessionId
     events: list[EventDTO]
 
 
@@ -187,6 +188,7 @@ def create_router(
         )
 
         return ListEventsResponse(
+            session_id=session_id,
             events=[
                 EventDTO(
                     id=e.id,

--- a/server/tests/api/test_sessions.py
+++ b/server/tests/api/test_sessions.py
@@ -5,7 +5,6 @@ from fastapi import status
 from lagom import Container
 from pytest import fixture, mark
 from datetime import datetime, timezone
-from itertools import count
 
 from emcie.server.core.agents import AgentId
 from emcie.server.core.sessions import EventSource, SessionId, SessionStore
@@ -303,11 +302,12 @@ async def test_that_events_can_be_listed(
     response = client.get(f"/sessions/{session_id}/events")
     assert response.status_code == status.HTTP_200_OK
     data = response.json()
-    assert "events" in data
+
+    assert data["session_id"] == session_id
 
     assert len(data["events"]) == len(session_events)
 
-    for i, event_params, listed_event in zip(count(), session_events, data["events"]):
+    for i, (event_params, listed_event) in enumerate(zip(session_events, data["events"])):
         assert listed_event["offset"] == i
         assert event_is_according_to_params(event=listed_event, params=event_params)
 


### PR DESCRIPTION
### **PR Type**
enhancement, tests


___

### **Description**
- Enhanced the `ListEventsResponse` model by adding a `session_id` attribute to include session identification in the response.
- Updated the `list_events` function to return the `session_id` along with the list of events.
- Improved test coverage by adding assertions to verify the presence of `session_id` in the response.
- Refactored test loop for clarity by using `enumerate`.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>sessions.py</strong><dd><code>Add `session_id` to ListEventsResponse and list_events function</code></dd></summary>
<hr>

server/src/emcie/server/api/sessions.py

<li>Added <code>session_id</code> to <code>ListEventsResponse</code> model.<br> <li> Included <code>session_id</code> in the return statement of <code>list_events</code> function.<br>


</details>


  </td>
  <td><a href="https://github.com/emcie-co/emcie/pull/67/files#diff-c4938aa87dca2d82e77ece5efa004f34927a6291c8b485975f4331dee0464178">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_sessions.py</strong><dd><code>Update tests to validate `session_id` in response</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

server/tests/api/test_sessions.py

<li>Added assertion to check <code>session_id</code> in the response.<br> <li> Modified loop to use <code>enumerate</code> for better readability.<br>


</details>


  </td>
  <td><a href="https://github.com/emcie-co/emcie/pull/67/files#diff-fb836c58b4db094348ed69e70f0baea58fbed83afb25033e8774e5a5ec46bba8">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

