### PR TITLE
Feature/mc 488 fix unclear output format in tool caller

### DIFF
--- a/src/parlant/core/engines/alpha/guideline_proposer.py
+++ b/src/parlant/core/engines/alpha/guideline_proposer.py
@@ -440,8 +440,6 @@ Expected Output
     ```""")
 
         prompt = builder.build()
-        with open("guideline_proposer_prompt feature branch.txt", "w") as f:
-            f.write(prompt)
         return prompt
 
 

--- a/src/parlant/core/engines/alpha/guideline_proposer.py
+++ b/src/parlant/core/engines/alpha/guideline_proposer.py
@@ -440,8 +440,6 @@ Expected Output
     ```""")
 
         prompt = builder.build()
-        with open("guideline_proposer_prompt.txt", "w") as f:
-            f.write(prompt)
         return prompt
 
 

--- a/src/parlant/core/engines/alpha/guideline_proposer.py
+++ b/src/parlant/core/engines/alpha/guideline_proposer.py
@@ -440,6 +440,8 @@ Expected Output
     ```""")
 
         prompt = builder.build()
+        with open("guideline_proposer_prompt feature branch.txt", "w") as f:
+            f.write(prompt)
         return prompt
 
 

--- a/src/parlant/core/engines/alpha/guideline_proposer.py
+++ b/src/parlant/core/engines/alpha/guideline_proposer.py
@@ -301,7 +301,7 @@ class GuidelineProposer:
         formatted_shot += f"""
 - **Expected Result**:
 ```json
-{json.dumps(shot.expected_result.model_dump(mode="json"), indent=2)}
+{json.dumps(shot.expected_result.model_dump(mode="json", exclude_unset=True), indent=2)}
 ```
 """
 
@@ -440,6 +440,8 @@ Expected Output
     ```""")
 
         prompt = builder.build()
+        with open("guideline_proposer_prompt.txt", "w") as f:
+            f.write(prompt)
         return prompt
 
 

--- a/src/parlant/core/engines/alpha/message_event_generator.py
+++ b/src/parlant/core/engines/alpha/message_event_generator.py
@@ -236,7 +236,7 @@ Do not disregard a guideline because you believe its 'when' condition or rationa
         return f"""
 - **Expected Result**:
 ```json
