### PR TITLE
feat(adapters): add `MongoDocumentDatabase`

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -4144,6 +4144,85 @@ files = [
 windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
+name = "pymongo"
+version = "4.11.2"
+description = "Python driver for MongoDB <http://www.mongodb.org>"
+optional = false
+python-versions = ">=3.9"
+files = [
+    {file = "pymongo-4.11.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:2a5184fd5ff4d96eb7758316646c9cc47ca8b8a8125853a537fe7a47ae50fe51"},
+    {file = "pymongo-4.11.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:979cc5ea601f1c1c33824bd4550ab4aa71b367cf5206697cc915840cc495dd73"},
+    {file = "pymongo-4.11.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b08c83538635c04694a22a5b6bf6b8156a3c9bc35bcdfb12de157ad1f0fc4d41"},
+    {file = "pymongo-4.11.2-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8ebb30e04c362576351fb34b1360b3fcfa6e2227a4bafa9bab2acba9c705239d"},
+    {file = "pymongo-4.11.2-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e4fca5a81546ab91b7ad0fbab754a6932ffc3240fa8ab06b238a3cb97e1395b2"},
+    {file = "pymongo-4.11.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5848c7180103a7d9bacb32ddf41cd4ec2bfac35f94eaef77d323c8cc8c2ea665"},
+    {file = "pymongo-4.11.2-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:81273ed1faf58e89c9e0f6290c8026aa31d8d9e45ea8bf0d96713e0433fd1764"},
+    {file = "pymongo-4.11.2-cp310-cp310-win32.whl", hash = "sha256:842de0a38ac2579e1c640564e36749c3b596095e7c8701384a70ed1acf16632b"},
+    {file = "pymongo-4.11.2-cp310-cp310-win_amd64.whl", hash = "sha256:1d679e099d15dac7fd25513dd91032869e291abf2bf6fac33494fc973b0e2346"},
+    {file = "pymongo-4.11.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:c87ad59bbc88bc41a0396ee87f2d0ad45d23db5649fd0ee2eff6fbc35c046db0"},
+    {file = "pymongo-4.11.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:ad13aee24d77aef19606eff569bea18124be097a64767ab631e7980f4b3a0a74"},
+    {file = "pymongo-4.11.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e9ace309794cc5ad5be94b873ad17e85dda09c3bb54c150aa71e9c03447d6763"},
+    {file = "pymongo-4.11.2-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ec7c1cfa6dc290f8d7bd85a6ab1e942a2fac4671b2d8c67437fc7c33b2d4e8b4"},
+    {file = "pymongo-4.11.2-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e0c6dfa545205547fb9205243a7327de02141c17cc6910544f2805b07ad45a96"},
+    {file = "pymongo-4.11.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1cedc2e38e0186676f96e1d76f40aa2cc016f392ed71f0649a67fd2520dcb35b"},
+    {file = "pymongo-4.11.2-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:74ebb54f450e557e6f0e950790bab9c9f190243077262e72085ff8feff17a10f"},
+    {file = "pymongo-4.11.2-cp311-cp311-win32.whl", hash = "sha256:ef32b5622dcf7cac2f81af5e14ce9989802bf19b691adb8ad00484e4fa9391c6"},
+    {file = "pymongo-4.11.2-cp311-cp311-win_amd64.whl", hash = "sha256:ab4c1dd1970e34d37c8ab22a2c28578cfe694347997d3692b8440541f4798d85"},
+    {file = "pymongo-4.11.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:b9955ddeffa7b236a985ed9c9ab87ca6c98eb02d7bd5034960f385fbfbdb54a0"},
+    {file = "pymongo-4.11.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:b94a9c22b31c158d254ba74ad41f928b0c3a208caac8d1436ddff711459b3cad"},
+    {file = "pymongo-4.11.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d05014366bea8b6e403591f81f9ef03871bace4802dc7afe7a066836b2f64e50"},
+    {file = "pymongo-4.11.2-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:bfbfabc46b1bb9253a3916e3c5c5112a0799d2b82bac789528acc579d7294508"},
+    {file = "pymongo-4.11.2-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7bb3de24ec209c44b8b70196252f4294bbf61095747153b0deab358c7085764b"},
+    {file = "pymongo-4.11.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e75c88f2a765005a3a93fb2367d11451efc90c3a288ade84c247621e3044ff64"},
+    {file = "pymongo-4.11.2-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:13a395554584a50dec350f69df0dc240be11d2b59399f1371311d07bb18133b5"},
+    {file = "pymongo-4.11.2-cp312-cp312-win32.whl", hash = "sha256:d563d16a693c6e38180a54e2a07cb41111422e99267e46304cd6d616a3759d68"},
+    {file = "pymongo-4.11.2-cp312-cp312-win_amd64.whl", hash = "sha256:9609849dfd00f2c2e3d17403cdce1a0d81494dc5a4d602d6584a0326be0d46c9"},
+    {file = "pymongo-4.11.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:587328d77d03d380342290d6494df6e7becca25c0621c3ad0be41e3ae751540d"},
+    {file = "pymongo-4.11.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:57474d83511292e06f2da585fd3a6cb013d1cba6173df30b3658efb46f74d579"},
+    {file = "pymongo-4.11.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:29fc4707d5f3918c6ee39250439ff41a70d96dc91ae5bfbc1a74bc204775cb82"},
+    {file = "pymongo-4.11.2-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0734940f9f347904796a98481fb4100859f121017e68b756e7426b66d8b2e176"},
+    {file = "pymongo-4.11.2-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:63239e2466d8324564cb4725c12fdd2be0ddfa7d250b4d0e41a47cd269c4cc1c"},
+    {file = "pymongo-4.11.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:164865b78bd9e0ec6fdbe2ee58fc1a33666f32f8c455af3c9897c5c58c7b3d00"},
+    {file = "pymongo-4.11.2-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:fbbc3ba041cf2e3f1f4eac293af15ce91cfbac68540f6b3733b834ad768aa319"},
+    {file = "pymongo-4.11.2-cp313-cp313-win32.whl", hash = "sha256:5da59332ec88ea662c4a9a99f84b322ed6b9d2999bfb947e186936ccae3941be"},
+    {file = "pymongo-4.11.2-cp313-cp313-win_amd64.whl", hash = "sha256:a4ba602980f43aa9998b0b8e77fd907cec9c7a845c385dc4e08a8b5716d2a85f"},
+    {file = "pymongo-4.11.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:77c7edf2dc7f0e46a66f440a0d291ae76533a2ead308d176681745b334d714a9"},
+    {file = "pymongo-4.11.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:7f98a4493a221ee5330dad1721181731f122b7492caac7f56cf7d0a695c88ee2"},
+    {file = "pymongo-4.11.2-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f28d42f9f6d8a5ae05a62401a9cb7c44c5d448dc58299a0ce657084d070ea5f6"},
+    {file = "pymongo-4.11.2-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5a1cfff63667179d4f165124af5843cfd865bc1e774a2bd76fc56592c5dfe5fa"},
+    {file = "pymongo-4.11.2-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5c012d44b841320148095b59e246cc0c8891f3ca125dcfa3cc9d89dc1573948b"},
+    {file = "pymongo-4.11.2-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c3410b5ee877430a99ed29b0e2bad8827015d313bbef19dbdba4f470049258d1"},
+    {file = "pymongo-4.11.2-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:36f9a3276dfb28b526eb5ca9511b627788cea6c4c8783a0dc609be1999b3506e"},
+    {file = "pymongo-4.11.2-cp313-cp313t-win32.whl", hash = "sha256:e04a102ccb4c9f5a6b06108aa5fc26bfe77c18747bf5b0fbd5f4a3a4298ddb53"},
+    {file = "pymongo-4.11.2-cp313-cp313t-win_amd64.whl", hash = "sha256:54e24645ceeddaa3224909f073e2695ff3e5c393a82c1e16cd46236d2681651f"},
+    {file = "pymongo-4.11.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:8402f5d09540f4a0542624245009f3aec8a9c7d2b7c1a09d6d399a64f6000d5e"},
+    {file = "pymongo-4.11.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:6e26ffb4c05b9abdd9d063020c39dfeef6d6fc79945a606ecd35add528e86bbe"},
+    {file = "pymongo-4.11.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9486db58c8d8048b59baac821885d91316a7219a97da13122142fdad1de916c0"},
+    {file = "pymongo-4.11.2-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:830eeeb7536b901c40aa20c913d431c1d9d10711ee01692d6fb9e4aa891e8444"},
+    {file = "pymongo-4.11.2-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:fea45642c3289304437dd0f459aee47b9dff994f8fff990dd3fd723c0f22caf1"},
+    {file = "pymongo-4.11.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8f01c5d7634db67b4e386735edcb7419041ddc3cdaa95dbdb0bbe19fd8f08dda"},
+    {file = "pymongo-4.11.2-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:db32510aba8968b62531135ff86c689075e3c6d60636636287ff060469226d07"},
+    {file = "pymongo-4.11.2-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:9a3572eb86d55ddbb20134f6c5c2af5aeb05120188ca907596561ffeaa4c2644"},
+    {file = "pymongo-4.11.2-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:80b5dc9a8d99d3891cff2664ad21e11bd4d9448a2dd00509bb9c057be31d0a6a"},
+    {file = "pymongo-4.11.2-cp39-cp39-win32.whl", hash = "sha256:3481ece566991a796a63bd5ffc3822cc974554485e5790653369e1fe96998b41"},
+    {file = "pymongo-4.11.2-cp39-cp39-win_amd64.whl", hash = "sha256:84643c86a41bc254466be3be0d85e7bc3f4c9ceb4eca44ee7ac751b12fec4785"},
+    {file = "pymongo-4.11.2.tar.gz", hash = "sha256:d0ee3e0275f67bddcd83b2263818b7c4ae7af1ecafebe7eb7fd16389457ec210"},
+]
+
+[package.dependencies]
+dnspython = ">=1.16.0,<3.0.0"
+
+[package.extras]
+aws = ["pymongo-auth-aws (>=1.1.0,<2.0.0)"]
+docs = ["furo (==2024.8.6)", "readthedocs-sphinx-search (>=0.3,<1.0)", "sphinx (>=5.3,<9)", "sphinx-autobuild (>=2020.9.1)", "sphinx-rtd-theme (>=2,<4)", "sphinxcontrib-shellcheck (>=1,<2)"]
+encryption = ["certifi", "pymongo-auth-aws (>=1.1.0,<2.0.0)", "pymongocrypt (>=1.12.0,<2.0.0)"]
+gssapi = ["pykerberos", "winkerberos (>=0.5.0)"]
+ocsp = ["certifi", "cryptography (>=2.5)", "pyopenssl (>=17.2.0)", "requests (<3.0.0)", "service-identity (>=18.1.0)"]
+snappy = ["python-snappy"]
+test = ["pytest (>=8.2)", "pytest-asyncio (>=0.24.0)"]
+zstd = ["zstandard"]
+
+[[package]]
 name = "pyparsing"
 version = "3.2.1"
 description = "pyparsing module - Classes and methods to define and execute parsing grammars"
@@ -4769,6 +4848,7 @@ files = [
     {file = "ruamel.yaml.clib-0.2.12-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f66efbc1caa63c088dead1c4170d148eabc9b80d95fb75b6c92ac0aad2437d76"},
     {file = "ruamel.yaml.clib-0.2.12-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:22353049ba4181685023b25b5b51a574bce33e7f51c759371a7422dcae5402a6"},
     {file = "ruamel.yaml.clib-0.2.12-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:932205970b9f9991b34f55136be327501903f7c66830e9760a8ffb15b07f05cd"},
+    {file = "ruamel.yaml.clib-0.2.12-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:a52d48f4e7bf9005e8f0a89209bf9a73f7190ddf0489eee5eb51377385f59f2a"},
     {file = "ruamel.yaml.clib-0.2.12-cp310-cp310-win32.whl", hash = "sha256:3eac5a91891ceb88138c113f9db04f3cebdae277f5d44eaa3651a4f573e6a5da"},
     {file = "ruamel.yaml.clib-0.2.12-cp310-cp310-win_amd64.whl", hash = "sha256:ab007f2f5a87bd08ab1499bdf96f3d5c6ad4dcfa364884cb4549aa0154b13a28"},
     {file = "ruamel.yaml.clib-0.2.12-cp311-cp311-macosx_13_0_arm64.whl", hash = "sha256:4a6679521a58256a90b0d89e03992c15144c5f3858f40d7c18886023d7943db6"},
@@ -4777,6 +4857,7 @@ files = [
     {file = "ruamel.yaml.clib-0.2.12-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:811ea1594b8a0fb466172c384267a4e5e367298af6b228931f273b111f17ef52"},
     {file = "ruamel.yaml.clib-0.2.12-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:cf12567a7b565cbf65d438dec6cfbe2917d3c1bdddfce84a9930b7d35ea59642"},
     {file = "ruamel.yaml.clib-0.2.12-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:7dd5adc8b930b12c8fc5b99e2d535a09889941aa0d0bd06f4749e9a9397c71d2"},
+    {file = "ruamel.yaml.clib-0.2.12-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:1492a6051dab8d912fc2adeef0e8c72216b24d57bd896ea607cb90bb0c4981d3"},
     {file = "ruamel.yaml.clib-0.2.12-cp311-cp311-win32.whl", hash = "sha256:bd0a08f0bab19093c54e18a14a10b4322e1eacc5217056f3c063bd2f59853ce4"},
     {file = "ruamel.yaml.clib-0.2.12-cp311-cp311-win_amd64.whl", hash = "sha256:a274fb2cb086c7a3dea4322ec27f4cb5cc4b6298adb583ab0e211a4682f241eb"},
     {file = "ruamel.yaml.clib-0.2.12-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:20b0f8dc160ba83b6dcc0e256846e1a02d044e13f7ea74a3d1d56ede4e48c632"},
@@ -4785,6 +4866,7 @@ files = [
     {file = "ruamel.yaml.clib-0.2.12-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:749c16fcc4a2b09f28843cda5a193e0283e47454b63ec4b81eaa2242f50e4ccd"},
     {file = "ruamel.yaml.clib-0.2.12-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:bf165fef1f223beae7333275156ab2022cffe255dcc51c27f066b4370da81e31"},
     {file = "ruamel.yaml.clib-0.2.12-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:32621c177bbf782ca5a18ba4d7af0f1082a3f6e517ac2a18b3974d4edf349680"},
+    {file = "ruamel.yaml.clib-0.2.12-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:b82a7c94a498853aa0b272fd5bc67f29008da798d4f93a2f9f289feb8426a58d"},
     {file = "ruamel.yaml.clib-0.2.12-cp312-cp312-win32.whl", hash = "sha256:e8c4ebfcfd57177b572e2040777b8abc537cdef58a2120e830124946aa9b42c5"},
     {file = "ruamel.yaml.clib-0.2.12-cp312-cp312-win_amd64.whl", hash = "sha256:0467c5965282c62203273b838ae77c0d29d7638c8a4e3a1c8bdd3602c10904e4"},
     {file = "ruamel.yaml.clib-0.2.12-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:4c8c5d82f50bb53986a5e02d1b3092b03622c02c2eb78e29bec33fd9593bae1a"},
@@ -4793,6 +4875,7 @@ files = [
     {file = "ruamel.yaml.clib-0.2.12-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:96777d473c05ee3e5e3c3e999f5d23c6f4ec5b0c38c098b3a5229085f74236c6"},
     {file = "ruamel.yaml.clib-0.2.12-cp313-cp313-musllinux_1_1_i686.whl", hash = "sha256:3bc2a80e6420ca8b7d3590791e2dfc709c88ab9152c00eeb511c9875ce5778bf"},
     {file = "ruamel.yaml.clib-0.2.12-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:e188d2699864c11c36cdfdada94d781fd5d6b0071cd9c427bceb08ad3d7c70e1"},
+    {file = "ruamel.yaml.clib-0.2.12-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:4f6f3eac23941b32afccc23081e1f50612bdbe4e982012ef4f5797986828cd01"},
     {file = "ruamel.yaml.clib-0.2.12-cp313-cp313-win32.whl", hash = "sha256:6442cb36270b3afb1b4951f060eccca1ce49f3d087ca1ca4563a6eb479cb3de6"},
     {file = "ruamel.yaml.clib-0.2.12-cp313-cp313-win_amd64.whl", hash = "sha256:e5b8daf27af0b90da7bb903a876477a9e6d7270be6146906b276605997c7e9a3"},
     {file = "ruamel.yaml.clib-0.2.12-cp39-cp39-macosx_12_0_arm64.whl", hash = "sha256:fc4b630cd3fa2cf7fce38afa91d7cfe844a9f75d7f0f36393fa98815e911d987"},
@@ -4801,6 +4884,7 @@ files = [
     {file = "ruamel.yaml.clib-0.2.12-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e2f1c3765db32be59d18ab3953f43ab62a761327aafc1594a2a1fbe038b8b8a7"},
     {file = "ruamel.yaml.clib-0.2.12-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:d85252669dc32f98ebcd5d36768f5d4faeaeaa2d655ac0473be490ecdae3c285"},
     {file = "ruamel.yaml.clib-0.2.12-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:e143ada795c341b56de9418c58d028989093ee611aa27ffb9b7f609c00d813ed"},
+    {file = "ruamel.yaml.clib-0.2.12-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:2c59aa6170b990d8d2719323e628aaf36f3bfbc1c26279c0eeeb24d05d2d11c7"},
     {file = "ruamel.yaml.clib-0.2.12-cp39-cp39-win32.whl", hash = "sha256:beffaed67936fbbeffd10966a4eb53c402fafd3d6833770516bf7314bc6ffa12"},
     {file = "ruamel.yaml.clib-0.2.12-cp39-cp39-win_amd64.whl", hash = "sha256:040ae85536960525ea62868b642bdb0c2cc6021c9f9d507810c0c604e66f5a7b"},
     {file = "ruamel.yaml.clib-0.2.12.tar.gz", hash = "sha256:6c8fbb13ec503f99a91901ab46e0b07ae7941cd527393187039aec586fdfd36f"},
@@ -6169,4 +6253,4 @@ together = ["together", "torch", "transformers"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "4e92b646f58bbe99782d58f343502620d547a23f878ce54a3a920f07c5511cea"
+content-hash = "c7507dd913d8feea43cbada4866185c7955c933bb42d40f7f1e0a358f2cb2376"

--- a/poetry.lock
+++ b/poetry.lock
@@ -4144,85 +4144,6 @@ files = [
 windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
-name = "pymongo"
-version = "4.11.2"
-description = "Python driver for MongoDB <http://www.mongodb.org>"
-optional = false
-python-versions = ">=3.9"
-files = [
-    {file = "pymongo-4.11.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:2a5184fd5ff4d96eb7758316646c9cc47ca8b8a8125853a537fe7a47ae50fe51"},
-    {file = "pymongo-4.11.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:979cc5ea601f1c1c33824bd4550ab4aa71b367cf5206697cc915840cc495dd73"},
-    {file = "pymongo-4.11.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b08c83538635c04694a22a5b6bf6b8156a3c9bc35bcdfb12de157ad1f0fc4d41"},
-    {file = "pymongo-4.11.2-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8ebb30e04c362576351fb34b1360b3fcfa6e2227a4bafa9bab2acba9c705239d"},
-    {file = "pymongo-4.11.2-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e4fca5a81546ab91b7ad0fbab754a6932ffc3240fa8ab06b238a3cb97e1395b2"},
-    {file = "pymongo-4.11.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5848c7180103a7d9bacb32ddf41cd4ec2bfac35f94eaef77d323c8cc8c2ea665"},
-    {file = "pymongo-4.11.2-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:81273ed1faf58e89c9e0f6290c8026aa31d8d9e45ea8bf0d96713e0433fd1764"},
-    {file = "pymongo-4.11.2-cp310-cp310-win32.whl", hash = "sha256:842de0a38ac2579e1c640564e36749c3b596095e7c8701384a70ed1acf16632b"},
-    {file = "pymongo-4.11.2-cp310-cp310-win_amd64.whl", hash = "sha256:1d679e099d15dac7fd25513dd91032869e291abf2bf6fac33494fc973b0e2346"},
-    {file = "pymongo-4.11.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:c87ad59bbc88bc41a0396ee87f2d0ad45d23db5649fd0ee2eff6fbc35c046db0"},
-    {file = "pymongo-4.11.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:ad13aee24d77aef19606eff569bea18124be097a64767ab631e7980f4b3a0a74"},
-    {file = "pymongo-4.11.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e9ace309794cc5ad5be94b873ad17e85dda09c3bb54c150aa71e9c03447d6763"},
-    {file = "pymongo-4.11.2-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ec7c1cfa6dc290f8d7bd85a6ab1e942a2fac4671b2d8c67437fc7c33b2d4e8b4"},
-    {file = "pymongo-4.11.2-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e0c6dfa545205547fb9205243a7327de02141c17cc6910544f2805b07ad45a96"},
-    {file = "pymongo-4.11.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1cedc2e38e0186676f96e1d76f40aa2cc016f392ed71f0649a67fd2520dcb35b"},
-    {file = "pymongo-4.11.2-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:74ebb54f450e557e6f0e950790bab9c9f190243077262e72085ff8feff17a10f"},
-    {file = "pymongo-4.11.2-cp311-cp311-win32.whl", hash = "sha256:ef32b5622dcf7cac2f81af5e14ce9989802bf19b691adb8ad00484e4fa9391c6"},
-    {file = "pymongo-4.11.2-cp311-cp311-win_amd64.whl", hash = "sha256:ab4c1dd1970e34d37c8ab22a2c28578cfe694347997d3692b8440541f4798d85"},
-    {file = "pymongo-4.11.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:b9955ddeffa7b236a985ed9c9ab87ca6c98eb02d7bd5034960f385fbfbdb54a0"},
-    {file = "pymongo-4.11.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:b94a9c22b31c158d254ba74ad41f928b0c3a208caac8d1436ddff711459b3cad"},
-    {file = "pymongo-4.11.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d05014366bea8b6e403591f81f9ef03871bace4802dc7afe7a066836b2f64e50"},
-    {file = "pymongo-4.11.2-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:bfbfabc46b1bb9253a3916e3c5c5112a0799d2b82bac789528acc579d7294508"},
-    {file = "pymongo-4.11.2-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7bb3de24ec209c44b8b70196252f4294bbf61095747153b0deab358c7085764b"},
-    {file = "pymongo-4.11.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e75c88f2a765005a3a93fb2367d11451efc90c3a288ade84c247621e3044ff64"},
-    {file = "pymongo-4.11.2-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:13a395554584a50dec350f69df0dc240be11d2b59399f1371311d07bb18133b5"},
-    {file = "pymongo-4.11.2-cp312-cp312-win32.whl", hash = "sha256:d563d16a693c6e38180a54e2a07cb41111422e99267e46304cd6d616a3759d68"},
-    {file = "pymongo-4.11.2-cp312-cp312-win_amd64.whl", hash = "sha256:9609849dfd00f2c2e3d17403cdce1a0d81494dc5a4d602d6584a0326be0d46c9"},
-    {file = "pymongo-4.11.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:587328d77d03d380342290d6494df6e7becca25c0621c3ad0be41e3ae751540d"},
-    {file = "pymongo-4.11.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:57474d83511292e06f2da585fd3a6cb013d1cba6173df30b3658efb46f74d579"},
-    {file = "pymongo-4.11.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:29fc4707d5f3918c6ee39250439ff41a70d96dc91ae5bfbc1a74bc204775cb82"},
-    {file = "pymongo-4.11.2-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0734940f9f347904796a98481fb4100859f121017e68b756e7426b66d8b2e176"},
-    {file = "pymongo-4.11.2-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:63239e2466d8324564cb4725c12fdd2be0ddfa7d250b4d0e41a47cd269c4cc1c"},
-    {file = "pymongo-4.11.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:164865b78bd9e0ec6fdbe2ee58fc1a33666f32f8c455af3c9897c5c58c7b3d00"},
-    {file = "pymongo-4.11.2-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:fbbc3ba041cf2e3f1f4eac293af15ce91cfbac68540f6b3733b834ad768aa319"},
-    {file = "pymongo-4.11.2-cp313-cp313-win32.whl", hash = "sha256:5da59332ec88ea662c4a9a99f84b322ed6b9d2999bfb947e186936ccae3941be"},
-    {file = "pymongo-4.11.2-cp313-cp313-win_amd64.whl", hash = "sha256:a4ba602980f43aa9998b0b8e77fd907cec9c7a845c385dc4e08a8b5716d2a85f"},
-    {file = "pymongo-4.11.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:77c7edf2dc7f0e46a66f440a0d291ae76533a2ead308d176681745b334d714a9"},
-    {file = "pymongo-4.11.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:7f98a4493a221ee5330dad1721181731f122b7492caac7f56cf7d0a695c88ee2"},
-    {file = "pymongo-4.11.2-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f28d42f9f6d8a5ae05a62401a9cb7c44c5d448dc58299a0ce657084d070ea5f6"},
-    {file = "pymongo-4.11.2-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5a1cfff63667179d4f165124af5843cfd865bc1e774a2bd76fc56592c5dfe5fa"},
-    {file = "pymongo-4.11.2-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5c012d44b841320148095b59e246cc0c8891f3ca125dcfa3cc9d89dc1573948b"},
-    {file = "pymongo-4.11.2-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c3410b5ee877430a99ed29b0e2bad8827015d313bbef19dbdba4f470049258d1"},
-    {file = "pymongo-4.11.2-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:36f9a3276dfb28b526eb5ca9511b627788cea6c4c8783a0dc609be1999b3506e"},
-    {file = "pymongo-4.11.2-cp313-cp313t-win32.whl", hash = "sha256:e04a102ccb4c9f5a6b06108aa5fc26bfe77c18747bf5b0fbd5f4a3a4298ddb53"},
-    {file = "pymongo-4.11.2-cp313-cp313t-win_amd64.whl", hash = "sha256:54e24645ceeddaa3224909f073e2695ff3e5c393a82c1e16cd46236d2681651f"},
-    {file = "pymongo-4.11.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:8402f5d09540f4a0542624245009f3aec8a9c7d2b7c1a09d6d399a64f6000d5e"},
-    {file = "pymongo-4.11.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:6e26ffb4c05b9abdd9d063020c39dfeef6d6fc79945a606ecd35add528e86bbe"},
-    {file = "pymongo-4.11.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9486db58c8d8048b59baac821885d91316a7219a97da13122142fdad1de916c0"},
-    {file = "pymongo-4.11.2-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:830eeeb7536b901c40aa20c913d431c1d9d10711ee01692d6fb9e4aa891e8444"},
-    {file = "pymongo-4.11.2-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:fea45642c3289304437dd0f459aee47b9dff994f8fff990dd3fd723c0f22caf1"},
-    {file = "pymongo-4.11.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8f01c5d7634db67b4e386735edcb7419041ddc3cdaa95dbdb0bbe19fd8f08dda"},
-    {file = "pymongo-4.11.2-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:db32510aba8968b62531135ff86c689075e3c6d60636636287ff060469226d07"},
-    {file = "pymongo-4.11.2-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:9a3572eb86d55ddbb20134f6c5c2af5aeb05120188ca907596561ffeaa4c2644"},
-    {file = "pymongo-4.11.2-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:80b5dc9a8d99d3891cff2664ad21e11bd4d9448a2dd00509bb9c057be31d0a6a"},
-    {file = "pymongo-4.11.2-cp39-cp39-win32.whl", hash = "sha256:3481ece566991a796a63bd5ffc3822cc974554485e5790653369e1fe96998b41"},
-    {file = "pymongo-4.11.2-cp39-cp39-win_amd64.whl", hash = "sha256:84643c86a41bc254466be3be0d85e7bc3f4c9ceb4eca44ee7ac751b12fec4785"},
-    {file = "pymongo-4.11.2.tar.gz", hash = "sha256:d0ee3e0275f67bddcd83b2263818b7c4ae7af1ecafebe7eb7fd16389457ec210"},
-]
-
-[package.dependencies]
-dnspython = ">=1.16.0,<3.0.0"
-
-[package.extras]
-aws = ["pymongo-auth-aws (>=1.1.0,<2.0.0)"]
-docs = ["furo (==2024.8.6)", "readthedocs-sphinx-search (>=0.3,<1.0)", "sphinx (>=5.3,<9)", "sphinx-autobuild (>=2020.9.1)", "sphinx-rtd-theme (>=2,<4)", "sphinxcontrib-shellcheck (>=1,<2)"]
-encryption = ["certifi", "pymongo-auth-aws (>=1.1.0,<2.0.0)", "pymongocrypt (>=1.12.0,<2.0.0)"]
-gssapi = ["pykerberos", "winkerberos (>=0.5.0)"]
-ocsp = ["certifi", "cryptography (>=2.5)", "pyopenssl (>=17.2.0)", "requests (<3.0.0)", "service-identity (>=18.1.0)"]
-snappy = ["python-snappy"]
-test = ["pytest (>=8.2)", "pytest-asyncio (>=0.24.0)"]
-zstd = ["zstandard"]
-
-[[package]]
 name = "pyparsing"
 version = "3.2.1"
 description = "pyparsing module - Classes and methods to define and execute parsing grammars"
@@ -4848,7 +4769,6 @@ files = [
     {file = "ruamel.yaml.clib-0.2.12-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f66efbc1caa63c088dead1c4170d148eabc9b80d95fb75b6c92ac0aad2437d76"},
     {file = "ruamel.yaml.clib-0.2.12-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:22353049ba4181685023b25b5b51a574bce33e7f51c759371a7422dcae5402a6"},
     {file = "ruamel.yaml.clib-0.2.12-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:932205970b9f9991b34f55136be327501903f7c66830e9760a8ffb15b07f05cd"},
-    {file = "ruamel.yaml.clib-0.2.12-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:a52d48f4e7bf9005e8f0a89209bf9a73f7190ddf0489eee5eb51377385f59f2a"},
     {file = "ruamel.yaml.clib-0.2.12-cp310-cp310-win32.whl", hash = "sha256:3eac5a91891ceb88138c113f9db04f3cebdae277f5d44eaa3651a4f573e6a5da"},
     {file = "ruamel.yaml.clib-0.2.12-cp310-cp310-win_amd64.whl", hash = "sha256:ab007f2f5a87bd08ab1499bdf96f3d5c6ad4dcfa364884cb4549aa0154b13a28"},
     {file = "ruamel.yaml.clib-0.2.12-cp311-cp311-macosx_13_0_arm64.whl", hash = "sha256:4a6679521a58256a90b0d89e03992c15144c5f3858f40d7c18886023d7943db6"},
@@ -4857,7 +4777,6 @@ files = [
     {file = "ruamel.yaml.clib-0.2.12-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:811ea1594b8a0fb466172c384267a4e5e367298af6b228931f273b111f17ef52"},
     {file = "ruamel.yaml.clib-0.2.12-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:cf12567a7b565cbf65d438dec6cfbe2917d3c1bdddfce84a9930b7d35ea59642"},
     {file = "ruamel.yaml.clib-0.2.12-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:7dd5adc8b930b12c8fc5b99e2d535a09889941aa0d0bd06f4749e9a9397c71d2"},
-    {file = "ruamel.yaml.clib-0.2.12-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:1492a6051dab8d912fc2adeef0e8c72216b24d57bd896ea607cb90bb0c4981d3"},
     {file = "ruamel.yaml.clib-0.2.12-cp311-cp311-win32.whl", hash = "sha256:bd0a08f0bab19093c54e18a14a10b4322e1eacc5217056f3c063bd2f59853ce4"},
     {file = "ruamel.yaml.clib-0.2.12-cp311-cp311-win_amd64.whl", hash = "sha256:a274fb2cb086c7a3dea4322ec27f4cb5cc4b6298adb583ab0e211a4682f241eb"},
     {file = "ruamel.yaml.clib-0.2.12-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:20b0f8dc160ba83b6dcc0e256846e1a02d044e13f7ea74a3d1d56ede4e48c632"},
@@ -4866,7 +4785,6 @@ files = [
     {file = "ruamel.yaml.clib-0.2.12-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:749c16fcc4a2b09f28843cda5a193e0283e47454b63ec4b81eaa2242f50e4ccd"},
     {file = "ruamel.yaml.clib-0.2.12-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:bf165fef1f223beae7333275156ab2022cffe255dcc51c27f066b4370da81e31"},
     {file = "ruamel.yaml.clib-0.2.12-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:32621c177bbf782ca5a18ba4d7af0f1082a3f6e517ac2a18b3974d4edf349680"},
-    {file = "ruamel.yaml.clib-0.2.12-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:b82a7c94a498853aa0b272fd5bc67f29008da798d4f93a2f9f289feb8426a58d"},
     {file = "ruamel.yaml.clib-0.2.12-cp312-cp312-win32.whl", hash = "sha256:e8c4ebfcfd57177b572e2040777b8abc537cdef58a2120e830124946aa9b42c5"},
     {file = "ruamel.yaml.clib-0.2.12-cp312-cp312-win_amd64.whl", hash = "sha256:0467c5965282c62203273b838ae77c0d29d7638c8a4e3a1c8bdd3602c10904e4"},
     {file = "ruamel.yaml.clib-0.2.12-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:4c8c5d82f50bb53986a5e02d1b3092b03622c02c2eb78e29bec33fd9593bae1a"},
@@ -4875,7 +4793,6 @@ files = [
     {file = "ruamel.yaml.clib-0.2.12-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:96777d473c05ee3e5e3c3e999f5d23c6f4ec5b0c38c098b3a5229085f74236c6"},
     {file = "ruamel.yaml.clib-0.2.12-cp313-cp313-musllinux_1_1_i686.whl", hash = "sha256:3bc2a80e6420ca8b7d3590791e2dfc709c88ab9152c00eeb511c9875ce5778bf"},
     {file = "ruamel.yaml.clib-0.2.12-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:e188d2699864c11c36cdfdada94d781fd5d6b0071cd9c427bceb08ad3d7c70e1"},
-    {file = "ruamel.yaml.clib-0.2.12-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:4f6f3eac23941b32afccc23081e1f50612bdbe4e982012ef4f5797986828cd01"},
     {file = "ruamel.yaml.clib-0.2.12-cp313-cp313-win32.whl", hash = "sha256:6442cb36270b3afb1b4951f060eccca1ce49f3d087ca1ca4563a6eb479cb3de6"},
     {file = "ruamel.yaml.clib-0.2.12-cp313-cp313-win_amd64.whl", hash = "sha256:e5b8daf27af0b90da7bb903a876477a9e6d7270be6146906b276605997c7e9a3"},
     {file = "ruamel.yaml.clib-0.2.12-cp39-cp39-macosx_12_0_arm64.whl", hash = "sha256:fc4b630cd3fa2cf7fce38afa91d7cfe844a9f75d7f0f36393fa98815e911d987"},
@@ -4884,7 +4801,6 @@ files = [
     {file = "ruamel.yaml.clib-0.2.12-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e2f1c3765db32be59d18ab3953f43ab62a761327aafc1594a2a1fbe038b8b8a7"},
     {file = "ruamel.yaml.clib-0.2.12-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:d85252669dc32f98ebcd5d36768f5d4faeaeaa2d655ac0473be490ecdae3c285"},
     {file = "ruamel.yaml.clib-0.2.12-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:e143ada795c341b56de9418c58d028989093ee611aa27ffb9b7f609c00d813ed"},
-    {file = "ruamel.yaml.clib-0.2.12-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:2c59aa6170b990d8d2719323e628aaf36f3bfbc1c26279c0eeeb24d05d2d11c7"},
     {file = "ruamel.yaml.clib-0.2.12-cp39-cp39-win32.whl", hash = "sha256:beffaed67936fbbeffd10966a4eb53c402fafd3d6833770516bf7314bc6ffa12"},
     {file = "ruamel.yaml.clib-0.2.12-cp39-cp39-win_amd64.whl", hash = "sha256:040ae85536960525ea62868b642bdb0c2cc6021c9f9d507810c0c604e66f5a7b"},
     {file = "ruamel.yaml.clib-0.2.12.tar.gz", hash = "sha256:6c8fbb13ec503f99a91901ab46e0b07ae7941cd527393187039aec586fdfd36f"},
@@ -6253,4 +6169,4 @@ together = ["together", "torch", "transformers"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c7507dd913d8feea43cbada4866185c7955c933bb42d40f7f1e0a358f2cb2376"
+content-hash = "4e92b646f58bbe99782d58f343502620d547a23f878ce54a3a920f07c5511cea"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,7 @@ google-genai = { version = "^1.2.0", optional = true }
 together = { version = "^1.2.12", optional = true }
 torch = { version = "^2.5.1", optional = true }
 transformers = { version = "^4.46.2", optional = true }
+pymongo = "^4.11.1"
 
 [tool.poetry.group.dev.dependencies]
 ipython = "^8.26.0"

--- a/src/parlant/adapters/db/mongo_db.py
+++ b/src/parlant/adapters/db/mongo_db.py
@@ -1,0 +1,175 @@
+# Copyright 2025 Emcie Co Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Any, Awaitable, Callable, Optional, Sequence
+from bson import CodecOptions
+from typing_extensions import Self
+from parlant.core.loggers import Logger
+from parlant.core.persistence.common import Where
+from parlant.core.persistence.document_database import (
+    BaseDocument,
+    DeleteResult,
+    DocumentCollection,
+    DocumentDatabase,
+    InsertResult,
+    TDocument,
+    UpdateResult,
+)
+from pymongo import AsyncMongoClient
+from pymongo.asynchronous.database import AsyncDatabase
+from pymongo.asynchronous.collection import AsyncCollection
+
+
+class MongoDocumentDatabase(DocumentDatabase):
+    def __init__(
+        self,
+        mongo_client_async: AsyncMongoClient[Any],
+        database_name: str,
+        logger: Logger,
+    ):
+        self.mongo_client: AsyncMongoClient[Any] = mongo_client_async
+        self.database_name = database_name
+
+        self._logger = logger
+
+        self._database: Optional[AsyncDatabase[Any]] = None
+        self._collections: dict[str, MongoDocumentCollection[Any]] = {}
+
+    async def create_collection(
+        self,
+        name: str,
+        schema: type[TDocument],
+    ) -> DocumentCollection[TDocument]:
+        if self._database is None:
+            raise Exception("underlying database missing.")
+
+        self._collections[name] = MongoDocumentCollection(
+            self,
+            await self._database.create_collection(
+                name=name,
+                codec_options=CodecOptions(document_class=schema),
+            ),
+        )
+        return self._collections[name]
+
+    async def get_collection(
+        self,
+        name: str,
+        schema: type[TDocument],
+        document_loader: Callable[[BaseDocument], Awaitable[TDocument | None]],
+    ) -> DocumentCollection[TDocument]:
+        if self._database is None:
+            raise Exception("underlying database missing.")
+
+        result_collection = self._database.get_collection(
+            name=name,
+            codec_options=CodecOptions(document_class=schema),
+        )
+
+        collection_existing_documents = result_collection.find({})
+        failed_migration_documents: list[TDocument] = []
+        for doc in await collection_existing_documents.to_list():
+            if loaded_doc := await document_loader(doc):
+                await result_collection.replace_one(doc, loaded_doc)
+            else:
+                failed_migration_documents.append(doc)
+                await result_collection.delete_one(doc)
+
+        if len(failed_migration_documents):
+            failed_migration_collection = await self.create_collection("failed_migrations", schema)
+            for doc in failed_migration_documents:
+                await failed_migration_collection.insert_one(doc)
+
+        self._collections[name] = MongoDocumentCollection(self, result_collection)
+        return self._collections[name]
+
+    async def get_or_create_collection(
+        self,
+        name: str,
+        schema: type[TDocument],
+        document_loader: Callable[[BaseDocument], Awaitable[TDocument | None]],
+    ) -> DocumentCollection[TDocument]:
+        return await self.get_collection(name, schema, document_loader)
+
+    async def delete_collection(self, name: str) -> None:
+        if self._database is None:
+            raise Exception("underlying database missing.")
+
+        await self._database.drop_collection(name)
+
+    async def __aenter__(self) -> Self:
+        self._database = self.mongo_client[self.database_name]
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: Optional[type[BaseException]],
+        exc_value: Optional[BaseException],
+        traceback: Optional[object],
+    ) -> bool:
+        if self._database is not None:
+            self._database = None
+
+        return False
+
+
+class MongoDocumentCollection(DocumentCollection[TDocument]):
+    def __init__(
+        self,
+        mongo_document_database: MongoDocumentDatabase,
+        mongo_collection: AsyncCollection[TDocument],
+    ) -> None:
+        self._database = mongo_document_database
+        self._collection = mongo_collection
+
+    async def find(self, filters: Where) -> Sequence[TDocument]:
+        mongo_cursor = self._collection.find(filters)
+        result = await mongo_cursor.to_list()
+        await mongo_cursor.close()
+        return result
+
+    async def find_one(self, filters: Where) -> TDocument | None:
+        result = await self._collection.find_one(filters)
+        return result
+
+    async def insert_one(self, document: TDocument) -> InsertResult:
+        await self._collection.insert_one(document)
+        return InsertResult(acknowledged=True)
+
+    async def update_one(
+        self,
+        filters: Where,
+        params: TDocument,
+        upsert: bool = False,
+    ) -> UpdateResult[TDocument]:
+        update_result = await self._collection.update_one(filters, {"$set": params}, upsert)
+        result_document = await self._collection.find_one(filters)
+        return UpdateResult[TDocument](
+            update_result.acknowledged,
+            update_result.matched_count,
+            update_result.modified_count,
+            result_document,
+        )
+
+    async def delete_one(self, filters: Where) -> DeleteResult[TDocument]:
+        result_document = await self._collection.find_one(filters)
+        if result_document is None:
+            return DeleteResult(True, 0, None)
+
+        delete_result = await self._collection.delete_one(filters)
+        return DeleteResult(
+            delete_result.acknowledged,
+            deleted_count=delete_result.deleted_count,
+            deleted_document=result_document,
+        )

--- a/src/parlant/adapters/db/mongo_db.py
+++ b/src/parlant/adapters/db/mongo_db.py
@@ -79,37 +79,43 @@ class MongoDocumentDatabase(DocumentDatabase):
             codec_options=CodecOptions(document_class=schema),
         )
 
-        flag_any_failed = False
         failed_migrations_collection_name = f"{self.database_name}_{name}_failed_migrations"
         collection_existing_documents = result_collection.find({})
         if failed_migrations_collection_name in await self._database.list_collection_names():
             self._logger.info(f"deleting old `{failed_migrations_collection_name}` collection")
             await self.delete_collection(failed_migrations_collection_name)
 
-        failed_migration_collection = await self.create_collection(
-            failed_migrations_collection_name, schema
-        )
+        failed_migration_collection: Optional[DocumentCollection[TDocument]] = None
         for doc in await collection_existing_documents.to_list():
             try:
                 if loaded_doc := await document_loader(doc):
                     await result_collection.replace_one(doc, loaded_doc)
-                else:
-                    flag_any_failed = True
-                    self._logger.warning(f'failed to load document "{doc}"')
-                    await failed_migration_collection.insert_one(doc)
-                    await result_collection.delete_one(doc)
+                    continue
+
+                if failed_migration_collection is None:
+                    self._logger.warning(
+                        f"creating: `{failed_migrations_collection_name}` collection to store failed migrations..."
+                    )
+                    failed_migration_collection = await self.create_collection(
+                        failed_migrations_collection_name, schema
+                    )
+
+                self._logger.warning(f'failed to load document "{doc}"')
+                await failed_migration_collection.insert_one(doc)
+                await result_collection.delete_one(doc)
             except Exception as e:
-                flag_any_failed = True
+                if failed_migration_collection is None:
+                    self._logger.warning(
+                        f"creating: `{failed_migrations_collection_name}` collection to store failed migrations..."
+                    )
+                    failed_migration_collection = await self.create_collection(
+                        failed_migrations_collection_name, schema
+                    )
+
                 self._logger.error(
                     f"failed to load document '{doc}' with error: {e}. Added to `{failed_migrations_collection_name}` collection."
                 )
                 await failed_migration_collection.insert_one(doc)
-
-        if not flag_any_failed:
-            self._logger.info(
-                f"deleting `{failed_migrations_collection_name}` collection as no migrations failed this run"
-            )
-            await self.delete_collection(failed_migrations_collection_name)
 
         self._collections[name] = MongoDocumentCollection(self, result_collection)
         return self._collections[name]

--- a/src/parlant/adapters/db/mongo_db.py
+++ b/src/parlant/adapters/db/mongo_db.py
@@ -54,7 +54,7 @@ class MongoDocumentDatabase(DocumentDatabase):
         self._logger.debug(f'create collection "{name}"')
         if self._database is None:
             raise Exception("underlying database missing.")
-        
+
         self._collections[name] = MongoDocumentCollection(
             self,
             await self._database.create_collection(

--- a/tests/adapters/db/test_mongodb.py
+++ b/tests/adapters/db/test_mongodb.py
@@ -998,7 +998,7 @@ async def test_failed_migration_collection(
             assert len(documents) == 0
 
             failed_migrations_collection = await db.get_collection(
-                "failed_migrations",
+                "test_db_dummy_collection_failed_migrations",
                 BaseDocument,
                 identity_loader,
             )

--- a/tests/adapters/db/test_mongodb.py
+++ b/tests/adapters/db/test_mongodb.py
@@ -1,0 +1,1117 @@
+# Copyright 2025 Emcie Co Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+from dataclasses import dataclass
+from datetime import datetime, timezone
+import os
+from typing import Any, AsyncIterator, Optional, Sequence, cast
+from pymongo import AsyncMongoClient
+from typing_extensions import Self
+from lagom import Container
+from pytest import fixture, mark, raises
+
+from parlant.core.agents import Agent, AgentDocumentStore, AgentId, AgentStore
+from parlant.core.common import Version
+from parlant.core.context_variables import (
+    ContextVariable,
+    ContextVariableDocumentStore,
+    ContextVariableValue,
+)
+from parlant.core.customers import CustomerDocumentStore, CustomerId
+from parlant.core.evaluations import (
+    Evaluation,
+    EvaluationDocumentStore,
+    GuidelinePayload,
+    Invoice,
+    InvoiceData,
+    InvoiceGuidelineData,
+    PayloadDescriptor,
+    PayloadKind,
+)
+from parlant.core.guidelines import (
+    Guideline,
+    GuidelineContent,
+    GuidelineDocumentStore,
+    GuidelineId,
+)
+from parlant.adapters.db.mongo_db import MongoDocumentDatabase
+from parlant.core.persistence.common import MigrationRequired
+from parlant.core.persistence.document_database import (
+    BaseDocument,
+    DocumentCollection,
+    identity_loader,
+)
+from parlant.core.persistence.document_database_helper import DocumentStoreMigrationHelper
+from parlant.core.sessions import Event, Session, SessionDocumentStore
+from parlant.core.guideline_tool_associations import (
+    GuidelineToolAssociation,
+    GuidelineToolAssociationDocumentStore,
+)
+from parlant.core.loggers import Logger
+from parlant.core.tools import ToolId
+
+from tests.test_utilities import SyncAwaiter
+
+
+@fixture
+def agent_id(
+    container: Container,
+    sync_await: SyncAwaiter,
+) -> AgentId:
+    store = container[AgentStore]
+    agent = sync_await(store.create_agent(name="test-agent", max_engine_iterations=2))
+    return agent.id
+
+
+@dataclass
+class _TestContext:
+    container: Container
+    agent_id: AgentId
+    sync_await: SyncAwaiter
+
+
+@fixture
+def context(
+    container: Container,
+    agent_id: AgentId,
+    sync_await: SyncAwaiter,
+) -> _TestContext:
+    return _TestContext(container, agent_id, sync_await)
+
+
+@fixture
+async def test_database_name() -> AsyncIterator[str]:
+    yield "test_db"
+
+
+async def pymongo_tasks_still_running() -> None:
+    while any("pymongo" in str(t) for t in asyncio.all_tasks()):
+        print(str(t) for t in asyncio.all_tasks())
+        await asyncio.sleep(1)
+
+
+@fixture
+async def test_mongo_client() -> AsyncIterator[Optional[AsyncMongoClient[Any]]]:
+    test_mongo_server = os.environ.get("TEST_MONGO_SERVER")
+    if test_mongo_server:
+        client = AsyncMongoClient[Any](test_mongo_server)
+        yield client
+        await client.close()
+        await pymongo_tasks_still_running()
+    else:
+        print("could not find `TEST_MONGO_SERVER` in environment, skipping mongo tests...")
+        yield None
+
+
+class MongoTestDocument(BaseDocument):
+    name: str
+
+
+@mark.parametrize(
+    ("agent_configuration"),
+    [
+        ({"name": "Test Agent"}),
+        ({"name": "Test Agent", "description": "You are a test agent"}),
+    ],
+)
+async def test_agent_creation(
+    context: _TestContext,
+    test_mongo_client: Optional[AsyncMongoClient[Any]],
+    test_database_name: str,
+    agent_configuration: dict[str, Any],
+) -> None:
+    if test_mongo_client is None:
+        return  # Skip the test because no path in env
+
+    await test_mongo_client.drop_database(test_database_name)
+
+    created_agent: Optional[Agent] = None
+
+    async with MongoDocumentDatabase(
+        test_mongo_client,
+        test_database_name,
+        context.container[Logger],
+    ) as agent_db:
+        async with AgentDocumentStore(agent_db) as agent_store:
+            created_agent = await agent_store.create_agent(**agent_configuration)
+
+            agents = list(await agent_store.list_agents())
+            assert len(agents) == 1
+            assert agents[0] == created_agent
+
+    assert created_agent
+
+    async with MongoDocumentDatabase(
+        test_mongo_client,
+        test_database_name,
+        context.container[Logger],
+    ) as agent_db:
+        async with AgentDocumentStore(agent_db) as agent_store:
+            actual_agents = await agent_store.list_agents()
+            assert len(actual_agents) == 1
+
+            db_agent = actual_agents[0]
+            assert db_agent.id == created_agent.id
+            assert db_agent.name == created_agent.name
+            assert db_agent.description == created_agent.description
+            assert db_agent.creation_utc == created_agent.creation_utc
+
+
+async def test_session_creation(
+    context: _TestContext,
+    test_mongo_client: Optional[AsyncMongoClient[Any]],
+    test_database_name: str,
+) -> None:
+    if test_mongo_client is None:
+        return  # Skip the test because no path in env
+
+    await test_mongo_client.drop_database(test_database_name)
+
+    session: Optional[Session] = None
+
+    async with MongoDocumentDatabase(
+        test_mongo_client, test_database_name, context.container[Logger]
+    ) as session_db:
+        async with SessionDocumentStore(session_db) as session_store:
+            customer_id = CustomerId("test_customer")
+            utc_now = datetime.now(timezone.utc)
+            session = await session_store.create_session(
+                creation_utc=utc_now,
+                customer_id=customer_id,
+                agent_id=context.agent_id,
+            )
+
+    assert session
+
+    async with MongoDocumentDatabase(
+        test_mongo_client, test_database_name, context.container[Logger]
+    ) as session_db:
+        async with SessionDocumentStore(session_db) as session_store:
+            actual_sessions = await session_store.list_sessions()
+            assert len(actual_sessions) == 1
+            db_session = actual_sessions[0]
+            assert db_session.id == session.id
+            assert db_session.customer_id == session.customer_id
+            assert db_session.agent_id == context.agent_id
+            assert db_session.consumption_offsets == {
+                "client": 0,
+            }
+
+
+async def test_event_creation(
+    context: _TestContext,
+    test_mongo_client: Optional[AsyncMongoClient[Any]],
+    test_database_name: str,
+) -> None:
+    if test_mongo_client is None:
+        return  # Skip the test because no path in env
+
+    await test_mongo_client.drop_database(test_database_name)
+
+    session: Optional[Session] = None
+    event: Optional[Event] = None
+
+    async with MongoDocumentDatabase(
+        test_mongo_client, test_database_name, context.container[Logger]
+    ) as session_db:
+        async with SessionDocumentStore(session_db) as session_store:
+            customer_id = CustomerId("test_customer")
+            utc_now = datetime.now(timezone.utc)
+            session = await session_store.create_session(
+                creation_utc=utc_now,
+                customer_id=customer_id,
+                agent_id=context.agent_id,
+            )
+
+            event = await session_store.create_event(
+                session_id=session.id,
+                source="customer",
+                kind="message",
+                correlation_id="test_correlation_id",
+                data={"message": "Hello, world!"},
+                creation_utc=datetime.now(timezone.utc),
+            )
+
+    assert session
+    assert event
+
+    async with MongoDocumentDatabase(
+        test_mongo_client, test_database_name, context.container[Logger]
+    ) as session_db:
+        async with SessionDocumentStore(session_db) as session_store:
+            actual_events = await session_store.list_events(session.id)
+            assert len(actual_events) == 1
+            db_event = actual_events[0]
+            assert db_event.id == event.id
+            assert db_event.kind == event.kind
+            assert db_event.data == event.data
+            assert db_event.source == event.source
+            assert db_event.creation_utc == event.creation_utc
+
+
+async def test_guideline_creation(
+    context: _TestContext,
+    test_mongo_client: Optional[AsyncMongoClient[Any]],
+    test_database_name: str,
+) -> None:
+    if test_mongo_client is None:
+        return  # Skip the test because no path in env
+
+    await test_mongo_client.drop_database(test_database_name)
+
+    guideline: Optional[Guideline] = None
+
+    async with MongoDocumentDatabase(
+        test_mongo_client, test_database_name, context.container[Logger]
+    ) as guideline_db:
+        async with GuidelineDocumentStore(guideline_db) as guideline_store:
+            guideline = await guideline_store.create_guideline(
+                guideline_set=context.agent_id,
+                condition="Creating a guideline with MongoDB implementation",
+                action="Expecting it to be stored in the MongoDB database",
+            )
+
+    assert guideline
+
+    async with MongoDocumentDatabase(
+        test_mongo_client, test_database_name, context.container[Logger]
+    ) as guideline_db:
+        async with GuidelineDocumentStore(guideline_db) as guideline_store:
+            guidelines = await guideline_store.list_guidelines(context.agent_id)
+            guideline_list = list(guidelines)
+
+            assert len(guideline_list) == 1
+            db_guideline = guideline_list[0]
+            assert db_guideline.id == guideline.id
+            assert db_guideline.content.condition == guideline.content.condition
+            assert db_guideline.content.action == guideline.content.action
+            assert db_guideline.creation_utc == guideline.creation_utc
+
+
+async def test_multiple_guideline_creation(
+    context: _TestContext,
+    test_mongo_client: Optional[AsyncMongoClient[Any]],
+    test_database_name: str,
+) -> None:
+    if test_mongo_client is None:
+        return  # Skip the test because no path in env
+
+    await test_mongo_client.drop_database(test_database_name)
+
+    first_guideline: Optional[Guideline] = None
+    second_guideline: Optional[Guideline] = None
+
+    async with MongoDocumentDatabase(
+        test_mongo_client, test_database_name, context.container[Logger]
+    ) as guideline_db:
+        async with GuidelineDocumentStore(guideline_db) as guideline_store:
+            first_guideline = await guideline_store.create_guideline(
+                guideline_set=context.agent_id,
+                condition="First guideline creation",
+                action="Test entry in MongoDB",
+            )
+
+            second_guideline = await guideline_store.create_guideline(
+                guideline_set=context.agent_id,
+                condition="Second guideline creation",
+                action="Additional test entry in MongoDB",
+            )
+
+    assert first_guideline
+    assert second_guideline
+
+    async with MongoDocumentDatabase(
+        test_mongo_client, test_database_name, context.container[Logger]
+    ) as guideline_db:
+        async with GuidelineDocumentStore(guideline_db) as guideline_store:
+            guidelines = list(await guideline_store.list_guidelines(context.agent_id))
+
+            assert len(guidelines) == 2
+
+            guideline_ids = [g.id for g in guidelines]
+            assert first_guideline.id in guideline_ids
+            assert second_guideline.id in guideline_ids
+
+            for guideline in guidelines:
+                if guideline.id == first_guideline.id:
+                    assert guideline.content.condition == "First guideline creation"
+                    assert guideline.content.action == "Test entry in MongoDB"
+                elif guideline.id == second_guideline.id:
+                    assert guideline.content.condition == "Second guideline creation"
+                    assert guideline.content.action == "Additional test entry in MongoDB"
+
+
+async def test_guideline_retrieval(
+    context: _TestContext,
+    test_mongo_client: Optional[AsyncMongoClient[Any]],
+    test_database_name: str,
+) -> None:
+    if test_mongo_client is None:
+        return  # Skip the test because no path in env
+
+    await test_mongo_client.drop_database(test_database_name)
+
+    created_guideline: Optional[Guideline] = None
+
+    async with MongoDocumentDatabase(
+        test_mongo_client, test_database_name, context.container[Logger]
+    ) as guideline_db:
+        async with GuidelineDocumentStore(guideline_db) as guideline_store:
+            created_guideline = await guideline_store.create_guideline(
+                guideline_set=context.agent_id,
+                condition="Test condition for loading",
+                action="Test content for loading guideline",
+            )
+
+            loaded_guidelines = await guideline_store.list_guidelines(context.agent_id)
+            loaded_guideline_list = list(loaded_guidelines)
+
+            assert len(loaded_guideline_list) == 1
+            loaded_guideline = loaded_guideline_list[0]
+            assert loaded_guideline.content.condition == "Test condition for loading"
+            assert loaded_guideline.content.action == "Test content for loading guideline"
+            assert loaded_guideline.id == created_guideline.id
+
+
+async def test_customer_creation(
+    context: _TestContext,
+    test_mongo_client: Optional[AsyncMongoClient[Any]],
+    test_database_name: str,
+) -> None:
+    if test_mongo_client is None:
+        return  # Skip the test because no path in env
+
+    await test_mongo_client.drop_database(test_database_name)
+
+    created_customer = None
+
+    async with MongoDocumentDatabase(
+        test_mongo_client, test_database_name, context.container[Logger]
+    ) as customer_db:
+        async with CustomerDocumentStore(customer_db) as customer_store:
+            name = "Jane Doe"
+            extra = {"email": "jane.doe@example.com"}
+            created_customer = await customer_store.create_customer(
+                name=name,
+                extra=extra,
+            )
+
+    assert created_customer
+    assert created_customer.name == created_customer.name
+    assert created_customer.extra == created_customer.extra
+
+    async with MongoDocumentDatabase(
+        test_mongo_client, test_database_name, context.container[Logger]
+    ) as customer_db:
+        async with CustomerDocumentStore(customer_db) as customer_store:
+            customers = await customer_store.list_customers()
+
+            customer_list = list(customers)
+            assert len(customer_list) == 2
+
+            retrieved_customer_guest = customer_list[0]
+            assert retrieved_customer_guest
+            assert "guest" in retrieved_customer_guest.name
+
+            retrieved_customer = customer_list[1]
+            assert retrieved_customer.id == created_customer.id
+            assert retrieved_customer.name == created_customer.name
+            assert retrieved_customer.extra == created_customer.extra
+
+
+async def test_customer_retrieval(
+    context: _TestContext,
+    test_mongo_client: Optional[AsyncMongoClient[Any]],
+    test_database_name: str,
+) -> None:
+    if test_mongo_client is None:
+        return  # Skip the test because no path in env
+
+    await test_mongo_client.drop_database(test_database_name)
+
+    created_customer = None
+
+    async with MongoDocumentDatabase(
+        test_mongo_client, test_database_name, context.container[Logger]
+    ) as customer_db:
+        async with CustomerDocumentStore(customer_db) as customer_store:
+            name = "John Doe"
+            extra = {"email": "john.doe@example.com"}
+
+            created_customer = await customer_store.create_customer(name=name, extra=extra)
+
+            retrieved_customer = await customer_store.read_customer(created_customer.id)
+
+            assert created_customer == retrieved_customer
+
+
+async def test_context_variable_creation(
+    context: _TestContext,
+    test_mongo_client: Optional[AsyncMongoClient[Any]],
+    test_database_name: str,
+) -> None:
+    if test_mongo_client is None:
+        return  # Skip the test because no path in env
+
+    await test_mongo_client.drop_database(test_database_name)
+
+    variable: Optional[ContextVariable] = None
+
+    async with MongoDocumentDatabase(
+        test_mongo_client, test_database_name, context.container[Logger]
+    ) as context_variable_db:
+        async with ContextVariableDocumentStore(context_variable_db) as context_variable_store:
+            tool_id = ToolId("local", "test_tool")
+            variable = await context_variable_store.create_variable(
+                variable_set=context.agent_id,
+                name="Sample Variable",
+                description="A test variable for persistence.",
+                tool_id=tool_id,
+                freshness_rules=None,
+            )
+
+    assert variable
+    assert variable.name == "Sample Variable"
+    assert variable.description == "A test variable for persistence."
+
+    async with MongoDocumentDatabase(
+        test_mongo_client, test_database_name, context.container[Logger]
+    ) as context_variable_db:
+        async with ContextVariableDocumentStore(context_variable_db) as context_variable_store:
+            variables = list(await context_variable_store.list_variables(context.agent_id))
+
+            assert len(variables) == 1
+            db_variable = variables[0]
+            assert db_variable.id == variable.id
+            assert db_variable.name == variable.name
+            assert db_variable.description == variable.description
+            assert db_variable.tool_id == variable.tool_id
+
+
+async def test_context_variable_value_update_and_retrieval(
+    context: _TestContext,
+    test_mongo_client: Optional[AsyncMongoClient[Any]],
+    test_database_name: str,
+) -> None:
+    if test_mongo_client is None:
+        return  # Skip the test because no path in env
+
+    await test_mongo_client.drop_database(test_database_name)
+
+    variable: Optional[ContextVariable] = None
+    value: Optional[ContextVariableValue] = None
+
+    async with MongoDocumentDatabase(
+        test_mongo_client, test_database_name, context.container[Logger]
+    ) as context_variable_db:
+        async with ContextVariableDocumentStore(context_variable_db) as context_variable_store:
+            tool_id = ToolId("local", "test_tool")
+            customer_id = CustomerId("test_customer")
+            variable = await context_variable_store.create_variable(
+                variable_set=context.agent_id,
+                name="Sample Variable",
+                description="A test variable for persistence.",
+                tool_id=tool_id,
+                freshness_rules=None,
+            )
+
+            test_data = {"key": "value"}
+            await context_variable_store.update_value(
+                variable_set=context.agent_id,
+                key=customer_id,
+                variable_id=variable.id,
+                data=test_data,
+            )
+
+            value = await context_variable_store.read_value(
+                variable_set=context.agent_id,
+                key=customer_id,
+                variable_id=variable.id,
+            )
+
+            assert value
+            assert value.data == test_data
+
+
+async def test_context_variable_listing(
+    context: _TestContext,
+    test_mongo_client: Optional[AsyncMongoClient[Any]],
+    test_database_name: str,
+) -> None:
+    if test_mongo_client is None:
+        return  # Skip the test because no path in env
+
+    await test_mongo_client.drop_database(test_database_name)
+
+    var1 = None
+    var2 = None
+
+    async with MongoDocumentDatabase(
+        test_mongo_client, test_database_name, context.container[Logger]
+    ) as context_variable_db:
+        async with ContextVariableDocumentStore(context_variable_db) as context_variable_store:
+            tool_id = ToolId("local", "test_tool")
+            var1 = await context_variable_store.create_variable(
+                variable_set=context.agent_id,
+                name="Variable One",
+                description="First test variable",
+                tool_id=tool_id,
+                freshness_rules=None,
+            )
+
+            var2 = await context_variable_store.create_variable(
+                variable_set=context.agent_id,
+                name="Variable Two",
+                description="Second test variable",
+                tool_id=tool_id,
+                freshness_rules=None,
+            )
+
+            variables = list(await context_variable_store.list_variables(context.agent_id))
+            assert len(variables) == 2
+
+            variable_ids = [v.id for v in variables]
+            assert var1.id in variable_ids
+            assert var2.id in variable_ids
+
+
+async def test_context_variable_deletion(
+    context: _TestContext,
+    test_mongo_client: Optional[AsyncMongoClient[Any]],
+    test_database_name: str,
+) -> None:
+    if test_mongo_client is None:
+        return  # Skip the test because no path in env
+
+    await test_mongo_client.drop_database(test_database_name)
+
+    variable = None
+
+    async with MongoDocumentDatabase(
+        test_mongo_client, test_database_name, context.container[Logger]
+    ) as context_variable_db:
+        async with ContextVariableDocumentStore(context_variable_db) as context_variable_store:
+            tool_id = ToolId("local", "test_tool")
+            variable = await context_variable_store.create_variable(
+                variable_set=context.agent_id,
+                name="Deletable Variable",
+                description="A variable to be deleted.",
+                tool_id=tool_id,
+                freshness_rules=None,
+            )
+
+            for k, d in [("k1", "d1"), ("k2", "d2"), ("k3", "d3")]:
+                await context_variable_store.update_value(
+                    variable_set=context.agent_id,
+                    key=k,
+                    variable_id=variable.id,
+                    data=d,
+                )
+
+            values = await context_variable_store.list_values(
+                variable_set=context.agent_id,
+                variable_id=variable.id,
+            )
+
+            assert len(values) == 3
+
+            await context_variable_store.delete_variable(
+                variable_set=context.agent_id,
+                id=variable.id,
+            )
+
+            variables = await context_variable_store.list_variables(context.agent_id)
+            assert not any(variable.id == v.id for v in variables)
+
+            values = await context_variable_store.list_values(
+                variable_set=context.agent_id,
+                variable_id=variable.id,
+            )
+            assert len(values) == 0
+
+
+async def test_guideline_tool_association_creation(
+    context: _TestContext,
+    test_mongo_client: Optional[AsyncMongoClient[Any]],
+    test_database_name: str,
+) -> None:
+    if test_mongo_client is None:
+        return  # Skip the test because no path in env
+
+    await test_mongo_client.drop_database(test_database_name)
+
+    association: Optional[GuidelineToolAssociation] = None
+
+    async with MongoDocumentDatabase(
+        test_mongo_client,
+        test_database_name,
+        context.container[Logger],
+    ) as guideline_tool_association_db:
+        async with GuidelineToolAssociationDocumentStore(
+            guideline_tool_association_db
+        ) as guideline_tool_association_store:
+            guideline_id = GuidelineId("guideline-789")
+            tool_id = ToolId("local", "test_tool")
+
+            association = await guideline_tool_association_store.create_association(
+                guideline_id=guideline_id, tool_id=tool_id
+            )
+
+    assert association
+    assert association.guideline_id == association.guideline_id
+    assert association.tool_id == association.tool_id
+
+    async with MongoDocumentDatabase(
+        test_mongo_client,
+        test_database_name,
+        context.container[Logger],
+    ) as guideline_tool_association_db:
+        async with GuidelineToolAssociationDocumentStore(
+            guideline_tool_association_db
+        ) as guideline_tool_association_store:
+            associations = list(await guideline_tool_association_store.list_associations())
+
+            assert len(associations) == 1
+            stored_association = associations[0]
+            assert stored_association.id == association.id
+            assert stored_association.guideline_id == association.guideline_id
+            assert stored_association.tool_id == association.tool_id
+
+
+async def test_guideline_tool_association_retrieval(
+    context: _TestContext,
+    test_mongo_client: Optional[AsyncMongoClient[Any]],
+    test_database_name: str,
+) -> None:
+    if test_mongo_client is None:
+        return  # Skip the test because no path in env
+
+    await test_mongo_client.drop_database(test_database_name)
+
+    created_association = None
+
+    async with MongoDocumentDatabase(
+        test_mongo_client,
+        test_database_name,
+        context.container[Logger],
+    ) as guideline_tool_association_db:
+        async with GuidelineToolAssociationDocumentStore(
+            guideline_tool_association_db
+        ) as guideline_tool_association_store:
+            guideline_id = GuidelineId("test_guideline")
+            tool_id = ToolId("local", "test_tool")
+            creation_utc = datetime.now(timezone.utc)
+
+            created_association = await guideline_tool_association_store.create_association(
+                guideline_id=guideline_id,
+                tool_id=tool_id,
+                creation_utc=creation_utc,
+            )
+
+            associations = list(await guideline_tool_association_store.list_associations())
+            assert len(associations) == 1
+            retrieved_association = associations[0]
+
+            assert retrieved_association.id == created_association.id
+            assert retrieved_association.guideline_id == guideline_id
+            assert retrieved_association.tool_id == tool_id
+            assert retrieved_association.creation_utc == creation_utc
+
+
+async def test_database_initialization(
+    context: _TestContext,
+    test_mongo_client: Optional[AsyncMongoClient[Any]],
+    test_database_name: str,
+) -> None:
+    if test_mongo_client is None:
+        return  # Skip the test because no path in env
+
+    await test_mongo_client.drop_database(test_database_name)
+
+    async with MongoDocumentDatabase(
+        test_mongo_client, test_database_name, context.container[Logger]
+    ) as guideline_db:
+        async with GuidelineDocumentStore(guideline_db) as guideline_store:
+            await guideline_store.create_guideline(
+                guideline_set=context.agent_id,
+                condition="Create a guideline for initialization test",
+                action="Verify it's stored in MongoDB correctly",
+            )
+
+    collections = await test_mongo_client[test_database_name].list_collection_names()
+    assert "guidelines" in collections
+
+
+async def test_evaluation_creation(
+    context: _TestContext,
+    test_mongo_client: Optional[AsyncMongoClient[Any]],
+    test_database_name: str,
+) -> None:
+    if test_mongo_client is None:
+        return  # Skip the test because no path in env
+
+    await test_mongo_client.drop_database(test_database_name)
+
+    evaluation: Optional[Evaluation] = None
+
+    async with MongoDocumentDatabase(
+        test_mongo_client, test_database_name, context.container[Logger]
+    ) as evaluation_db:
+        async with EvaluationDocumentStore(evaluation_db) as evaluation_store:
+            payloads = [
+                GuidelinePayload(
+                    content=GuidelineContent(
+                        condition="Test evaluation creation with invoice",
+                        action="Ensure the evaluation with invoice is persisted in MongoDB",
+                    ),
+                    operation="add",
+                    coherence_check=True,
+                    connection_proposition=True,
+                )
+            ]
+
+            evaluation = await evaluation_store.create_evaluation(
+                agent_id=context.agent_id,
+                payload_descriptors=[PayloadDescriptor(PayloadKind.GUIDELINE, p) for p in payloads],
+            )
+
+    assert evaluation
+    assert evaluation.agent_id == context.agent_id
+
+    async with MongoDocumentDatabase(
+        test_mongo_client, test_database_name, context.container[Logger]
+    ) as evaluation_db:
+        async with EvaluationDocumentStore(evaluation_db) as evaluation_store:
+            evaluations = await evaluation_store.list_evaluations()
+            evaluations_list = list(evaluations)
+
+            assert len(evaluations_list) == 1
+            db_evaluation = evaluations_list[0]
+            assert db_evaluation.id == evaluation.id
+            assert db_evaluation.agent_id == context.agent_id
+            assert len(db_evaluation.invoices) == 1
+
+
+async def test_evaluation_update(
+    context: _TestContext,
+    test_mongo_client: Optional[AsyncMongoClient[Any]],
+    test_database_name: str,
+) -> None:
+    if test_mongo_client is None:
+        return  # Skip the test because no path in env
+
+    await test_mongo_client.drop_database(test_database_name)
+
+    evaluation = None
+
+    async with MongoDocumentDatabase(
+        test_mongo_client, test_database_name, context.container[Logger]
+    ) as evaluation_db:
+        async with EvaluationDocumentStore(evaluation_db) as evaluation_store:
+            payloads = [
+                GuidelinePayload(
+                    content=GuidelineContent(
+                        condition="Initial evaluation payload with invoice",
+                        action="This content will be updated",
+                    ),
+                    operation="add",
+                    coherence_check=True,
+                    connection_proposition=True,
+                )
+            ]
+
+            evaluation = await evaluation_store.create_evaluation(
+                agent_id=context.agent_id,
+                payload_descriptors=[PayloadDescriptor(PayloadKind.GUIDELINE, p) for p in payloads],
+            )
+
+            invoice_data: InvoiceData = InvoiceGuidelineData(
+                coherence_checks=[],
+                connection_propositions=None,
+            )
+
+            invoice = Invoice(
+                kind=PayloadKind.GUIDELINE,
+                payload=payloads[0],
+                state_version="123",
+                checksum="initial_checksum",
+                approved=True,
+                data=invoice_data,
+                error=None,
+            )
+
+            await evaluation_store.update_evaluation(
+                evaluation_id=evaluation.id, params={"invoices": [invoice]}
+            )
+
+            updated_evaluation = await evaluation_store.read_evaluation(evaluation.id)
+            assert updated_evaluation.invoices is not None
+            assert len(updated_evaluation.invoices) == 1
+            assert updated_evaluation.invoices[0].checksum == "initial_checksum"
+            assert updated_evaluation.invoices[0].approved is True
+
+
+class DummyStore:
+    VERSION = Version.from_string("2.0.0")
+
+    class DummyDocumentV1(BaseDocument):
+        name: str
+
+    class DummyDocumentV2(BaseDocument):
+        name: str
+        additional_field: str
+
+    def __init__(self, database: MongoDocumentDatabase, allow_migration: bool = True):
+        self._database: MongoDocumentDatabase = database
+        self._collection: DocumentCollection[DummyStore.DummyDocumentV2]
+        self.allow_migration = allow_migration
+
+    async def _document_loader(self, doc: BaseDocument) -> Optional[DummyDocumentV2]:
+        if doc["version"] == "1.0.0":
+            doc = cast(DummyStore.DummyDocumentV1, doc)
+            return self.DummyDocumentV2(
+                id=doc["id"],
+                version=Version.String("2.0.0"),
+                name=doc["name"],
+                additional_field="default_value",
+            )
+        elif doc["version"] == "2.0.0":
+            return cast(DummyStore.DummyDocumentV2, doc)
+        return None
+
+    async def __aenter__(self) -> Self:
+        async with DocumentStoreMigrationHelper(
+            store=self,
+            database=self._database,
+            allow_migration=self.allow_migration,
+        ):
+            self._collection = await self._database.get_or_create_collection(
+                name="dummy_collection",
+                schema=DummyStore.DummyDocumentV2,
+                document_loader=self._document_loader,
+            )
+
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: Optional[type[BaseException]],
+        exc_value: Optional[BaseException],
+        traceback: Optional[object],
+    ) -> None:
+        pass
+
+    async def list_dummy(self) -> Sequence[DummyDocumentV2]:
+        return await self._collection.find({})
+
+
+async def test_document_upgrade_during_loading_of_store(
+    context: _TestContext,
+    test_mongo_client: Optional[AsyncMongoClient[Any]],
+    test_database_name: str,
+) -> None:
+    if test_mongo_client is None:
+        return  # Skip the test because no path in env
+
+    await test_mongo_client.drop_database(test_database_name)
+
+    adb = test_mongo_client[test_database_name]
+    await adb.metadata.insert_one({"id": "123", "version": "1.0.0"})
+    await adb.dummy_collection.insert_one(
+        {"id": "dummy_id", "version": "1.0.0", "name": "Test Document"}
+    )
+
+    logger = context.container[Logger]
+
+    async with MongoDocumentDatabase(test_mongo_client, "test_db", logger) as db:
+        async with DummyStore(db, allow_migration=True) as store:
+            documents = await store.list_dummy()
+
+            assert len(documents) == 1
+            upgraded_doc = documents[0]
+            assert upgraded_doc["version"] == "2.0.0"
+            assert upgraded_doc["name"] == "Test Document"
+            assert upgraded_doc["additional_field"] == "default_value"
+
+
+async def test_that_migration_is_not_needed_for_new_store(
+    context: _TestContext,
+    test_mongo_client: Optional[AsyncMongoClient[Any]],
+    test_database_name: str,
+) -> None:
+    if test_mongo_client is None:
+        return  # Skip the test because no path in env
+
+    await test_mongo_client.drop_database(test_database_name)
+
+    logger = context.container[Logger]
+
+    async with MongoDocumentDatabase(test_mongo_client, "test_db", logger) as db:
+        async with DummyStore(db, allow_migration=False):
+            meta_collection = await db.get_or_create_collection(
+                name="metadata", schema=BaseDocument, document_loader=identity_loader
+            )
+            meta_document = await meta_collection.find_one({})
+
+            assert meta_document
+            assert meta_document["version"] == "2.0.0"
+
+
+async def test_failed_migration_collection(
+    container: Container,
+    test_mongo_client: Optional[AsyncMongoClient[Any]],
+    test_database_name: str,
+) -> None:
+    if test_mongo_client is None:
+        return  # Skip the test because no path in env
+
+    await test_mongo_client.drop_database(test_database_name)
+
+    adb = test_mongo_client[test_database_name]
+    await adb.metadata.insert_one({"id": "meta_id", "version": "1.0.0"})
+    await adb.dummy_collection.insert_one(
+        {
+            "id": "invalid_dummy_id",
+            "version": "3.0",
+            "name": "Unmigratable Document",
+        }
+    )
+
+    logger = container[Logger]
+
+    async with MongoDocumentDatabase(test_mongo_client, "test_db", logger) as db:
+        async with DummyStore(db, allow_migration=True) as store:
+            documents = await store.list_dummy()
+
+            assert len(documents) == 0
+
+            failed_migrations_collection = await db.get_collection(
+                "failed_migrations",
+                BaseDocument,
+                identity_loader,
+            )
+            failed_docs = await failed_migrations_collection.find({})
+
+            assert len(failed_docs) == 1
+            failed_doc = failed_docs[0]
+            assert failed_doc["id"] == "invalid_dummy_id"
+            assert failed_doc["version"] == "3.0"
+            assert failed_doc.get("name") == "Unmigratable Document"
+
+
+async def test_that_version_mismatch_raises_error_when_migration_is_required_but_disabled(
+    context: _TestContext,
+    test_mongo_client: Optional[AsyncMongoClient[Any]],
+    test_database_name: str,
+) -> None:
+    if test_mongo_client is None:
+        return  # Skip the test because no path in env
+
+    await test_mongo_client.drop_database(test_database_name)
+
+    adb = test_mongo_client[test_database_name]
+    await adb.metadata.insert_one({"id": "meta_id", "version": "NotRealVersion"})
+
+    logger = context.container[Logger]
+
+    async with MongoDocumentDatabase(test_mongo_client, "test_db", logger) as db:
+        with raises(MigrationRequired) as exc_info:
+            async with DummyStore(db, allow_migration=False) as _:
+                pass
+
+        assert "Migration required for DummyStore." in str(exc_info.value)
+
+
+async def test_that_persistence_and_store_version_match_allows_store_to_open_when_migrate_is_disabled(
+    context: _TestContext,
+    test_mongo_client: Optional[AsyncMongoClient[Any]],
+    test_database_name: str,
+) -> None:
+    if test_mongo_client is None:
+        return  # Skip the test because no path in env
+
+    await test_mongo_client.drop_database(test_database_name)
+
+    adb = test_mongo_client[test_database_name]
+    await adb.metadata.insert_one({"id": "meta_id", "version": "2.0.0"})
+
+    logger = context.container[Logger]
+
+    async with MongoDocumentDatabase(test_mongo_client, "test_db", logger) as db:
+        async with DummyStore(db, allow_migration=False):
+            meta_collection = await db.get_or_create_collection(
+                name="metadata",
+                schema=BaseDocument,
+                document_loader=identity_loader,
+            )
+            meta_document = await meta_collection.find_one({})
+
+            assert meta_document
+            assert meta_document["version"] == "2.0.0"
+
+
+async def test_delete_one_in_collection(
+    context: _TestContext,
+    test_mongo_client: Optional[AsyncMongoClient[Any]],
+    test_database_name: str,
+) -> None:
+    if test_mongo_client is None:
+        return  # Skip the test because no path in env
+
+    await test_mongo_client.drop_database(test_database_name)
+
+    async with MongoDocumentDatabase(
+        test_mongo_client, test_database_name, context.container[Logger]
+    ) as guideline_db:
+        async with GuidelineDocumentStore(guideline_db) as guideline_store:
+            guideline = await guideline_store.create_guideline(
+                guideline_set=context.agent_id,
+                condition="Guideline to be deleted",
+                action="This guideline will be deleted in the test",
+            )
+
+            await guideline_store.delete_guideline(context.agent_id, guideline.id)
+
+            guidelines = list(await guideline_store.list_guidelines(context.agent_id))
+            assert len(guidelines) == 0
+
+
+async def test_delete_collection(
+    context: _TestContext,
+    test_mongo_client: Optional[AsyncMongoClient[Any]],
+    test_database_name: str,
+) -> None:
+    if test_mongo_client is None:
+        return  # Skip the test because no path in env
+
+    await test_mongo_client.drop_database(test_database_name)
+
+    async with MongoDocumentDatabase(
+        test_mongo_client, test_database_name, context.container[Logger]
+    ) as mongo_db:
+        async with GuidelineDocumentStore(mongo_db) as guideline_store:
+            await guideline_store.create_guideline(
+                guideline_set=context.agent_id,
+                condition="Test collection deletion",
+                action="This collection will be deleted",
+            )
+
+        collections = await test_mongo_client[test_database_name].list_collection_names()
+        assert "guidelines" in collections
+
+        await mongo_db.delete_collection("guidelines")
+
+        collections = await test_mongo_client[test_database_name].list_collection_names()
+        assert "guidelines" not in collections

--- a/tests/adapters/db/test_mongodb.py
+++ b/tests/adapters/db/test_mongodb.py
@@ -18,6 +18,7 @@ from datetime import datetime, timezone
 import os
 from typing import Any, AsyncIterator, Optional, Sequence, cast
 from pymongo import AsyncMongoClient
+import pytest
 from typing_extensions import Self
 from lagom import Container
 from pytest import fixture, mark, raises
@@ -103,7 +104,7 @@ async def pymongo_tasks_still_running() -> None:
 
 
 @fixture
-async def test_mongo_client() -> AsyncIterator[Optional[AsyncMongoClient[Any]]]:
+async def test_mongo_client() -> AsyncIterator[AsyncMongoClient[Any]]:
     test_mongo_server = os.environ.get("TEST_MONGO_SERVER")
     if test_mongo_server:
         client = AsyncMongoClient[Any](test_mongo_server)
@@ -112,7 +113,7 @@ async def test_mongo_client() -> AsyncIterator[Optional[AsyncMongoClient[Any]]]:
         await pymongo_tasks_still_running()
     else:
         print("could not find `TEST_MONGO_SERVER` in environment, skipping mongo tests...")
-        yield None
+        raise pytest.skip()
 
 
 class MongoTestDocument(BaseDocument):
@@ -128,13 +129,10 @@ class MongoTestDocument(BaseDocument):
 )
 async def test_agent_creation(
     context: _TestContext,
-    test_mongo_client: Optional[AsyncMongoClient[Any]],
+    test_mongo_client: AsyncMongoClient[Any],
     test_database_name: str,
     agent_configuration: dict[str, Any],
 ) -> None:
-    if test_mongo_client is None:
-        return  # Skip the test because no path in env
-
     await test_mongo_client.drop_database(test_database_name)
 
     created_agent: Optional[Agent] = None
@@ -171,12 +169,9 @@ async def test_agent_creation(
 
 async def test_session_creation(
     context: _TestContext,
-    test_mongo_client: Optional[AsyncMongoClient[Any]],
+    test_mongo_client: AsyncMongoClient[Any],
     test_database_name: str,
 ) -> None:
-    if test_mongo_client is None:
-        return  # Skip the test because no path in env
-
     await test_mongo_client.drop_database(test_database_name)
 
     session: Optional[Session] = None
@@ -212,12 +207,9 @@ async def test_session_creation(
 
 async def test_event_creation(
     context: _TestContext,
-    test_mongo_client: Optional[AsyncMongoClient[Any]],
+    test_mongo_client: AsyncMongoClient[Any],
     test_database_name: str,
 ) -> None:
-    if test_mongo_client is None:
-        return  # Skip the test because no path in env
-
     await test_mongo_client.drop_database(test_database_name)
 
     session: Optional[Session] = None
@@ -263,12 +255,9 @@ async def test_event_creation(
 
 async def test_guideline_creation(
     context: _TestContext,
-    test_mongo_client: Optional[AsyncMongoClient[Any]],
+    test_mongo_client: AsyncMongoClient[Any],
     test_database_name: str,
 ) -> None:
-    if test_mongo_client is None:
-        return  # Skip the test because no path in env
-
     await test_mongo_client.drop_database(test_database_name)
 
     guideline: Optional[Guideline] = None
@@ -302,12 +291,9 @@ async def test_guideline_creation(
 
 async def test_multiple_guideline_creation(
     context: _TestContext,
-    test_mongo_client: Optional[AsyncMongoClient[Any]],
+    test_mongo_client: AsyncMongoClient[Any],
     test_database_name: str,
 ) -> None:
-    if test_mongo_client is None:
-        return  # Skip the test because no path in env
-
     await test_mongo_client.drop_database(test_database_name)
 
     first_guideline: Optional[Guideline] = None
@@ -355,12 +341,9 @@ async def test_multiple_guideline_creation(
 
 async def test_guideline_retrieval(
     context: _TestContext,
-    test_mongo_client: Optional[AsyncMongoClient[Any]],
+    test_mongo_client: AsyncMongoClient[Any],
     test_database_name: str,
 ) -> None:
-    if test_mongo_client is None:
-        return  # Skip the test because no path in env
-
     await test_mongo_client.drop_database(test_database_name)
 
     created_guideline: Optional[Guideline] = None
@@ -387,12 +370,9 @@ async def test_guideline_retrieval(
 
 async def test_customer_creation(
     context: _TestContext,
-    test_mongo_client: Optional[AsyncMongoClient[Any]],
+    test_mongo_client: AsyncMongoClient[Any],
     test_database_name: str,
 ) -> None:
-    if test_mongo_client is None:
-        return  # Skip the test because no path in env
-
     await test_mongo_client.drop_database(test_database_name)
 
     created_customer = None
@@ -433,12 +413,9 @@ async def test_customer_creation(
 
 async def test_customer_retrieval(
     context: _TestContext,
-    test_mongo_client: Optional[AsyncMongoClient[Any]],
+    test_mongo_client: AsyncMongoClient[Any],
     test_database_name: str,
 ) -> None:
-    if test_mongo_client is None:
-        return  # Skip the test because no path in env
-
     await test_mongo_client.drop_database(test_database_name)
 
     created_customer = None
@@ -459,12 +436,9 @@ async def test_customer_retrieval(
 
 async def test_context_variable_creation(
     context: _TestContext,
-    test_mongo_client: Optional[AsyncMongoClient[Any]],
+    test_mongo_client: AsyncMongoClient[Any],
     test_database_name: str,
 ) -> None:
-    if test_mongo_client is None:
-        return  # Skip the test because no path in env
-
     await test_mongo_client.drop_database(test_database_name)
 
     variable: Optional[ContextVariable] = None
@@ -502,12 +476,9 @@ async def test_context_variable_creation(
 
 async def test_context_variable_value_update_and_retrieval(
     context: _TestContext,
-    test_mongo_client: Optional[AsyncMongoClient[Any]],
+    test_mongo_client: AsyncMongoClient[Any],
     test_database_name: str,
 ) -> None:
-    if test_mongo_client is None:
-        return  # Skip the test because no path in env
-
     await test_mongo_client.drop_database(test_database_name)
 
     variable: Optional[ContextVariable] = None
@@ -547,12 +518,9 @@ async def test_context_variable_value_update_and_retrieval(
 
 async def test_context_variable_listing(
     context: _TestContext,
-    test_mongo_client: Optional[AsyncMongoClient[Any]],
+    test_mongo_client: AsyncMongoClient[Any],
     test_database_name: str,
 ) -> None:
-    if test_mongo_client is None:
-        return  # Skip the test because no path in env
-
     await test_mongo_client.drop_database(test_database_name)
 
     var1 = None
@@ -589,12 +557,9 @@ async def test_context_variable_listing(
 
 async def test_context_variable_deletion(
     context: _TestContext,
-    test_mongo_client: Optional[AsyncMongoClient[Any]],
+    test_mongo_client: AsyncMongoClient[Any],
     test_database_name: str,
 ) -> None:
-    if test_mongo_client is None:
-        return  # Skip the test because no path in env
-
     await test_mongo_client.drop_database(test_database_name)
 
     variable = None
@@ -644,12 +609,9 @@ async def test_context_variable_deletion(
 
 async def test_guideline_tool_association_creation(
     context: _TestContext,
-    test_mongo_client: Optional[AsyncMongoClient[Any]],
+    test_mongo_client: AsyncMongoClient[Any],
     test_database_name: str,
 ) -> None:
-    if test_mongo_client is None:
-        return  # Skip the test because no path in env
-
     await test_mongo_client.drop_database(test_database_name)
 
     association: Optional[GuidelineToolAssociation] = None
@@ -692,12 +654,9 @@ async def test_guideline_tool_association_creation(
 
 async def test_guideline_tool_association_retrieval(
     context: _TestContext,
-    test_mongo_client: Optional[AsyncMongoClient[Any]],
+    test_mongo_client: AsyncMongoClient[Any],
     test_database_name: str,
 ) -> None:
-    if test_mongo_client is None:
-        return  # Skip the test because no path in env
-
     await test_mongo_client.drop_database(test_database_name)
 
     created_association = None
@@ -732,12 +691,9 @@ async def test_guideline_tool_association_retrieval(
 
 async def test_database_initialization(
     context: _TestContext,
-    test_mongo_client: Optional[AsyncMongoClient[Any]],
+    test_mongo_client: AsyncMongoClient[Any],
     test_database_name: str,
 ) -> None:
-    if test_mongo_client is None:
-        return  # Skip the test because no path in env
-
     await test_mongo_client.drop_database(test_database_name)
 
     async with MongoDocumentDatabase(
@@ -756,12 +712,9 @@ async def test_database_initialization(
 
 async def test_evaluation_creation(
     context: _TestContext,
-    test_mongo_client: Optional[AsyncMongoClient[Any]],
+    test_mongo_client: AsyncMongoClient[Any],
     test_database_name: str,
 ) -> None:
-    if test_mongo_client is None:
-        return  # Skip the test because no path in env
-
     await test_mongo_client.drop_database(test_database_name)
 
     evaluation: Optional[Evaluation] = None
@@ -806,12 +759,9 @@ async def test_evaluation_creation(
 
 async def test_evaluation_update(
     context: _TestContext,
-    test_mongo_client: Optional[AsyncMongoClient[Any]],
+    test_mongo_client: AsyncMongoClient[Any],
     test_database_name: str,
 ) -> None:
-    if test_mongo_client is None:
-        return  # Skip the test because no path in env
-
     await test_mongo_client.drop_database(test_database_name)
 
     evaluation = None
@@ -919,12 +869,9 @@ class DummyStore:
 
 async def test_document_upgrade_during_loading_of_store(
     context: _TestContext,
-    test_mongo_client: Optional[AsyncMongoClient[Any]],
+    test_mongo_client: AsyncMongoClient[Any],
     test_database_name: str,
 ) -> None:
-    if test_mongo_client is None:
-        return  # Skip the test because no path in env
-
     await test_mongo_client.drop_database(test_database_name)
 
     adb = test_mongo_client[test_database_name]
@@ -948,12 +895,9 @@ async def test_document_upgrade_during_loading_of_store(
 
 async def test_that_migration_is_not_needed_for_new_store(
     context: _TestContext,
-    test_mongo_client: Optional[AsyncMongoClient[Any]],
+    test_mongo_client: AsyncMongoClient[Any],
     test_database_name: str,
 ) -> None:
-    if test_mongo_client is None:
-        return  # Skip the test because no path in env
-
     await test_mongo_client.drop_database(test_database_name)
 
     logger = context.container[Logger]
@@ -971,12 +915,9 @@ async def test_that_migration_is_not_needed_for_new_store(
 
 async def test_failed_migration_collection(
     container: Container,
-    test_mongo_client: Optional[AsyncMongoClient[Any]],
+    test_mongo_client: AsyncMongoClient[Any],
     test_database_name: str,
 ) -> None:
-    if test_mongo_client is None:
-        return  # Skip the test because no path in env
-
     await test_mongo_client.drop_database(test_database_name)
 
     adb = test_mongo_client[test_database_name]
@@ -1013,12 +954,9 @@ async def test_failed_migration_collection(
 
 async def test_that_version_mismatch_raises_error_when_migration_is_required_but_disabled(
     context: _TestContext,
-    test_mongo_client: Optional[AsyncMongoClient[Any]],
+    test_mongo_client: AsyncMongoClient[Any],
     test_database_name: str,
 ) -> None:
-    if test_mongo_client is None:
-        return  # Skip the test because no path in env
-
     await test_mongo_client.drop_database(test_database_name)
 
     adb = test_mongo_client[test_database_name]
@@ -1036,12 +974,9 @@ async def test_that_version_mismatch_raises_error_when_migration_is_required_but
 
 async def test_that_persistence_and_store_version_match_allows_store_to_open_when_migrate_is_disabled(
     context: _TestContext,
-    test_mongo_client: Optional[AsyncMongoClient[Any]],
+    test_mongo_client: AsyncMongoClient[Any],
     test_database_name: str,
 ) -> None:
-    if test_mongo_client is None:
-        return  # Skip the test because no path in env
-
     await test_mongo_client.drop_database(test_database_name)
 
     adb = test_mongo_client[test_database_name]
@@ -1064,12 +999,9 @@ async def test_that_persistence_and_store_version_match_allows_store_to_open_whe
 
 async def test_delete_one_in_collection(
     context: _TestContext,
-    test_mongo_client: Optional[AsyncMongoClient[Any]],
+    test_mongo_client: AsyncMongoClient[Any],
     test_database_name: str,
 ) -> None:
-    if test_mongo_client is None:
-        return  # Skip the test because no path in env
-
     await test_mongo_client.drop_database(test_database_name)
 
     async with MongoDocumentDatabase(
@@ -1090,12 +1022,9 @@ async def test_delete_one_in_collection(
 
 async def test_delete_collection(
     context: _TestContext,
-    test_mongo_client: Optional[AsyncMongoClient[Any]],
+    test_mongo_client: AsyncMongoClient[Any],
     test_database_name: str,
 ) -> None:
-    if test_mongo_client is None:
-        return  # Skip the test because no path in env
-
     await test_mongo_client.drop_database(test_database_name)
 
     async with MongoDocumentDatabase(


### PR DESCRIPTION
This PR Introduces a `MongoDocumentDatabase` adapter (in `adapters/db/mongo_db.py`), based on the discussion in https://github.com/emcie-co/parlant/issues/307 .

### Notable implementation details
* creating a `MongoDocumentDatabase` requires providing a live `AsyncMongoClient` instance.
* `get_or_create_collection` is just a wrapper for `get_collection` since get also handles creation if it does not exist.
* following the `failed_migrations` protocol for when the `document_loader` fails on a document.
* `update_one` and `delete_one` of `MongoDocumentCollection` need to call an extra `find_one` in order to have a value to return in their respective result objects.
* Added tests to `tests/adapters/db/test_mongodb.py` based on corresponding `json_file` tests.

### N.B.

* current version on develop doesn't pass mypy `pre-push` ... so I had to `--no-verify` it, after making sure none of my files were the offending ones.
* also note that without a valid `OPENAI_API_KEY` there's hardly any points in running the test suite, it all fails.

### Questions

* I guess we can make `create_collection` also call on `get_collection` with an `identity_loader` to make it even smaller? Or should get_or_create not call `self` and explicitly match the called action (even though mongo doesn't care)?