### PR TITLE
Feature/mc 654 enhancement add support for a choice provider that requires tool context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ TBD
 - Added tags to context variables, guidelines, glossary and agents
 - Added guideline matching strategies
 - Added guideline relationships
+- Added support for tool parameters choice provider using the tool context as argument
 
 ### Changed
 - Made the message generator slightly more polite by default, following user feedback

--- a/src/parlant/core/engines/alpha/tool_caller.py
+++ b/src/parlant/core/engines/alpha/tool_caller.py
@@ -158,6 +158,7 @@ class ToolCaller:
         ordinary_guideline_matches: Sequence[GuidelineMatch],
         tool_enabled_guideline_matches: Mapping[GuidelineMatch, Sequence[ToolId]],
         staged_events: Sequence[EmittedEvent],
+        tool_context: ToolContext,
     ) -> ToolCallInferenceResult:
         with self._logger.scope("ToolCaller"):
             return await self._do_infer_tool_calls(
@@ -168,6 +169,7 @@ class ToolCaller:
                 ordinary_guideline_matches,
                 tool_enabled_guideline_matches,
                 staged_events,
+                tool_context,
             )
 
     async def _do_infer_tool_calls(
@@ -179,6 +181,7 @@ class ToolCaller:
         ordinary_guideline_matches: Sequence[GuidelineMatch],
         tool_enabled_guideline_matches: Mapping[GuidelineMatch, Sequence[ToolId]],
         staged_events: Sequence[EmittedEvent],
+        tool_context: ToolContext,
     ) -> ToolCallInferenceResult:
         if not tool_enabled_guideline_matches:
             return ToolCallInferenceResult(

--- a/src/parlant/core/engines/alpha/tool_caller.py
+++ b/src/parlant/core/engines/alpha/tool_caller.py
@@ -202,7 +202,9 @@ class ToolCaller:
                         tool_id.service_name
                     )
 
-                tool = await services[tool_id.service_name].read_tool(tool_id.tool_name)
+                tool = await services[tool_id.service_name].resolve_tool(
+                    tool_id.tool_name, tool_context
+                )
 
                 batches[(tool_id, tool)].append(guideline_match)
 

--- a/src/parlant/core/engines/alpha/tool_event_generator.py
+++ b/src/parlant/core/engines/alpha/tool_event_generator.py
@@ -114,6 +114,12 @@ class ToolEventGenerator:
             self._logger.debug("Skipping tool calling; no tools associated with guidelines found")
             return ToolEventGenerationResult(generations=[], events=[], insights=ToolInsights())
 
+        tool_context = ToolContext(
+            agent_id=agent.id,
+            session_id=session_id,
+            customer_id=customer.id,
+        )
+
         inference_result = await self.tool_caller.infer_tool_calls(
             agent,
             context_variables,
@@ -122,6 +128,7 @@ class ToolEventGenerator:
             ordinary_guideline_matches,
             tool_enabled_guideline_matches,
             staged_events,
+            tool_context,
         )
 
         tool_calls = list(chain.from_iterable(inference_result.batches))
@@ -134,11 +141,7 @@ class ToolEventGenerator:
             )
 
         tool_results = await self.tool_caller.execute_tool_calls(
-            ToolContext(
-                agent_id=agent.id,
-                session_id=session_id,
-                customer_id=customer.id,
-            ),
+            tool_context,
             tool_calls,
         )
 

--- a/src/parlant/core/services/tools/openapi.py
+++ b/src/parlant/core/services/tools/openapi.py
@@ -212,6 +212,11 @@ class OpenAPIClient(ToolService):
         return tool_spec.tool
 
     @override
+    async def resolve_tool(self, name: str, context: ToolContext) -> Tool:
+        # OpenAPI tools don't have a server-side choice_provider, so it simply calls read_tool
+        return await self.read_tool(name)
+
+    @override
     async def call_tool(
         self,
         name: str,

--- a/tests/core/stable/engines/alpha/test_tool_caller.py
+++ b/tests/core/stable/engines/alpha/test_tool_caller.py
@@ -563,10 +563,16 @@ async def test_that_a_tool_with_a_parameter_attached_to_a_choice_provider_gets_t
         return ToolResult({"choices": [products_by_category[category] for category in categories]})
 
     conversation_context_laptops = [
-        ("customer", "Hi, what products are available in category of laptops and peripherals ?"),
+        (
+            EventSource.CUSTOMER,
+            "Hi, what products are available in category of laptops and peripherals ?",
+        ),
     ]
     conversation_context_cakes = [
-        ("customer", "Hi, what products are available in category of cakes and cookies ?"),
+        (
+            EventSource.CUSTOMER,
+            "Hi, what products are available in category of cakes and cookies ?",
+        ),
     ]
 
     interaction_history_larry = create_interaction_history(conversation_context_laptops)


### PR DESCRIPTION
Added a support for using the tool context in choice providers of tools parameters:
- Added a new interface function "resolve_tool" to ToolService and derived classes. resolve_tool is fully implemented in the plugin server, while in local tool service and openapi client it calls read_tool (no resolving as there's nothing to resolve)
- If the choice_provider has a parameter of type ToolContext then the tool context is forwarded to this parameter, other parameters are forwarded by name, as it was before.