-{json.dumps(shot.expected_result.model_dump(mode="json"), indent=2)}
+{json.dumps(shot.expected_result.model_dump(mode="json", exclude_unset=True), indent=2)}
 ```"""
 
     def _format_prompt(

--- a/src/parlant/core/engines/alpha/prompt_builder.py
+++ b/src/parlant/core/engines/alpha/prompt_builder.py
@@ -202,10 +202,11 @@ The following is information that you're given about the user and context of the
             self.add_section(
                 name=BuiltInSection.GLOSSARY,
                 content=f"""
-The following is a glossary of the business.
-In some cases, a glossary term directly overrides "common knowledge" or the most prevalent definition of that same term (or object).
-Therefore, when encountering any of these terms, prioritize the interpretation provided in the glossary over any definitions you may already know.
-Please be tolerant of possible typos by the user with regards to these terms,and let the user know if/when you assume they meant a term by their typo: ###
+The following is a glossary of the business. 
+Understanding these terms, as they apply to the business, is critical for your task.
+When encountering any of these terms, prioritize the interpretation provided here over any definitions you may already know.
+Please be tolerant of possible typos by the user with regards to these terms,
+and let the user know if/when you assume they meant a term by their typo: ###
 {terms_string}
 ###
 """,  # noqa

--- a/src/parlant/core/engines/alpha/prompt_builder.py
+++ b/src/parlant/core/engines/alpha/prompt_builder.py
@@ -202,11 +202,10 @@ The following is information that you're given about the user and context of the
             self.add_section(
                 name=BuiltInSection.GLOSSARY,
                 content=f"""
-The following is a glossary of the business. 
-Understanding these terms, as they apply to the business, is critical for your task.
-When encountering any of these terms, prioritize the interpretation provided here over any definitions you may already know.
-Please be tolerant of possible typos by the user with regards to these terms,
-and let the user know if/when you assume they meant a term by their typo: ###
+The following is a glossary of the business.
+In some cases, a glossary term directly overrides "common knowledge" or the most prevalent definition of that same term (or object).
+Therefore, when encountering any of these terms, prioritize the interpretation provided in the glossary over any definitions you may already know.
+Please be tolerant of possible typos by the user with regards to these terms,and let the user know if/when you assume they meant a term by their typo: ###
 {terms_string}
 ###
 """,  # noqa

--- a/src/parlant/core/engines/alpha/tool_caller.py
+++ b/src/parlant/core/engines/alpha/tool_caller.py
@@ -425,6 +425,8 @@ However, note that you may choose to have multiple entries in 'tool_calls_for_ca
         )
 
         prompt = builder.build()
+        with open("tool calling prompt.txt", "w") as f:
+            f.write(prompt)
         return prompt
 
     def _add_tool_definitions_section(
@@ -602,7 +604,7 @@ _baseline_shots: Sequence[ToolCallerInferenceShot] = [
             ),
             most_recent_customer_inquiry_or_need_was_already_resolved=False,
             name="check_balance",
-            subtleties_to_be_aware_of="<NOTE ANY SIGNIFICANT SUBTLETIES TO BE AWARE OF WHEN RUNNING THIS TOOL IN OUR AGENT'S CONTEXT>",
+            subtleties_to_be_aware_of="check_balance(12345) is already staged",
             tool_calls_for_candidate_tool=[
                 {
                     "applicability_rationale": "We need the client's current balance to respond to their question",
@@ -612,7 +614,7 @@ _baseline_shots: Sequence[ToolCallerInferenceShot] = [
                     "comparison_with_rejected_tools_including_references_to_subtleties": (
                         "There are no tools in the list of rejected tools"
                     ),
-                    "relevant_subtleties": "<IF SUBTLETIES FOUND, REFER TO THE RELEVANT ONES HERE>",
+                    "relevant_subtleties": "check_balance(12345) is already staged",
                     "a_more_fitting_tool_was_rejected_for_some_reason_and_potentially_despite_a_found_subtlety": False,
                     "better_rejected_tool_name": None,
                     "better_rejected_tool_rationale": None,
@@ -632,14 +634,14 @@ _baseline_shots: Sequence[ToolCallerInferenceShot] = [
             ),
             most_recent_customer_inquiry_or_need_was_already_resolved=False,
             name="ping_supervisor",
-            subtleties_to_be_aware_of="<NOTE ANY SIGNIFICANT SUBTLETIES TO BE AWARE OF WHEN RUNNING THIS TOOL IN OUR AGENT'S CONTEXT>",
+            subtleties_to_be_aware_of="no subtleties were detected",
             tool_calls_for_candidate_tool=[
                 {
                     "applicability_rationale": "There is no reason to notify the supervisor of anything",
                     "applicability_score": 1,
                     "same_call_is_already_staged": False,
                     "comparison_with_rejected_tools_including_references_to_subtleties": "There are no tools in the list of rejected tools",
-                    "relevant_subtleties": "<IF SUBTLETIES FOUND, REFER TO THE RELEVANT ONES HERE>",
+                    "relevant_subtleties": "no subtleties were detected",
                     "a_more_fitting_tool_was_rejected_for_some_reason_and_potentially_despite_a_found_subtlety": False,
                     "should_run": False,
                 }
@@ -660,7 +662,7 @@ _baseline_shots: Sequence[ToolCallerInferenceShot] = [
             ),
             most_recent_customer_inquiry_or_need_was_already_resolved=False,
             name="check_ride_price",
-            subtleties_to_be_aware_of="<NOTE ANY SIGNIFICANT SUBTLETIES TO BE AWARE OF WHEN RUNNING THIS TOOL IN OUR AGENT'S CONTEXT>",
+            subtleties_to_be_aware_of="no subtleties were detected",
             tool_calls_for_candidate_tool=[
                 {
                     "applicability_rationale": "We need to know the price of a ride from New York to Newark to respond to the customer",
@@ -670,7 +672,7 @@ _baseline_shots: Sequence[ToolCallerInferenceShot] = [
                     "comparison_with_rejected_tools_including_references_to_subtleties": (
                         "None of the available reference tools are deemed more suitable for the candidate tool’s application"
                     ),
-                    "relevant_subtleties": "<IF SUBTLETIES FOUND, REFER TO THE RELEVANT ONES HERE>",
+                    "relevant_subtleties": "no subtleties were detected",
                     "a_more_fitting_tool_was_rejected_for_some_reason_and_potentially_despite_a_found_subtlety": False,
                     "better_rejected_tool_name": None,
                     "better_rejected_tool_rationale": None,
@@ -692,7 +694,7 @@ _baseline_shots: Sequence[ToolCallerInferenceShot] = [
             ),
             most_recent_customer_inquiry_or_need_was_already_resolved=False,
             name="check_calories",
-            subtleties_to_be_aware_of="<NOTE ANY SIGNIFICANT SUBTLETIES TO BE AWARE OF WHEN RUNNING THIS TOOL IN OUR AGENT'S CONTEXT>",
+            subtleties_to_be_aware_of="two products need to be checked for calories - margherita and deep dish",
             tool_calls_for_candidate_tool=[
                 {
                     "applicability_rationale": "We need to check how many calories are in the margherita pizza",
@@ -702,7 +704,7 @@ _baseline_shots: Sequence[ToolCallerInferenceShot] = [
                     "comparison_with_rejected_tools_including_references_to_subtleties": (
                         "None of the available reference tools are deemed more suitable for the candidate tool’s application"
                     ),
-                    "relevant_subtleties": "<IF SUBTLETIES FOUND, REFER TO THE RELEVANT ONES HERE>",
+                    "relevant_subtleties": "two products need to be checked for calories - begin with margherita",
                     "a_more_fitting_tool_was_rejected_for_some_reason_and_potentially_despite_a_found_subtlety": False,
                     "better_rejected_tool_name": None,
                     "better_rejected_tool_rationale": None,
@@ -716,7 +718,7 @@ _baseline_shots: Sequence[ToolCallerInferenceShot] = [
                     "comparison_with_rejected_tools_including_references_to_subtleties": (
                         "None of the available reference tools are deemed more suitable for the candidate tool’s application"
                     ),
-                    "relevant_subtleties": "<IF SUBTLETIES FOUND, REFER TO THE RELEVANT ONES HERE>",
+                    "relevant_subtleties": "two products need to be checked for calories - now check deep dish",
                     "a_more_fitting_tool_was_rejected_for_some_reason_and_potentially_despite_a_found_subtlety": False,
                     "better_rejected_tool_name": None,
                     "better_rejected_tool_rationale": None,
@@ -735,7 +737,7 @@ _baseline_shots: Sequence[ToolCallerInferenceShot] = [
             most_recent_customer_inquiry_or_need="Checking the price of a Harley-Davidson Street Glide motorcycle",
             most_recent_customer_inquiry_or_need_was_already_resolved=False,
             name="check_motorcycle_price",
-            subtleties_to_be_aware_of="<NOTE ANY SIGNIFICANT SUBTLETIES TO BE AWARE OF WHEN RUNNING THIS TOOL IN OUR AGENT'S CONTEXT>",
+            subtleties_to_be_aware_of="Both the candidate and referenc tool could apply - we need to choose the one that applies best",
             tool_calls_for_candidate_tool=[
                 {
                     "applicability_rationale": "we need to check for the price of a specific motorcycle model",
@@ -745,7 +747,7 @@ _baseline_shots: Sequence[ToolCallerInferenceShot] = [
                     "comparison_with_rejected_tools_including_references_to_subtleties": (
                         "candidate tool is more specialized for this use case than the rejected tools"
                     ),
-                    "relevant_subtleties": "<IF SUBTLETIES FOUND, REFER TO THE RELEVANT ONES HERE>",
+                    "relevant_subtleties": "Both the candidate and referenc tool could apply - we need to choose the one that applies best",
                     "a_more_fitting_tool_was_rejected_for_some_reason_and_potentially_despite_a_found_subtlety": False,
                     "better_rejected_tool_name": "check_motorcycle_price",
                     "better_rejected_tool_rationale": (
@@ -768,7 +770,7 @@ _baseline_shots: Sequence[ToolCallerInferenceShot] = [
             most_recent_customer_inquiry_or_need="Checking the price of a Harley-Davidson Street Glide motorcycle",
             most_recent_customer_inquiry_or_need_was_already_resolved=False,
             name="check_vehicle_price",
-            subtleties_to_be_aware_of="<NOTE ANY SIGNIFICANT SUBTLETIES TO BE AWARE OF WHEN RUNNING THIS TOOL IN OUR AGENT'S CONTEXT>",
+            subtleties_to_be_aware_of="no subtleties were detected",
             tool_calls_for_candidate_tool=[
                 {
                     "applicability_rationale": "we need to check for the price of a specific vehicle - a Harley-Davidson Street Glide",
@@ -776,7 +778,7 @@ _baseline_shots: Sequence[ToolCallerInferenceShot] = [
                     "arguments": {"model": "Harley-Davidson Street Glide"},
                     "same_call_is_already_staged": False,
                     "comparison_with_rejected_tools_including_references_to_subtleties": "not as good a fit as check_motorcycle_price",
-                    "relevant_subtleties": "<IF SUBTLETIES FOUND, REFER TO THE RELEVANT ONES HERE>",
+                    "relevant_subtleties": "no subtleties were detected",
                     "a_more_fitting_tool_was_rejected_for_some_reason_and_potentially_despite_a_found_subtlety": True,
                     "better_rejected_tool_name": "check_motorcycle_price",
                     "better_rejected_tool_rationale": (
@@ -798,7 +800,7 @@ _baseline_shots: Sequence[ToolCallerInferenceShot] = [
             most_recent_customer_inquiry_or_need="Checking the current temperature in the living room",
             most_recent_customer_inquiry_or_need_was_already_resolved=False,
             name="check_indoor_temperature",
-            subtleties_to_be_aware_of="<NOTE ANY SIGNIFICANT SUBTLETIES TO BE AWARE OF WHEN RUNNING THIS TOOL IN OUR AGENT'S CONTEXT>",
+            subtleties_to_be_aware_of="no subtleties were detected",
             tool_calls_for_candidate_tool=[
                 {
                     "applicability_rationale": "need to check the current temperature in a specific room",
@@ -806,7 +808,7 @@ _baseline_shots: Sequence[ToolCallerInferenceShot] = [
                     "arguments": {"room": "living room"},
                     "same_call_is_already_staged": False,
                     "comparison_with_rejected_tools_including_references_to_subtleties": "not as good a fit as check_temperature",
-                    "relevant_subtleties": "<IF SUBTLETIES FOUND, REFER TO THE RELEVANT ONES HERE>",
+                    "relevant_subtleties": "no subtleties were detected",
                     "a_more_fitting_tool_was_rejected_for_some_reason_and_potentially_despite_a_found_subtlety": True,
                     "better_rejected_tool_name": "check_temperature",
                     "better_rejected_tool_rationale": (

--- a/src/parlant/core/engines/alpha/tool_caller.py
+++ b/src/parlant/core/engines/alpha/tool_caller.py
@@ -232,7 +232,7 @@ class ToolCaller:
     def _get_glossary_text(
         self,
         terms: Sequence[Term],
-    ) -> PromptBuilder:
+    ) -> str:
         terms_string = "\n".join(f"{i}) {repr(t)}" for i, t in enumerate(terms, start=1))
 
         return f"""

--- a/src/parlant/core/engines/alpha/tool_caller.py
+++ b/src/parlant/core/engines/alpha/tool_caller.py
@@ -55,8 +55,8 @@ class ToolCallEvaluation(DefaultBaseModel):
     comparison_with_rejected_tools_including_references_to_subtleties: str
     relevant_subtleties: str
     a_more_fitting_tool_was_rejected_for_some_reason_and_potentially_despite_a_found_subtlety: bool
-    better_rejected_tool_name: Optional[str] = ""
-    better_rejected_tool_rationale: Optional[str] = ""
+    better_rejected_tool_name: Optional[str] = None
+    better_rejected_tool_rationale: Optional[str] = None
     should_run: bool
 
 
@@ -242,7 +242,7 @@ class ToolCaller:
 
 - **Expected Result**:
 ```json
-{json.dumps(shot.expected_result.model_dump(mode="json"), indent=2)}
+{json.dumps(shot.expected_result.model_dump(mode="json", exclude_unset=True), indent=2)}
 ```"""
 
     def _format_tool_call_inference_prompt(
@@ -425,8 +425,6 @@ However, note that you may choose to have multiple entries in 'tool_calls_for_ca
         )
 
         prompt = builder.build()
-        with open("tool calling prompt.txt", "w") as f:
-            f.write(prompt)
         return prompt
 
     def _add_tool_definitions_section(
@@ -616,8 +614,6 @@ _baseline_shots: Sequence[ToolCallerInferenceShot] = [
                     ),
                     "relevant_subtleties": "check_balance(12345) is already staged",
                     "a_more_fitting_tool_was_rejected_for_some_reason_and_potentially_despite_a_found_subtlety": False,
-                    "better_rejected_tool_name": None,
-                    "better_rejected_tool_rationale": None,
                     "should_run": False,
                 }
             ],
@@ -674,8 +670,6 @@ _baseline_shots: Sequence[ToolCallerInferenceShot] = [
                     ),
                     "relevant_subtleties": "no subtleties were detected",
                     "a_more_fitting_tool_was_rejected_for_some_reason_and_potentially_despite_a_found_subtlety": False,
-                    "better_rejected_tool_name": None,
-                    "better_rejected_tool_rationale": None,
                     "should_run": True,
                 }
             ],
@@ -706,8 +700,6 @@ _baseline_shots: Sequence[ToolCallerInferenceShot] = [
                     ),
                     "relevant_subtleties": "two products need to be checked for calories - begin with margherita",
                     "a_more_fitting_tool_was_rejected_for_some_reason_and_potentially_despite_a_found_subtlety": False,
-                    "better_rejected_tool_name": None,
-                    "better_rejected_tool_rationale": None,
                     "should_run": True,
                 },
                 {
@@ -720,8 +712,6 @@ _baseline_shots: Sequence[ToolCallerInferenceShot] = [
                     ),
                     "relevant_subtleties": "two products need to be checked for calories - now check deep dish",
                     "a_more_fitting_tool_was_rejected_for_some_reason_and_potentially_despite_a_found_subtlety": False,
-                    "better_rejected_tool_name": None,
-                    "better_rejected_tool_rationale": None,
                     "should_run": True,
                 },
             ],

--- a/src/parlant/core/engines/alpha/tool_caller.py
+++ b/src/parlant/core/engines/alpha/tool_caller.py
@@ -55,8 +55,8 @@ class ToolCallEvaluation(DefaultBaseModel):
     comparison_with_rejected_tools_including_references_to_subtleties: str
     relevant_subtleties: str
     a_more_fitting_tool_was_rejected_for_some_reason_and_potentially_despite_a_found_subtlety: bool
-    better_rejected_tool_name: Optional[str] = None
-    better_rejected_tool_rationale: Optional[str] = None
+    better_rejected_tool_name: Optional[str] = ""
+    better_rejected_tool_rationale: Optional[str] = ""
     should_run: bool
 
 

--- a/tests/core/stable/engines/alpha/features/user_stories/conversation.feature
+++ b/tests/core/stable/engines/alpha/features/user_stories/conversation.feature
@@ -77,18 +77,3 @@ Feature: Conversation
         Then a single message event is emitted
         And the message contains no welcoming back of the customer
         And the message contains that the request will be escelated
-
-    Scenario: The agent treats guideline with multiple actions where one is continuous as if its fully continuous
-        Given an agent
-        And an empty session
-        And a guideline "unlock_card_guideline" to ask for the last 6 digits and help them unlock when the customer needs help unlocking their card
-        And the tool "try_unlock_card" 
-        And an association between "unlock_card_guideline" and "try_unlock_card"
-        And a customer message, "my card is locked"
-        And an agent message, "I'm sorry to hear that your card is locked. Could you please provide the last 6 digits of your card so I can assist you in unlocking it?"
-        And a customer message, "123456"
-        When processing is triggered
-        Then a single message event is emitted
-        And a single tool calls event is emitted
-        And the tool calls event contains that the card was succesfully unlocked
-        And the message contains that the card was unlocked

--- a/tests/core/unstable/engines/alpha/features/user_stories/conversation.feature
+++ b/tests/core/unstable/engines/alpha/features/user_stories/conversation.feature
@@ -48,3 +48,18 @@ Feature: Conversation
         Then a single message event is emitted
         And the message contains the name 'Beef'
         And the message contains a welcoming back of the customer to the store and asking how the agent could help
+
+    Scenario: The agent treats guideline with multiple actions where one is continuous as if its fully continuous
+        Given an agent
+        And an empty session
+        And a guideline "unlock_card_guideline" to ask for the last 6 digits and help them unlock when the customer needs help unlocking their card
+        And the tool "try_unlock_card" 
+        And an association between "unlock_card_guideline" and "try_unlock_card"
+        And a customer message, "my card is locked"
+        And an agent message, "I'm sorry to hear that your card is locked. Could you please provide the last 6 digits of your card so I can assist you in unlocking it?"
+        And a customer message, "123456"
+        When processing is triggered
+        Then a single message event is emitted
+        And a single tool calls event is emitted
+        And the tool calls event contains that the card was succesfully unlocked
+        And the message contains that the card was unlocked

--- a/tests/core/unstable/engines/alpha/test_user_story_scenarios.py
+++ b/tests/core/unstable/engines/alpha/test_user_story_scenarios.py
@@ -32,7 +32,7 @@ load_steps(
 
 scenarios(
     *(
-        f"core/stable/engines/alpha/features/user_stories/{feature}.feature"
+        f"core/unstable/engines/alpha/features/user_stories/{feature}.feature"
         for feature in ("conversation",)
     )
 )


### PR DESCRIPTION
Fixed the tool caller's few shots to include better rationales and arguments.

Other small changes:
- Changed the glossary section in the tool caller prompt
- removed redundant lines from the few shot examples in the guideline proposer & message event generator 
- moved an unstable test to the unstable folder
- fixed bug where unstable user stories  were not loaded  correctly