### PR TITLE
Overlapping tools implementation

### DIFF
--- a/src/parlant/bin/server.py
+++ b/src/parlant/bin/server.py
@@ -38,6 +38,9 @@ from parlant.core.engines.alpha import guideline_matcher
 from parlant.core.engines.alpha import message_generator
 from parlant.core.engines.alpha.hooks import EngineHooks
 from parlant.core.engines.alpha.relational_guideline_resolver import RelationalGuidelineResolver
+from parlant.core.engines.alpha.tool_calling.overlapping_tools_batch import (
+    OverlappingToolsBatchSchema,
+)
 from parlant.core.engines.alpha.utterance_selector import (
     UtteranceDraftSchema,
     UtteranceFieldExtractionSchema,
@@ -501,6 +504,7 @@ async def initialize_container(
         ConditionsEntailmentTestsSchema,
         ActionsContradictionTestsSchema,
         GuidelineConnectionPropositionsSchema,
+        OverlappingToolsBatchSchema,
     ):
         try_define(SchematicGenerator[schema], await nlp_service.get_schematic_generator(schema))  # type: ignore
 

--- a/src/parlant/core/engines/alpha/tool_calling/default_tool_call_batcher.py
+++ b/src/parlant/core/engines/alpha/tool_calling/default_tool_call_batcher.py
@@ -1,6 +1,11 @@
+from collections import deque
 from itertools import chain
-from typing import Mapping, Sequence
+from typing import Mapping, Sequence, cast
 from parlant.core.engines.alpha.guideline_match import GuidelineMatch
+from parlant.core.engines.alpha.tool_calling.overlapping_tools_batch import (
+    OverlappingToolsBatch,
+    OverlappingToolsBatchSchema,
+)
 from parlant.core.engines.alpha.tool_calling.single_tool_batch import (
     SingleToolBatch,
     SingleToolBatchSchema,
@@ -12,7 +17,7 @@ from parlant.core.engines.alpha.tool_calling.tool_caller import (
 )
 from parlant.core.loggers import Logger
 from parlant.core.nlp.generation import SchematicGenerator
-from parlant.core.relationships import RelationshipStore
+from parlant.core.relationships import RelationshipStore, ToolRelationshipKind
 from parlant.core.services.tools.service_registry import ServiceRegistry
 from parlant.core.tools import Tool, ToolId, ToolOverlap
 
@@ -22,12 +27,14 @@ class DefaultToolCallBatcher(ToolCallBatcher):
         self,
         logger: Logger,
         service_registry: ServiceRegistry,
-        schematic_generator: SchematicGenerator[SingleToolBatchSchema],
+        single_tool_schematic_generator: SchematicGenerator[SingleToolBatchSchema],
+        overlapping_tools_schematic_generator: SchematicGenerator[OverlappingToolsBatchSchema],
         relationship_store: RelationshipStore,
-    ):
+    ) -> None:
         self._logger = logger
         self._service_registry = service_registry
-        self._schematic_generator = schematic_generator
+        self._single_tool_schematic_generator = single_tool_schematic_generator
+        self._overlapping_tools_schematic_generator = overlapping_tools_schematic_generator
         self._relationship_store = relationship_store
 
     async def create_batches(
@@ -36,15 +43,62 @@ class DefaultToolCallBatcher(ToolCallBatcher):
         context: ToolCallContext,
     ) -> Sequence[ToolCallBatch]:
         result: list[ToolCallBatch] = []
-
         independent_tools = {}
         dependent_tools = {}
+        overlapping_tools_batches = []
+        visited = set()
 
-        for tool_id, _tool in tools:
+        tool_id_to_tool = {k[0]: (k[1], v) for k, v in tools.items()}
+
+        async def collect_overlapping_tools(
+            root_id: ToolId,
+        ) -> list[tuple[ToolId, Tool, Sequence[GuidelineMatch]]]:
+            overlapped_tools: list[tuple[ToolId, Tool, Sequence[GuidelineMatch]]] = []
+            queue = deque([root_id])
+            while queue:
+                current = queue.popleft()
+                if current in visited:
+                    continue
+                visited.add(current)
+                all_relationships = list(
+                    chain(
+                        await self._relationship_store.list_relationships(
+                            source_id=current, indirect=False, kind=ToolRelationshipKind.OVERLAP
+                        ),
+                        await self._relationship_store.list_relationships(
+                            target_id=current, indirect=False, kind=ToolRelationshipKind.OVERLAP
+                        ),
+                    )
+                )
+                for r in all_relationships:
+                    neighbor = (
+                        cast(ToolId, r.target.id)
+                        if cast(ToolId, r.target.id) != current
+                        else cast(ToolId, r.source.id)
+                    )
+                    if neighbor in tool_id_to_tool and neighbor not in visited:
+                        overlapped_tools.append(
+                            (
+                                neighbor,
+                                tool_id_to_tool[neighbor][0],
+                                tool_id_to_tool[neighbor][1],
+                            )
+                        )
+                        queue.append(neighbor)
+            return overlapped_tools
+
+        for (tool_id, _tool), guidelines in tools.items():
             if _tool.overlap == ToolOverlap.NONE:
-                independent_tools[(tool_id, _tool)] = tools[(tool_id, _tool)]
-            else:
-                dependent_tools[(tool_id, _tool)] = tools[(tool_id, _tool)]
+                independent_tools[tool_id] = (_tool, guidelines)
+            elif _tool.overlap == ToolOverlap.ALWAYS:
+                dependent_tools[tool_id] = (_tool, guidelines)
+            elif _tool.overlap == ToolOverlap.AUTO and tool_id not in visited:
+                overlapped = await collect_overlapping_tools(tool_id)
+                if overlapped:
+                    overlapped.append((tool_id, _tool, guidelines))
+                    overlapping_tools_batches.append(overlapped)
+                else:
+                    independent_tools[tool_id] = (_tool, guidelines)
 
         if independent_tools:
             context_without_reference_tools = ToolCallContext(
@@ -64,16 +118,21 @@ class DefaultToolCallBatcher(ToolCallBatcher):
             )
             result.extend(
                 self._create_single_tool_batch(
-                    candidate_tool=(k[0], k[1], v), context=context_without_reference_tools
+                    candidate_tool=(k, v[0], v[1]), context=context_without_reference_tools
                 )
                 for k, v in independent_tools.items()
             )
         if dependent_tools:
             result.extend(
-                self._create_single_tool_batch(candidate_tool=(k[0], k[1], v), context=context)
+                self._create_single_tool_batch(candidate_tool=(k, v[0], v[1]), context=context)
                 for k, v in dependent_tools.items()
             )
 
+        if overlapping_tools_batches:
+            result.extend(
+                self._create_overlapping_tools_batch(overlapping_tools_batch=b, context=context)
+                for b in overlapping_tools_batches
+            )
         return result
 
     def _create_single_tool_batch(
@@ -84,7 +143,20 @@ class DefaultToolCallBatcher(ToolCallBatcher):
         return SingleToolBatch(
             logger=self._logger,
             service_registry=self._service_registry,
-            schematic_generator=self._schematic_generator,
+            schematic_generator=self._single_tool_schematic_generator,
             candidate_tool=candidate_tool,
+            context=context,
+        )
+
+    def _create_overlapping_tools_batch(
+        self,
+        overlapping_tools_batch: Sequence[tuple[ToolId, Tool, Sequence[GuidelineMatch]]],
+        context: ToolCallContext,
+    ) -> ToolCallBatch:
+        return OverlappingToolsBatch(
+            logger=self._logger,
+            service_registry=self._service_registry,
+            schematic_generator=self._overlapping_tools_schematic_generator,
+            overlapping_tools_batch=overlapping_tools_batch,
             context=context,
         )

--- a/src/parlant/core/engines/alpha/tool_calling/default_tool_call_batcher.py
+++ b/src/parlant/core/engines/alpha/tool_calling/default_tool_call_batcher.py
@@ -77,6 +77,11 @@ class DefaultToolCallBatcher(ToolCallBatcher):
                         else cast(ToolId, r.source.id)
                     )
                     if neighbor in tool_id_to_tool and neighbor not in visited:
+                        if tool_id_to_tool[neighbor][0].overlap == ToolOverlap.NONE:
+                            self._logger.warning(
+                                f"Overlap relationship ignored because: {tool_id_to_tool[neighbor][0].name} has ToolOverlap.NONE"
+                            )
+                            continue
                         overlapped_tools.append(
                             (
                                 neighbor,

--- a/src/parlant/core/engines/alpha/tool_calling/overlapping_tools_batch.py
+++ b/src/parlant/core/engines/alpha/tool_calling/overlapping_tools_batch.py
@@ -424,7 +424,7 @@ There are no staged tool calls at this time.
             template="""
 OUTPUT FORMAT
 -----------------
-Given the tool, your output should adhere to the following format:
+Given these tools, your output should adhere to the following format:
 ```json
 {{
     "last_customer_message": "<REPEAT THE LAST USER MESSAGE IN THE INTERACTION>",

--- a/src/parlant/core/engines/alpha/tool_calling/overlapping_tools_batch.py
+++ b/src/parlant/core/engines/alpha/tool_calling/overlapping_tools_batch.py
@@ -326,8 +326,8 @@ TASK DESCRIPTION
 -----------------
 Your task is to review a batch of provided tools and, based on your most recent interaction with the customer, decide whether to use them.
 The provided tools have been grouped together due to overlapping functionality or shared parameters.
-You should prefer to run the tool that is the best fit for the current contex. Specifically, the one that is most relevant and tailored to the user's inquiry or need.
-For each tool in the batch, indicate the tool applicability with a boolean value: true if the tool is usefull at this point, or false if it is not. 
+You should prefer to run the tool that is the best fit for the current context. Specifically, the one that is most relevant and tailored to the user's inquiry or need.
+For each tool in the batch, indicate the tool applicability with a boolean value: true if the tool is useful at this point, or false if it is not. 
 For any tool marked as true, include the available arguments for activation.
 Note that a tool may be considered applicable even if not all of its required arguments are available. In such cases, provide the parameters that are currently available, 
 following the format specified in its description.
@@ -433,7 +433,7 @@ Given the tool, your output should adhere to the following format:
     "tools_evaluation": [
         {{
             "name": "<TOOL NAME>",
-            "subtleties_to_be_aware_of": "<NOTE ANY SIGNIFICANT SUBTLETIES TO BE AWARE OF WHEN RUNNING THIS TOOL IN OUR AGENT'S CONTEX>",
+            "subtleties_to_be_aware_of": "<NOTE ANY SIGNIFICANT SUBTLETIES TO BE AWARE OF WHEN RUNNING THIS TOOL IN OUR AGENT'S CONTEXT>",
             "applicability_rationale": "<A FEW WORDS THAT EXPLAIN WHETHER, HOW, AND TO WHAT EXTENT THE TOOL NEEDS TO BE CALLED AT THIS POINT>",
             "potentially_alternative_tools": "<NAME(S) OF THE TOOL(S) IF ANY THAT CAN ALTERNATIVELY BE RUN INSTEAD OF THIS TOOL>",
             "comparison_with_alternative_tools_including_references_to_subtleties": "<A VERY BRIEF OVERVIEW OF HOW THIS CALL FARES AGAINST THE ALTERNATIVE TOOLS IN APPLICABILITY>",
@@ -444,9 +444,9 @@ Given the tool, your output should adhere to the following format:
                     "argument_evaluations": [
                         {{
                             "parameter_name": "<PARAMETER NAME>",
-                            "acceptable_source_for_this_argument_according_to_its_tool_definition": "<REAPET THE ACCEPTABLE SOURCE FOR THE ARGUMENT FROM TOOL DEFINITION>",
+                            "acceptable_source_for_this_argument_according_to_its_tool_definition": "<REPEAT THE ACCEPTABLE SOURCE FOR THE ARGUMENT FROM TOOL DEFINITION>",
                             "evaluate_is_it_provided_by_an_acceptable_source": "<BRIEFLY EVALUATE IF THE SOURCE FOR THE VALUE MATCHES THE ACCEPTABLE SOURCE>",
-                            "evaluate_was_it_already_provided_and_should_it_be_provided_again": "<BRIEFLY EVALUATE IF THE PARAMERWE VALUE WAS PROVIDED AND SHOULD BE PROVIDED AGAIN>",
+                            "evaluate_was_it_already_provided_and_should_it_be_provided_again": "<BRIEFLY EVALUATE IF THE PARAMETER VALUE WAS PROVIDED AND SHOULD BE PROVIDED AGAIN>",
                             "evaluate_is_it_potentially_problematic_to_guess_what_the_value_is_if_it_isnt_provided": "<BRIEFLY EVALUATE IF IT'S A PROBLEM TO GUESS THE VALUE>",
                             "is_optional": <BOOL>,
                             "is_missing": <BOOL>,

--- a/src/parlant/core/engines/alpha/tool_calling/overlapping_tools_batch.py
+++ b/src/parlant/core/engines/alpha/tool_calling/overlapping_tools_batch.py
@@ -428,7 +428,7 @@ Given the tool, your output should adhere to the following format:
 ```json
 {{
     "last_customer_message": "<REPEAT THE LAST USER MESSAGE IN THE INTERACTION>",
-    "most_recent_customer_inquiry_or_need": "<CUSTOMER"S INQUIRY OR NEED>",
+    "most_recent_customer_inquiry_or_need": "<CUSTOMER'S INQUIRY OR NEED>",
     "most_recent_customer_inquiry_or_need_was_already_resolved": <BOOL>,
     "tools_evaluation": [
         {{

--- a/src/parlant/core/engines/alpha/tool_calling/overlapping_tools_batch.py
+++ b/src/parlant/core/engines/alpha/tool_calling/overlapping_tools_batch.py
@@ -1,0 +1,746 @@
+# Copyright 2025 Emcie Co Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+from typing import Any, Optional, Sequence
+from parlant.core.agents import Agent
+from parlant.core.common import DefaultBaseModel, generate_id
+from parlant.core.context_variables import ContextVariable, ContextVariableValue
+from parlant.core.emissions import EmittedEvent
+from parlant.core.engines.alpha.guideline_match import GuidelineMatch
+from parlant.core.engines.alpha.prompt_builder import BuiltInSection, PromptBuilder, SectionStatus
+from parlant.core.glossary import Term
+from parlant.core.loggers import Logger
+from parlant.core.nlp.generation import SchematicGenerator
+from parlant.core.nlp.generation_info import GenerationInfo
+from parlant.core.services.tools.service_registry import ServiceRegistry
+from parlant.core.sessions import Event, EventKind
+from parlant.core.shots import Shot, ShotCollection
+from dataclasses import dataclass
+from parlant.core.engines.alpha.tool_calling.tool_caller import (
+    MissingToolData,
+    ToolCall,
+    ToolCallBatch,
+    ToolCallBatchResult,
+    ToolCallContext,
+    ToolCallId,
+    ToolInsights,
+)
+from parlant.core.tools import Tool, ToolId, ToolParameterDescriptor, ToolParameterOptions
+
+
+class OverlappingToolsBatchArgumentEvaluation(DefaultBaseModel):
+    parameter_name: str
+    acceptable_source_for_this_argument_according_to_its_tool_definition: str
+    evaluate_is_it_provided_by_an_acceptable_source: str
+    evaluate_was_it_already_provided_and_should_it_be_provided_again: str
+    evaluate_is_it_potentially_problematic_to_guess_what_the_value_is_if_it_isnt_provided: str
+    is_optional: Optional[bool] = False
+    has_default_value_if_not_provided_by_acceptable_source: Optional[bool] = None
+    is_missing: bool
+    value_as_string: Optional[str] = None
+
+
+class OverlappingToolsBatchToolCallEvaluation(DefaultBaseModel):
+    argument_evaluations: Optional[list[OverlappingToolsBatchArgumentEvaluation]] = None
+    same_call_is_already_staged: bool
+
+
+class OverlappingToolsBatchToolEvaluation(DefaultBaseModel):
+    name: str
+    subtleties_to_be_aware_of: str
+    applicability_rationale: str
+    potentially_alternative_tools: str
+    comparison_with_alternative_tools_including_references_to_subtleties: str
+    alternative_tool_should_run_instead_of_this_tool: bool
+    is_applicable: bool
+    calls: Optional[list[OverlappingToolsBatchToolCallEvaluation]] = None
+
+
+class OverlappingToolsBatchSchema(DefaultBaseModel):
+    last_customer_message: Optional[str] = None
+    most_recent_customer_inquiry_or_need: Optional[str] = None
+    most_recent_customer_inquiry_or_need_was_already_resolved: Optional[bool] = None
+    tools_evaluation: list[OverlappingToolsBatchToolEvaluation]
+
+
+@dataclass
+class OverlappingToolsBatchShot(Shot):
+    expected_result: OverlappingToolsBatchSchema
+
+
+class OverlappingToolsBatch(ToolCallBatch):
+    def __init__(
+        self,
+        logger: Logger,
+        service_registry: ServiceRegistry,
+        schematic_generator: SchematicGenerator[OverlappingToolsBatchSchema],
+        overlapping_tools_batch: Sequence[tuple[ToolId, Tool, Sequence[GuidelineMatch]]],
+        context: ToolCallContext,
+    ) -> None:
+        self._service_registry = service_registry
+        self._logger = logger
+        self._schematic_generator = schematic_generator
+        self._context = context
+        self._overlapping_tools_batch = overlapping_tools_batch
+
+    async def process(self) -> ToolCallBatchResult:
+        with self._logger.operation("Evaluation: "):
+            (
+                generation_info,
+                inference_output,
+                missing_data,
+            ) = await self._infer_calls_for_overlapping_tools(
+                agent=self._context.agent,
+                context_variables=self._context.context_variables,
+                interaction_history=self._context.interaction_history,
+                terms=self._context.terms,
+                ordinary_guideline_matches=self._context.ordinary_guideline_matches,
+                overlapping_tools_batch=self._overlapping_tools_batch,
+                staged_events=self._context.staged_events,
+            )
+            return ToolCallBatchResult(
+                generation_info=generation_info,
+                tool_calls=inference_output,
+                insights=ToolInsights(missing_data=missing_data),
+            )
+
+    async def _infer_calls_for_overlapping_tools(
+        self,
+        agent: Agent,
+        context_variables: Sequence[tuple[ContextVariable, ContextVariableValue]],
+        interaction_history: Sequence[Event],
+        terms: Sequence[Term],
+        ordinary_guideline_matches: Sequence[GuidelineMatch],
+        overlapping_tools_batch: Sequence[tuple[ToolId, Tool, Sequence[GuidelineMatch]]],
+        staged_events: Sequence[EmittedEvent],
+    ) -> tuple[GenerationInfo, list[ToolCall], list[MissingToolData]]:
+        inference_prompt = self._build_tool_call_inference_prompt(
+            agent,
+            context_variables,
+            interaction_history,
+            terms,
+            ordinary_guideline_matches,
+            overlapping_tools_batch,
+            staged_events,
+            await self.shots(),
+        )
+
+        # Send the tool call inference prompt to the LLM
+        with self._logger.operation("Evaluation: "):
+            generation_info, inference_output = await self._run_inference(inference_prompt)
+
+        # Evaluate the tool calls
+        tool_calls, missing_data = await self._evaluate_tool_calls_parameters(
+            inference_output, overlapping_tools_batch
+        )
+
+        return generation_info, tool_calls, missing_data
+
+    def _get_tool_descriptor(
+        self,
+        tool_name: str,
+        overlapping_tools_batch: Sequence[tuple[ToolId, Tool, Sequence[GuidelineMatch]]],
+    ) -> Optional[tuple[ToolId, Tool]]:
+        for tool_id, tool, _ in overlapping_tools_batch:
+            if tool_name == tool_id.to_string():
+                return tool_id, tool
+        return None
+
+    async def _evaluate_tool_calls_parameters(
+        self,
+        inference_output: Sequence[OverlappingToolsBatchToolEvaluation],
+        overlapping_tools_batch: Sequence[tuple[ToolId, Tool, Sequence[GuidelineMatch]]],
+    ) -> tuple[list[ToolCall], list[MissingToolData]]:
+        tool_calls = []
+        missing_data = []
+
+        for tool_inference in inference_output:
+            tool_name = tool_inference.name
+            result = self._get_tool_descriptor(tool_name, overlapping_tools_batch)
+            if (
+                result
+                and tool_inference.is_applicable
+                and not tool_inference.alternative_tool_should_run_instead_of_this_tool
+                and tool_inference.calls
+            ):
+                tool_id, tool = result
+                for tc in tool_inference.calls:
+                    if not tc.same_call_is_already_staged:
+                        if all(
+                            not evaluation.is_missing
+                            for evaluation in tc.argument_evaluations or []
+                            if evaluation.parameter_name in tool.required
+                        ):
+                            self._logger.debug(
+                                f"Inference::Completion::Activated:\n{tc.model_dump_json(indent=2)}"
+                            )
+
+                            arguments = {}
+
+                            if tool.parameters:  # We check this because sometimes LLMs hallucinate placeholders for no-param tools
+                                for evaluation in tc.argument_evaluations or []:
+                                    if evaluation.is_missing:
+                                        continue
+
+                                    # Note that if LLM provided 'None' for a required parameter with a default - it will get 'None' as value
+                                    arguments[evaluation.parameter_name] = (
+                                        evaluation.value_as_string
+                                    )
+
+                            tool_calls.append(
+                                ToolCall(
+                                    id=ToolCallId(generate_id()),
+                                    tool_id=tool_id,
+                                    arguments=arguments,
+                                )
+                            )
+                        else:
+                            for evaluation in tc.argument_evaluations or []:
+                                if evaluation.parameter_name not in tool.parameters:
+                                    self._logger.error(
+                                        f"Inference::Completion: Argument {evaluation.parameter_name} not found in tool parameters"
+                                    )
+                                    continue
+
+                                tool_descriptor, tool_options = tool.parameters[
+                                    evaluation.parameter_name
+                                ]
+
+                                if (
+                                    evaluation.is_missing
+                                    and not evaluation.is_optional
+                                    and not tool_options.hidden
+                                ):
+                                    missing_data.append(
+                                        MissingToolData(
+                                            parameter=tool_options.display_name
+                                            or evaluation.parameter_name,
+                                            significance=tool_options.significance,
+                                            description=tool_descriptor.get("description"),
+                                            precedence=tool_options.precedence,
+                                        )
+                                    )
+
+                    else:
+                        self._logger.debug(
+                            f"Inference::Completion::Skipped:\n{tc.model_dump_json(indent=2)}"
+                        )
+
+        return tool_calls, missing_data
+
+    async def shots(self) -> Sequence[OverlappingToolsBatchShot]:
+        return await shot_collection.list()
+
+    def _get_glossary_text(
+        self,
+        terms: Sequence[Term],
+    ) -> str:
+        terms_string = "\n".join(f"{i}) {repr(t)}" for i, t in enumerate(terms, start=1))
+
+        return f"""
+The following is a glossary of the business.
+In some cases, a glossary term directly overrides "common knowledge" or the most prevalent definition of that same term (or object).
+Therefore, when encountering any of these terms, prioritize the interpretation provided in the glossary over any definitions you may already know.
+Please be tolerant of possible typos by the user with regards to these terms,and let the user know if/when you assume they meant a term by their typo: ###
+{terms_string}
+###
+"""  # noqa
+
+    def _format_shots(
+        self,
+        shots: Sequence[OverlappingToolsBatchShot],
+    ) -> str:
+        return "\n".join(
+            f"""
+Example #{i}: ###
+{self._format_shot(shot)}
+###
+"""
+            for i, shot in enumerate(shots, start=1)
+        )
+
+    def _format_shot(
+        self,
+        shot: OverlappingToolsBatchShot,
+    ) -> str:
+        return f"""
+- **Context**:
+{shot.description}
+
+- **Expected Result**:
+```json
+{json.dumps(shot.expected_result.model_dump(mode="json", exclude_unset=True), indent=2)}
+```"""
+
+    def _build_tool_call_inference_prompt(
+        self,
+        agent: Agent,
+        context_variables: Sequence[tuple[ContextVariable, ContextVariableValue]],
+        interaction_event_list: Sequence[Event],
+        terms: Sequence[Term],
+        ordinary_guideline_matches: Sequence[GuidelineMatch],
+        batch: Sequence[tuple[ToolId, Tool, Sequence[GuidelineMatch]]],
+        staged_events: Sequence[EmittedEvent],
+        shots: Sequence[OverlappingToolsBatchShot],
+    ) -> PromptBuilder:
+        staged_calls = self._get_staged_calls(staged_events)
+
+        builder = PromptBuilder(on_build=lambda prompt: self._logger.debug(f"Prompt:\n{prompt}"))
+
+        builder.add_section(
+            name="tool-caller-general-instructions",
+            template="""
+GENERAL INSTRUCTIONS
+-----------------
+You are part of a system of AI agents which interact with a customer on the behalf of a business.
+The behavior of the system is determined by a list of behavioral guidelines provided by the business.
+Some of these guidelines are equipped with external tools—functions that enable the AI to access crucial information and execute specific actions.
+Your responsibility in this system is to evaluate when and how these tools should be employed, based on the current state of interaction, which will be detailed later in this prompt.
+
+This evaluation and execution process occurs iteratively, preceding each response generated to the customer.
+Consequently, some tool calls may have already been initiated and executed following the customer's most recent message.
+Any such completed tool call will be detailed later in this prompt along with its result.
+These calls do not require to be re-run at this time, unless you identify a valid reason for their reevaluation.
+
+""",
+            props={},
+        )
+        builder.add_agent_identity(agent)
+        builder.add_section(
+            name="tool-caller-task-description",
+            template="""
+-----------------
+TASK DESCRIPTION
+-----------------
+Your task is to review a batch of provided tools and, based on your most recent interaction with the customer, decide whether to use them.
+The provided tools have been grouped together due to overlapping functionality or shared parameters.
+You should prefer to run the tool that is the best fit for the current contex. Specifically, the one that is most relevant and tailored to the user's inquiry or need.
+For each tool in the batch, indicate the tool applicability with a boolean value: true if the tool is usefull at this point, or false if it is not. 
+For any tool marked as true, include the available arguments for activation.
+Note that a tool may be considered applicable even if not all of its required arguments are available. In such cases, provide the parameters that are currently available, 
+following the format specified in its description.
+
+While doing so, take the following instructions into account:
+
+1. You may suggest tool that don’t directly address the customer’s latest interaction but can advance the conversation to a more useful state based on function definitions.
+2. You may choose to call more than one tool, specifically when handling more than one requirement.
+3. Each tool may be called multiple times with different arguments.
+4. Avoid calling a tool with the SAME arguments more than once, unless clearly justified by the interaction.
+5. Ensure each tool call relies only on the immediate context and staged calls, without requiring other tools not yet invoked, to avoid dependencies.
+6. If a tool needs to be applied multiple times (each with different arguments), you may include it in the output multiple times.
+7. When multiple tools can perform the same task and yield the same result, avoid selecting more than one. Choose the tool that best matches the user's specific request.
+
+The exact format of your output will be provided to you at the end of this prompt.
+
+The following examples show correct outputs for various hypothetical situations.
+Only the responses are provided, without the interaction history or tool descriptions, though these can be inferred from the responses.
+
+""",
+            props={},
+        )
+        builder.add_section(
+            name="tool-caller-examples",
+            template="""
+EXAMPLES
+-----------------
+{formatted_shots}
+""",
+            props={"formatted_shots": self._format_shots(shots), "shots": shots},
+        )
+        builder.add_context_variables(context_variables)
+        if terms:
+            builder.add_section(
+                name=BuiltInSection.GLOSSARY,
+                template=self._get_glossary_text(terms),
+                props={"terms": terms},
+                status=SectionStatus.ACTIVE,
+            )
+        builder.add_interaction_history(interaction_event_list)
+
+        builder.add_section(
+            name=BuiltInSection.GUIDELINE_DESCRIPTIONS,
+            template=self._add_guideline_matches_section(
+                ordinary_guideline_matches,
+                batch,
+            ),
+            props={
+                "ordinary_guideline_matches": ordinary_guideline_matches,
+                "batch": batch,
+            },
+        )
+        tool_descriptors = [(tool_descriptor[0], tool_descriptor[1]) for tool_descriptor in batch]
+        tool_definitions_template, tool_definitions_props = self._add_tool_definitions_section(
+            tool_descriptors=tool_descriptors,
+        )
+        builder.add_section(
+            name="tool-caller-tool-definitions",
+            template=tool_definitions_template,
+            props={
+                **tool_definitions_props,
+            },
+        )
+        if staged_calls:
+            builder.add_section(
+                name="tool-caller-staged-tool-calls",
+                template="""
+STAGED TOOL CALLS
+-----------------
+The following is a list of tool calls staged after the interaction’s latest state. Use this information to avoid redundant calls and to guide your response.
+
+Reminder: If a tool is already staged with the exact same arguments, set "same_call_is_already_staged" to true.
+You may still choose to re-run the tool call, but only if there is a specific reason for it to be executed multiple times.
+
+The staged tool calls are:
+{staged_calls}
+###
+""",
+                props={"staged_calls": staged_calls},
+            )
+        else:
+            builder.add_section(
+                name="tool-caller-empty-staged-tool-calls",
+                template="""
+STAGED TOOL CALLS
+-----------------
+There are no staged tool calls at this time.
+""",
+                props={},
+            )
+
+        builder.add_section(
+            name="tool-caller-output-format",
+            template="""
+OUTPUT FORMAT
+-----------------
+Given the tool, your output should adhere to the following format:
+```json
+{{
+    "last_customer_message": "<REPEAT THE LAST USER MESSAGE IN THE INTERACTION>",
+    "most_recent_customer_inquiry_or_need": "<CUSTOMER"S INQUIRY OR NEED>",
+    "most_recent_customer_inquiry_or_need_was_already_resolved": <BOOL>,
+    "tools_evaluation": [
+        {{
+            "name": "<TOOL NAME>",
+            "subtleties_to_be_aware_of": "<NOTE ANY SIGNIFICANT SUBTLETIES TO BE AWARE OF WHEN RUNNING THIS TOOL IN OUR AGENT'S CONTEX>",
+            "applicability_rationale": "<A FEW WORDS THAT EXPLAIN WHETHER, HOW, AND TO WHAT EXTENT THE TOOL NEEDS TO BE CALLED AT THIS POINT>",
+            "potentially_alternative_tools": "<NAME(S) OF THE TOOL(S) IF ANY THAT CAN ALTERNATIVELY BE RUN INSTEAD OF THIS TOOL>",
+            "comparison_with_alternative_tools_including_references_to_subtleties": "<A VERY BRIEF OVERVIEW OF HOW THIS CALL FARES AGAINST THE ALTERNATIVE TOOLS IN APPLICABILITY>",
+            "alternative_tool_should_run_instead_of_this_tool": <BOOL>,
+            "is_applicable": <BOOL>,
+            "calls": [ 
+                {{
+                    "argument_evaluations": [
+                        {{
+                            "parameter_name": "<PARAMETER NAME>",
+                            "acceptable_source_for_this_argument_according_to_its_tool_definition": "<REAPET THE ACCEPTABLE SOURCE FOR THE ARGUMENT FROM TOOL DEFINITION>",
+                            "evaluate_is_it_provided_by_an_acceptable_source": "<BRIEFLY EVALUATE IF THE SOURCE FOR THE VALUE MATCHES THE ACCEPTABLE SOURCE>",
+                            "evaluate_was_it_already_provided_and_should_it_be_provided_again": "<BRIEFLY EVALUATE IF THE PARAMERWE VALUE WAS PROVIDED AND SHOULD BE PROVIDED AGAIN>",
+                            "evaluate_is_it_potentially_problematic_to_guess_what_the_value_is_if_it_isnt_provided": "<BRIEFLY EVALUATE IF IT'S A PROBLEM TO GUESS THE VALUE>",
+                            "is_optional": <BOOL>,
+                            "is_missing": <BOOL>,
+                            "value_as_string": "<PARAMETER VALUE>"
+                        }},
+                        ...
+                    ],
+                    "same_call_is_already_staged": <BOOL>,
+                }},
+                ...
+            ],
+        }},
+        ...
+    ]
+
+}}
+```
+
+You need to have tools_evaluation for each tool in the tools batch. Also, note that you may choose to have multiple entries in 'calls' if you wish to call the tool multiple times with different arguments.
+""",
+            props={},
+        )
+        return builder
+
+    def _add_tool_definitions_section(
+        self,
+        tool_descriptors: Sequence[tuple[ToolId, Tool]],
+    ) -> tuple[str, dict[str, Any]]:
+        def _get_param_spec(spec: tuple[ToolParameterDescriptor, ToolParameterOptions]) -> str:
+            descriptor, options = spec
+
+            result: dict[str, Any] = {"schema": {"type": descriptor["type"]}}
+
+            if descriptor["type"] == "array":
+                result["schema"]["items"] = {"type": descriptor["item_type"]}
+
+                if enum := descriptor.get("enum"):
+                    result["schema"]["items"]["enum"] = enum
+            else:
+                if enum := descriptor.get("enum"):
+                    result["schema"]["enum"] = enum
+
+            if options.description:
+                result["description"] = options.description
+            elif description := descriptor.get("description"):
+                result["description"] = description
+
+            if examples := descriptor.get("examples"):
+                result["extraction_examples__only_for_reference"] = examples
+
+            match options.source:
+                case "any":
+                    result["acceptable_source"] = (
+                        "This argument can be extracted in the best way you think"
+                    )
+                case "context":
+                    result["acceptable_source"] = (
+                        "This argument can be extracted only from the context given in this prompt"
+                    )
+                case "customer":
+                    result["acceptable_source"] = (
+                        "This argument must be provided by the customer, and NEVER automatically guessed by you"
+                    )
+
+            return json.dumps(result)
+
+        def _get_tool_spec(t_id: ToolId, t: Tool) -> dict[str, Any]:
+            return {
+                "tool_name": t_id.to_string(),
+                "description": t.description,
+                "optional_arguments": {
+                    name: _get_param_spec(spec)
+                    for name, spec in t.parameters.items()
+                    if name not in t.required
+                },
+                "required_parameters": {
+                    name: _get_param_spec(spec)
+                    for name, spec in t.parameters.items()
+                    if name in t.required
+                },
+            }
+
+        tools_specs = [_get_tool_spec(tool_id, tool) for tool_id, tool in tool_descriptors]
+        return (
+            """
+You are provided with multiple tools, which are active candidates for execution.
+Your task is to evaluate the necessity and applicability of each tool. Note that those tools may serve similar purpose. if so, choose the one that best fits the current context.
+Use the more specific tool when it fits. Fallback to the generic tool when the specific one doesn't apply.
+In certain cases it will be necessary to use more than one tool. However, if you decide to activate multiple tools that address the SAME PURPOSE or produce SIMILAR RESULTS,
+you must provide a clear and strong justification for doing so.
+
+
+Tools: ###
+{tools_specs}
+###
+
+""",
+            {
+                "tools_specs": tools_specs,
+            },
+        )
+
+    def _add_guideline_matches_section(
+        self,
+        ordinary_guideline_matches: Sequence[GuidelineMatch],
+        tools_propositions: Sequence[tuple[ToolId, Tool, Sequence[GuidelineMatch]]],
+    ) -> str:
+        ordinary_guidelines_list = ""
+        if ordinary_guideline_matches:
+            ordinary_guidelines = []
+            for i, p in enumerate(ordinary_guideline_matches, start=1):
+                guideline = (
+                    f"{i}) When {p.guideline.content.condition}, then {p.guideline.content.action}"
+                )
+                ordinary_guidelines.append(guideline)
+            ordinary_guidelines_list = "\n".join(ordinary_guidelines)
+
+        if tools_propositions:
+            tools_guidelines: list[str] = []
+            for id, _, guidelines in tools_propositions:
+                tool_guidelines: list[str] = []
+                for i, p in enumerate(guidelines, start=1):
+                    guideline = f"{i}) When {p.guideline.content.condition}, then {p.guideline.content.action}"
+                    tool_guidelines.append(guideline)
+                tools_guidelines.append("\n".join(tool_guidelines))
+                tools_guidelines.append(f"Associated Tool: {id.service_name}:{id.tool_name}")
+            tools_guidelines_list = "\n".join(tools_guidelines)
+        guidelines_list = ordinary_guidelines_list + tools_guidelines_list
+        return f"""
+GUIDELINES
+---------------------
+The following guidelines have been identified as relevant to the current state of interaction with the customer.
+Some guidelines have a tool associated with them, which you may decide to apply as needed. Use these guidelines to understand the context for the provided tools.
+
+Guidelines:
+###
+{guidelines_list}
+###
+"""
+
+    def _get_staged_calls(
+        self,
+        emitted_events: Sequence[EmittedEvent],
+    ) -> Optional[str]:
+        staged_calls = [
+            PromptBuilder.adapt_event(e) for e in emitted_events if e.kind == EventKind.TOOL
+        ]
+
+        if not staged_calls:
+            return None
+
+        return json.dumps(staged_calls)
+
+    async def _run_inference(
+        self,
+        prompt: PromptBuilder,
+    ) -> tuple[GenerationInfo, Sequence[OverlappingToolsBatchToolEvaluation]]:
+        inference = await self._schematic_generator.generate(
+            prompt=prompt,
+            hints={"temperature": 0.05},
+        )
+
+        self._logger.debug(f"Inference::Completion:\n{inference.content.model_dump_json(indent=2)}")
+
+        return inference.info, inference.content.tools_evaluation
+
+
+example_1_shot = OverlappingToolsBatchShot(
+    description=(
+        "the candidate tools are check_vehicle_price(model: str), check_motorcycle_price(model: str)"
+    ),
+    expected_result=OverlappingToolsBatchSchema(
+        last_customer_message="What's your price for a Harley-Davidson Street Glide?",
+        most_recent_customer_inquiry_or_need="Checking the price of a Harley-Davidson Street Glide motorcycle",
+        most_recent_customer_inquiry_or_need_was_already_resolved=False,
+        tools_evaluation=[
+            OverlappingToolsBatchToolEvaluation(
+                name="check_vehicle_price",
+                subtleties_to_be_aware_of="Harley-Davidson Street Glide is a vehicle, but more specifically a motorcycle. "
+                "While this general vehicle pricing tool could apply, it is less tailored to the specific type of vehicle.",
+                applicability_rationale="we need to check for the price of a specific motorcycle model",
+                potentially_alternative_tools="check_motorcycle_price",
+                comparison_with_alternative_tools_including_references_to_subtleties="Harley-Davidson Street Glide is a vehicle and specifically a motorcycle."
+                " check_motorcycle_price is specifically designed for that category. Choosing the more specific tool ensures better alignment with the product type.",
+                alternative_tool_should_run_instead_of_this_tool=True,
+                is_applicable=False,
+            ),
+            OverlappingToolsBatchToolEvaluation(
+                name="check_motorcycle_price",
+                subtleties_to_be_aware_of="Harley-Davidson Street Glide is a type of motorcycle.",
+                applicability_rationale="we need to check for the price of a specific motorcycle model",
+                potentially_alternative_tools="check_vehicle_price",
+                comparison_with_alternative_tools_including_references_to_subtleties="This tool is specifically intended for motorcycle models, which makes it a more suitable choice "
+                "than a general vehicle pricing tool. Specificity to product type improves accuracy and relevance.",
+                alternative_tool_should_run_instead_of_this_tool=False,
+                is_applicable=True,
+                calls=[
+                    OverlappingToolsBatchToolCallEvaluation(
+                        argument_evaluations=[
+                            OverlappingToolsBatchArgumentEvaluation(
+                                parameter_name="model",
+                                acceptable_source_for_this_argument_according_to_its_tool_definition="<INFER THIS BASED ON TOOL DEFINITION>",
+                                evaluate_is_it_provided_by_an_acceptable_source="Yes; the customer asked about a specific model",
+                                evaluate_was_it_already_provided_and_should_it_be_provided_again="The customer asked about a specific model",
+                                evaluate_is_it_potentially_problematic_to_guess_what_the_value_is_if_it_isnt_provided="It would be absurd to provide unsolicited information on some random model, but I don't need to guess here since the customer provided it",
+                                is_missing=False,
+                                is_optional=False,
+                                value_as_string="Harley-Davidson Street Glide",
+                            )
+                        ],
+                        same_call_is_already_staged=False,
+                    )
+                ],
+            ),
+        ],
+    ),
+)
+
+
+example_2_shot = OverlappingToolsBatchShot(
+    description=(
+        "the candidate tools are check_temperature(location: str), check_indoor_temperature(room: str)"
+    ),
+    expected_result=OverlappingToolsBatchSchema(
+        last_customer_message="What's the temperatures in the living room right now? And what is the temperature outside?",
+        most_recent_customer_inquiry_or_need="Checking the current temperature in the living room and outside",
+        most_recent_customer_inquiry_or_need_was_already_resolved=False,
+        tools_evaluation=[
+            OverlappingToolsBatchToolEvaluation(
+                name="check_temperature",
+                subtleties_to_be_aware_of="The user is asking about both indoor and outdoor temperatures. "
+                "This tool is suitable for checking outdoor temperature, but for indoor queries like the living room, a more specific tool exists and should be used instead.",
+                applicability_rationale="The user is asking for the temperature outside, which matches the purpose of this tool.",
+                potentially_alternative_tools="check_indoor_temperature",
+                comparison_with_alternative_tools_including_references_to_subtleties="This tool is suitable for general or outdoor temperature queries. "
+                "While it could technically be used for any temperature check, it's better to use a tool specifically designed for indoor readings—like check_indoor_temperature for the living room.",
+                alternative_tool_should_run_instead_of_this_tool=False,
+                is_applicable=True,
+                calls=[
+                    OverlappingToolsBatchToolCallEvaluation(
+                        argument_evaluations=[
+                            OverlappingToolsBatchArgumentEvaluation(
+                                parameter_name="location",
+                                acceptable_source_for_this_argument_according_to_its_tool_definition="<INFER THIS BASED ON TOOL DEFINITION>",
+                                evaluate_is_it_provided_by_an_acceptable_source="Yes, the user asked about the temperature outside, which implies a general outdoor location (e.g., 'outside')",
+                                evaluate_was_it_already_provided_and_should_it_be_provided_again="The customer asked about a specific location",
+                                evaluate_is_it_potentially_problematic_to_guess_what_the_value_is_if_it_isnt_provided="It would be absurd to provide information on some random place, but I don't need to guess here since the customer provided it",
+                                is_missing=False,
+                                is_optional=False,
+                                value_as_string="outside",
+                            )
+                        ],
+                        same_call_is_already_staged=False,
+                    )
+                ],
+            ),
+            OverlappingToolsBatchToolEvaluation(
+                name="check_indoor_temperature",
+                subtleties_to_be_aware_of="The user is asking about both indoor and outdoor temperatures. "
+                "While a general temperature tool exists, this tool is specifically designed for indoor use and should be preferred for queries like the living room.",
+                applicability_rationale="We need to check the temperature in an indoor room—the living room.",
+                potentially_alternative_tools="check_indoor_temperature",
+                comparison_with_alternative_tools_including_references_to_subtleties="We are checking the temperature in the living room, which is an indoor space. "
+                "Even though check_temperature could return a value, check_indoor_temperature is more specific and should be used when available. "
+                "For the outdoor part of the question, we already used check_temperature.",
+                alternative_tool_should_run_instead_of_this_tool=False,
+                is_applicable=True,
+                calls=[
+                    OverlappingToolsBatchToolCallEvaluation(
+                        argument_evaluations=[
+                            OverlappingToolsBatchArgumentEvaluation(
+                                parameter_name="location",
+                                acceptable_source_for_this_argument_according_to_its_tool_definition="<INFER THIS BASED ON TOOL DEFINITION>",
+                                evaluate_is_it_provided_by_an_acceptable_source="Yes; the customer asked about a specific location",
+                                evaluate_was_it_already_provided_and_should_it_be_provided_again="The customer asked about a specific location",
+                                evaluate_is_it_potentially_problematic_to_guess_what_the_value_is_if_it_isnt_provided="It would be absurd to provide unsolicited information on some random room, but I don't need to guess here since the customer provided it",
+                                is_missing=False,
+                                is_optional=False,
+                                value_as_string="living room",
+                            )
+                        ],
+                        same_call_is_already_staged=False,
+                    )
+                ],
+            ),
+        ],
+    ),
+)
+
+
+_baseline_shots: Sequence[OverlappingToolsBatchShot] = [
+    example_1_shot,
+    example_2_shot,
+]
+
+
+shot_collection = ShotCollection[OverlappingToolsBatchShot](_baseline_shots)

--- a/src/parlant/core/engines/alpha/tool_calling/single_tool_batch.py
+++ b/src/parlant/core/engines/alpha/tool_calling/single_tool_batch.py
@@ -474,7 +474,7 @@ Given the tool, your output should adhere to the following format:
 ```json
 {{
     "last_customer_message": "<REPEAT THE LAST USER MESSAGE IN THE INTERACTION>",
-    "most_recent_customer_inquiry_or_need": "<CUSTOMER"S INQUIRY OR NEED>",
+    "most_recent_customer_inquiry_or_need": "<CUSTOMER'S INQUIRY OR NEED>",
     "most_recent_customer_inquiry_or_need_was_already_resolved": <BOOL>,
     "name": "{service_name}:{tool_name}",
     "subtleties_to_be_aware_of": "<NOTE ANY SIGNIFICANT SUBTLETIES TO BE AWARE OF WHEN RUNNING THIS TOOL IN OUR AGENT'S CONTEXT>",

--- a/src/parlant/core/engines/alpha/tool_calling/single_tool_batch.py
+++ b/src/parlant/core/engines/alpha/tool_calling/single_tool_batch.py
@@ -37,7 +37,7 @@ class SingleToolBatchArgumentEvaluation(DefaultBaseModel):
     evaluate_is_it_provided_by_an_acceptable_source: str
     evaluate_was_it_already_provided_and_should_it_be_provided_again: str
     evaluate_is_it_potentially_problematic_to_guess_what_the_value_is_if_it_isnt_provided: str
-    is_optional: Optional[bool] = None
+    is_optional: Optional[bool] = False
     has_default_value_if_not_provided_by_acceptable_source: Optional[bool] = None
     valid_invalid_or_missing: str
     value_as_string: Optional[str] = None

--- a/src/parlant/core/services/tools/plugins.py
+++ b/src/parlant/core/services/tools/plugins.py
@@ -410,7 +410,7 @@ def _tool_decorator_impl(
                 parameters=_describe_parameters(func),
                 required=_find_required_params(func),
                 consequential=kwargs.get("consequential", False),
-                overlap=kwargs.get("overlap", ToolOverlap.ALWAYS),
+                overlap=kwargs.get("overlap", ToolOverlap.AUTO),
             ),
             function=func,
         )

--- a/src/parlant/core/tools.py
+++ b/src/parlant/core/tools.py
@@ -265,6 +265,7 @@ class _LocalTool:
     parameters: dict[str, tuple[ToolParameterDescriptor, ToolParameterOptions]]
     required: list[str]
     consequential: bool
+    overlap: ToolOverlap
 
 
 class LocalToolService(ToolService):
@@ -283,7 +284,7 @@ class LocalToolService(ToolService):
             parameters=local_tool.parameters,
             required=local_tool.required,
             consequential=local_tool.consequential,
-            overlap=ToolOverlap.ALWAYS,
+            overlap=local_tool.overlap,
         )
 
     # Note that in this function's arguments ToolParameterOptions is optional (initialized to default if not given)
@@ -297,6 +298,7 @@ class LocalToolService(ToolService):
         ],
         required: Sequence[str],
         consequential: bool = False,
+        overlap: ToolOverlap = ToolOverlap.AUTO,
     ) -> Tool:
         creation_utc = datetime.now(timezone.utc)
 
@@ -311,6 +313,7 @@ class LocalToolService(ToolService):
             creation_utc=creation_utc,
             required=list(required),
             consequential=consequential,
+            overlap=overlap,
         )
 
         self._local_tools_by_name[name] = local_tool

--- a/src/parlant/core/tools.py
+++ b/src/parlant/core/tools.py
@@ -164,7 +164,7 @@ class ToolOverlap(Enum):
     """The tool never overlaps with any other tool. No need to check relationships."""
 
     AUTO = auto()
-    """(TODO: WIP feature): Check relationship store. If no relationships, then assume no overlap. This is the default value for overlap."""
+    """Check relationship store. If no relationships, then assume no overlap. This is the default value for overlap."""
 
     ALWAYS = auto()
     """The tool always overlaps with other tools in context."""

--- a/tests/api/test_context_variables.py
+++ b/tests/api/test_context_variables.py
@@ -32,7 +32,7 @@ async def tool_id(container: Container) -> ToolId:
         module_path="test.module.path",
         parameters={"test_parameter": {"type": "string"}},
         required=["test_parameter"],
-        overlap=ToolOverlap.ALWAYS,
+        overlap=ToolOverlap.NONE,
     )
 
     return ToolId("local", "test_tool")

--- a/tests/api/test_context_variables.py
+++ b/tests/api/test_context_variables.py
@@ -20,7 +20,7 @@ from pytest import fixture
 from parlant.core.agents import AgentId
 from parlant.core.context_variables import ContextVariableStore
 from parlant.core.tags import Tag, TagId, TagStore
-from parlant.core.tools import LocalToolService, ToolId
+from parlant.core.tools import LocalToolService, ToolId, ToolOverlap
 
 
 @fixture
@@ -32,6 +32,7 @@ async def tool_id(container: Container) -> ToolId:
         module_path="test.module.path",
         parameters={"test_parameter": {"type": "string"}},
         required=["test_parameter"],
+        overlap=ToolOverlap.ALWAYS,
     )
 
     return ToolId("local", "test_tool")

--- a/tests/api/test_guidelines.py
+++ b/tests/api/test_guidelines.py
@@ -29,7 +29,7 @@ from parlant.core.guideline_tool_associations import GuidelineToolAssociationSto
 from parlant.core.guidelines import Guideline, GuidelineContent, GuidelineStore
 from parlant.core.services.tools.service_registry import ServiceRegistry
 from parlant.core.tags import Tag, TagId, TagStore
-from parlant.core.tools import LocalToolService, ToolId
+from parlant.core.tools import LocalToolService, ToolId, ToolOverlap
 
 from tests.test_utilities import (
     OPENAPI_SERVER_URL,
@@ -653,6 +653,7 @@ async def test_legacy_that_a_tool_association_can_be_added(
         description="",
         parameters={},
         required=[],
+        overlap=ToolOverlap.ALWAYS,
     )
 
     guideline = await guideline_store.create_guideline(
@@ -735,6 +736,7 @@ async def test_legacy_that_a_tool_association_can_be_removed(
         description="",
         parameters={},
         required=[],
+        overlap=ToolOverlap.ALWAYS,
     )
 
     guideline = await guideline_store.create_guideline(
@@ -808,6 +810,7 @@ async def test_legacy_that_guideline_deletion_removes_tool_associations(
         description="",
         parameters={},
         required=[],
+        overlap=ToolOverlap.ALWAYS,
     )
 
     guideline = await guideline_store.create_guideline(
@@ -1709,6 +1712,7 @@ async def test_that_a_tool_association_can_be_added_to_a_guideline(
         description="",
         parameters={},
         required=[],
+        overlap=ToolOverlap.ALWAYS,
     )
 
     guideline = await guideline_store.create_guideline(

--- a/tests/api/test_guidelines.py
+++ b/tests/api/test_guidelines.py
@@ -653,7 +653,7 @@ async def test_legacy_that_a_tool_association_can_be_added(
         description="",
         parameters={},
         required=[],
-        overlap=ToolOverlap.ALWAYS,
+        overlap=ToolOverlap.NONE,
     )
 
     guideline = await guideline_store.create_guideline(
@@ -736,7 +736,7 @@ async def test_legacy_that_a_tool_association_can_be_removed(
         description="",
         parameters={},
         required=[],
-        overlap=ToolOverlap.ALWAYS,
+        overlap=ToolOverlap.NONE,
     )
 
     guideline = await guideline_store.create_guideline(
@@ -810,7 +810,7 @@ async def test_legacy_that_guideline_deletion_removes_tool_associations(
         description="",
         parameters={},
         required=[],
-        overlap=ToolOverlap.ALWAYS,
+        overlap=ToolOverlap.NONE,
     )
 
     guideline = await guideline_store.create_guideline(
@@ -1712,7 +1712,7 @@ async def test_that_a_tool_association_can_be_added_to_a_guideline(
         description="",
         parameters={},
         required=[],
-        overlap=ToolOverlap.ALWAYS,
+        overlap=ToolOverlap.NONE,
     )
 
     guideline = await guideline_store.create_guideline(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,7 +33,7 @@ from parlant.core.emission.event_publisher import EventPublisherFactory
 from parlant.core.emissions import EventEmitterFactory
 from parlant.core.customers import CustomerDocumentStore, CustomerStore
 from parlant.core.engines.alpha import guideline_matcher
-from parlant.core.engines.alpha.tool_calling import single_tool_batch
+from parlant.core.engines.alpha.tool_calling import overlapping_tools_batch, single_tool_batch
 from parlant.core.engines.alpha import message_generator
 from parlant.core.engines.alpha.hooks import EngineHooks
 from parlant.core.engines.alpha.relational_guideline_resolver import RelationalGuidelineResolver
@@ -288,6 +288,7 @@ async def container(
             UtteranceRevisionSchema,
             UtteranceFieldExtractionSchema,
             single_tool_batch.SingleToolBatchSchema,
+            overlapping_tools_batch.OverlappingToolsBatchSchema,
             ConditionsEntailmentTestsSchema,
             ActionsContradictionTestsSchema,
             GuidelineConnectionPropositionsSchema,
@@ -301,6 +302,9 @@ async def container(
         container[ShotCollection[GenericGuidelineMatchingShot]] = guideline_matcher.shot_collection
         container[ShotCollection[single_tool_batch.SingleToolBatchShot]] = (
             single_tool_batch.shot_collection
+        )
+        container[ShotCollection[overlapping_tools_batch.OverlappingToolsBatchShot]] = (
+            overlapping_tools_batch.shot_collection
         )
         container[ShotCollection[MessageGeneratorShot]] = message_generator.shot_collection
 

--- a/tests/core/common/engines/alpha/steps/tools.py
+++ b/tests/core/common/engines/alpha/steps/tools.py
@@ -16,6 +16,12 @@ from typing import Any, cast
 from pytest_bdd import given, parsers
 
 from parlant.core.tools import ToolOverlap, ToolParameterOptions
+from parlant.core.relationships import (
+    EntityType,
+    RelationshipEntity,
+    RelationshipStore,
+    ToolRelationshipKind,
+)
 from parlant.core.agents import AgentId, AgentStore
 from parlant.core.guideline_tool_associations import (
     GuidelineToolAssociation,
@@ -262,16 +268,17 @@ def given_a_tool(
             "description": "Transfer money from one account to another",
             "module_path": "tests.tool_utilities",
             "parameters": {
+                "amount": {"type": "integer", "description": "The number of coins to transfer"},
                 "from_account": {
                     "type": "string",
-                    "description": "The account from which money will be transferred",
+                    "description": "The name of the account from which money will be transferred",
                 },
                 "to_account": {
                     "type": "string",
-                    "description": "The account to which money will be transferred",
+                    "description": "The name of the account to which money will be transferred",
                 },
             },
-            "required": ["from_account", "to_account"],
+            "required": ["amount", "from_account", "to_account"],
         },
         "check_fruit_price": {
             "name": "check_fruit_price",
@@ -605,7 +612,7 @@ def given_a_tool(
         },
         "search_electronic_products": {
             "name": "search_electronic_products",
-            "description": "Search for products in the inventory based on various criteria",
+            "description": "Search for electronic products in the inventory based on various criteria",
             "module_path": "tests.tool_utilities",
             "parameters": {
                 "keyword": {
@@ -630,6 +637,197 @@ def given_a_tool(
             },
             "required": ["keyword"],
         },
+        "search_products": {
+            "name": "search_products",
+            "description": "Search for products in the inventory based on various criteria",
+            "module_path": "tests.tool_utilities",
+            "parameters": {
+                "keyword": {
+                    "type": "string",
+                    "description": "Search term to match against product names and descriptions",
+                },
+                "product_type": {
+                    "type": "string",
+                    "description": "Filter by product category",
+                    "enum": [
+                        "Electronics",
+                        "Clothing",
+                        "Home",
+                        "Beauty",
+                        "Toys",
+                        "Sports",
+                        "Automotive",
+                        "Other",
+                    ],
+                },
+                "min_price": {"type": "integer", "description": "Minimum price filter"},
+                "max_price": {"type": "integer", "description": "Maximum price filter"},
+                "in_stock_only": {
+                    "type": "boolean",
+                    "description": "Only show products that are currently in stock",
+                },
+                "brand": {"type": "string", "description": "Brand or manufacturer name"},
+            },
+            "required": ["keyword"],
+        },
+        "book_flight": {
+            "name": "book_flight",
+            "description": "Books a flight with the provided details",
+            "module_path": "tests.tool_utilities",
+            "parameters": {
+                "departure_city": {
+                    "type": "string",
+                    "description": "The name of the city the user flighting from",
+                },
+                "destination_city": {
+                    "type": "string",
+                    "description": "The name of the city the user is flighting to",
+                },
+                "departure_date": {
+                    "type": "string",
+                    "description": "The departure date given in format DD-MM-YYYY",
+                },
+                "return_date": {
+                    "type": "string",
+                    "description": "The return date given in format DD-MM-YYYY",
+                },
+                "passenger_name": {
+                    "type": "string",
+                    "description": "The name of the passenger",
+                },
+            },
+            "required": ["departure_city", "destination_city", "departure_date"],
+        },
+        "send_email": {
+            "name": "send_email",
+            "description": "Sends an email to the specified recipient.",
+            "module_path": "tests.tool_utilities",
+            "parameters": {
+                "to": {
+                    "type": "string",
+                    "description": "the name of the person to send the email to",
+                },
+                "subject": {
+                    "type": "string",
+                    "description": "The subject of the mail",
+                },
+                "body": {
+                    "type": "string",
+                    "description": "The body of the mail",
+                },
+            },
+            "required": ["to", "subject"],
+        },
+        "schedule_meeting": {
+            "name": "schedule_meeting",
+            "description": "Schedules a meeting with the given participant.",
+            "module_path": "tests.tool_utilities",
+            "parameters": {
+                "participant": {
+                    "type": "string",
+                    "description": "The participant name to include in the meeting",
+                },
+                "date": {
+                    "type": "string",
+                    "description": "The meeting date given in format DD-MM-YYYY",
+                },
+                "time": {
+                    "type": "string",
+                    "description": "The meeting hour given in 24-hour format HH:MM",
+                },
+                "agenda": {
+                    "type": "string",
+                    "description": "The meeting agenda",
+                },
+            },
+            "required": ["participant", "date", "time"],
+        },
+        "schedule_appointment": {
+            "name": "schedule_appointment",
+            "description": "Schedules a new appointment for a patient with a specific doctor.",
+            "module_path": "tests.tool_utilities",
+            "parameters": {
+                "patient": {
+                    "type": "string",
+                    "description": "The name of the patient for whom the appointment is being scheduled. Will be the user name if specified and the appointment is for the user.",
+                },
+                "doctor_name": {
+                    "type": "string",
+                    "description": "The name of the doctor the appointment is with.",
+                },
+                "date": {
+                    "type": "string",
+                    "description": "The appointment date in format DD-MM-YYYY.",
+                },
+                "time": {
+                    "type": "string",
+                    "description": "The appointment time in 24-hour format HH:MM.",
+                },
+                "reason": {
+                    "type": "string",
+                    "description": "The reason for the appointment (optional).",
+                },
+            },
+            "required": ["patient", "doctor_name", "date", "time"],
+        },
+        "reschedule_appointment": {
+            "name": "reschedule_appointment",
+            "description": "Reschedules an existing appointment for a patient with a specific doctor.",
+            "module_path": "tests.tool_utilities",
+            "parameters": {
+                "patient": {
+                    "type": "string",
+                    "description": "The name of the patient whose appointment is being rescheduled. Will be the user name if specified and the appointment is for the user.",
+                },
+                "doctor_name": {
+                    "type": "string",
+                    "description": "The name of the doctor the appointment is with.",
+                },
+                "new_date": {
+                    "type": "string",
+                    "description": "The new date for the appointment in format DD-MM-YYYY.",
+                },
+                "new_time": {
+                    "type": "string",
+                    "description": "The new time for the appointment in 24-hour format HH:MM.",
+                },
+            },
+            "required": ["patient", "doctor_name", "new_date", "new_time"],
+        },
+        "transfer_shekels": {
+            "name": "transfer_shekels",
+            "description": "Transfers a specified amount in shekels from one account to another.",
+            "module_path": "tests.tool_utilities",
+            "parameters": {
+                "amount": {"type": "integer", "description": "The amount of shekels to transfer"},
+                "from_account": {
+                    "type": "string",
+                    "description": "The name of the account sending the shekels",
+                },
+                "to_account": {
+                    "type": "string",
+                    "description": "The name of the account receiving the shekels",
+                },
+            },
+            "required": ["amount", "from_account", "to_account"],
+        },
+        "transfer_dollars": {
+            "name": "transfer_dollars",
+            "description": "Transfers a specified amount in shekels from one account to another.",
+            "module_path": "tests.tool_utilities",
+            "parameters": {
+                "amount": {"type": "integer", "description": "The amount of dollars to transfer"},
+                "from_account": {
+                    "type": "string",
+                    "description": "The name of the account sending the dollars",
+                },
+                "to_account": {
+                    "type": "string",
+                    "description": "The name of the account receiving the dollars",
+                },
+            },
+            "required": ["amount", "from_account", "to_account"],
+        },
     }
 
     tool = context.sync_await(local_tool_service.create_tool(**tools[tool_name]))
@@ -649,5 +847,33 @@ def given_max_engine_iteration(
         agent_store.update_agent(
             agent_id=agent_id,
             params={"max_engine_iterations": int(max_engine_iterations)},
+        )
+    )
+
+
+@step(
+    given,
+    parsers.parse('a tool relationship whereby "{tool_a}" overlaps with "{tool_b}"'),
+)
+def given_an_overlaping_tools_relationship(
+    context: ContextOfTest,
+    tool_a: str,
+    tool_b: str,
+) -> None:
+    store = context.container[RelationshipStore]
+    tool_a_id = ToolId(service_name="local", tool_name=tool_a)
+    tool_b_id = ToolId(service_name="local", tool_name=tool_b)
+
+    context.sync_await(
+        store.create_relationship(
+            source=RelationshipEntity(
+                id=tool_a_id,
+                type=EntityType.TOOL,
+            ),
+            target=RelationshipEntity(
+                id=tool_b_id,
+                type=EntityType.TOOL,
+            ),
+            kind=ToolRelationshipKind.OVERLAP,
         )
     )

--- a/tests/core/common/engines/alpha/steps/tools.py
+++ b/tests/core/common/engines/alpha/steps/tools.py
@@ -15,7 +15,7 @@
 from typing import Any, cast
 from pytest_bdd import given, parsers
 
-from parlant.core.tools import ToolParameterOptions
+from parlant.core.tools import ToolOverlap, ToolParameterOptions
 from parlant.core.agents import AgentId, AgentStore
 from parlant.core.guideline_tool_associations import (
     GuidelineToolAssociation,
@@ -118,6 +118,30 @@ def given_the_tool_from_service(
 
     tool = context.sync_await(
         local_tool_service.create_tool(**service_tools[service_name][tool_name])
+    )
+
+    context.tools[tool_name] = tool
+
+
+@step(given, parsers.parse('the tool "{tool_name}" with always as overlap'))
+def given_the_tool_with_always_as_overlap(
+    context: ContextOfTest,
+    tool_name: str,
+) -> None:
+    local_tool_service = context.container[LocalToolService]
+
+    tools: dict[str, dict[str, Any]] = {
+        "get_terrys_offering": {
+            "name": "get_terrys_offering",
+            "description": "Explain Terry's offering",
+            "module_path": "tests.tool_utilities",
+            "parameters": {},
+            "required": [],
+        }
+    }
+
+    tool = context.sync_await(
+        local_tool_service.create_tool(**tools[tool_name], overlap=ToolOverlap.ALWAYS)
     )
 
     context.tools[tool_name] = tool

--- a/tests/core/stable/engines/alpha/features/baseline/tools.feature
+++ b/tests/core/stable/engines/alpha/features/baseline/tools.feature
@@ -798,3 +798,20 @@ Feature: Tools
         Then a single tool calls event is emitted
         And the tool calls event contains 1 tool call(s)
         And the tool calls event contains a call to "search_electronic_products" with laptop as keyword and max price of 5 
+
+    Scenario: The agent correctly chooses to call the right tool
+        Given an agent whose job is to sell groceries
+        And the term "carrot" defined as a kind of fruit
+        And a guideline "check_prices" to reply with the price of the item when a customer asks about an items price
+        And the tool "check_fruit_price"
+        And the tool "check_vegetable_price"
+        And an association between "check_prices" and "check_fruit_price"
+        And an association between "check_prices" and "check_vegetable_price"
+        And a tool relationship whereby "check_fruit_price" overlaps with "check_vegetable_price"
+        And a customer message, "What's the price of 1 kg of carrots?"
+        When processing is triggered
+        Then a single tool calls event is emitted
+        And the tool calls event contains 1 tool call(s)
+        And the tool calls event contains a call with tool_id of "local:check_fruit_price"
+        And a single message event is emitted
+        And the message contains that the price of 1 kg of carrots is 10 dollars

--- a/tests/core/stable/engines/alpha/features/baseline/tools.feature
+++ b/tests/core/stable/engines/alpha/features/baseline/tools.feature
@@ -852,21 +852,21 @@ Feature: Tools
         And the tool "transfer_money"
         And an association between "do_transaction" and "transfer_shekels"
         And an association between "do_transaction" and "transfer_money"
-        And a customer message, "Hey, can transfer to my friend Alisse 200 shekels? my name is Fredric"
+        And a customer message, "Hey, can I transfer to my friend Alisse 200 shekels? my name is Fredric"
         And a tool relationship whereby "transfer_shekels" overlaps with "transfer_money"
         When processing is triggered
         Then a single tool calls event is emitted
         And the tool calls event contains 1 tool call(s)
         And the tool calls event contains a call to "transfer_shekels" with 200 as amount from Fredric to Alisse
 
-    Scenario:Tool caller chooses the more suitable tool for transfer when two overlap and there are missing parameters (1)
+    Scenario: Tool caller chooses the more suitable tool for transfer when two overlap and there are missing parameters (1)
         Given a guideline "do_transaction" to transfer money for the customer when customer asks to transfer money
         And the tool "transfer_shekels"
         And the tool "transfer_money"
         And an association between "do_transaction" and "transfer_shekels"
         And an association between "do_transaction" and "transfer_money"
         And a tool relationship whereby "transfer_shekels" overlaps with "transfer_money"
-        And a customer message, "Hey, can transfer to my friend Alisse 200 shekels?"
+        And a customer message, "Hey, can I transfer to my friend Alisse 200 shekels?"
         When processing is triggered
         Then no tool calls event is emitted
 

--- a/tests/core/stable/engines/alpha/features/baseline/tools.feature
+++ b/tests/core/stable/engines/alpha/features/baseline/tools.feature
@@ -602,29 +602,198 @@ Feature: Tools
         And the number of missing parameters is exactly 1
         And the message mentions that parameters are invalid
         And the number of invalid parameters is exactly 2
-        And the message mentions the robot, mistress and homie
-        
-    Scenario: Tool caller chooses the right tool when two are activated 
-        Given a customer named "Harry"
-        And an empty session with "Harry"
-        And a guideline "to_schedule_meeting" to schedule a meeting when customer asks to schedule a meeting
+        And the message mentions the robot, mistress and hom
+
+    Scenario: Tool caller chooses the right tool for scheduling when three are overlapping
+        Given a customer named "Hailey"
+        And an empty session with "Hailey"
         And a guideline "to_schedule_appointment" to schedule an appointment with a doctor when user asks to make an appointment
-        And a guideline "to_send_email" to send an email to them when customer asks to reach out with someone
-        And the tool "send_email"
-        And an association between "to_send_email" and "send_email"
-        And the tool "schedule_meeting"
-        And an association between "to_schedule_meeting" and "schedule_meeting"
+        And a guideline "to_reschedule_appointment" to rescedule existing appointment when user had an appointment and they want to change its time
+        And a guideline "to_schedule_meeting" to schedule a meeting when customer asks to meet with someone
         And the tool "schedule_appointment"
         And an association between "to_schedule_appointment" and "schedule_appointment"
+        And the tool "reschedule_appointment"
+        And an association between "to_reschedule_appointment" and "reschedule_appointment"
+        And the tool "schedule_meeting"
+        And an association between "to_schedule_meeting" and "schedule_meeting"
+        And a tool relationship whereby "reschedule_appointment" overlaps with "schedule_appointment"
         And a tool relationship whereby "schedule_meeting" overlaps with "schedule_appointment"
-        # And a tool relationship whereby "schedule_meeting" overlaps with "send_email"
-        And a context variable "Current Date" set to "April 9th, 2025" for "Harry"
-        And a customer message, "Can you reach out to Morgan and see if she’s free to meet tommorow at 10:30 about the hiring freeze?"
+        And a context variable "Current Date" set to "April 10th, 2025" for "Hailey"
+        And a customer message, "Hi I want to make an appointment with Dr Sara Goodman tommorow at 19:00. Can you help me with that?"
         When processing is triggered
         Then a single tool calls event is emitted
         And the tool calls event contains 1 tool call(s)
-        And the tool calls event contains a call to "local:send_email" to morgan with subject of a meeting tommorow and doesn't contains a call to "local:schedule_meeting"
+        And the tool calls event contains a call to "local:schedule_appointment" to Hailey with Dr sara goodman at 11-04-2025 19:00
 
+    Scenario: Tool caller use both tools for scheduling appointment correctly when they overlap 
+        Given a customer named "Hailey"
+        And an empty session with "Hailey"
+        And a guideline "to_schedule_appointment" to schedule an appointment with a doctor when user asks to make an appointment
+        And a guideline "to_reschedule_appointment" to rescedule existing appointment when user had an appointment and they want to change its time
+        And the tool "schedule_appointment"
+        And an association between "to_schedule_appointment" and "schedule_appointment"
+        And the tool "reschedule_appointment"
+        And an association between "to_reschedule_appointment" and "reschedule_appointment"
+        And a tool relationship whereby "reschedule_appointment" overlaps with "schedule_appointment"
+        And a context variable "Current Date" set to "April 10th, 2025" for "Hailey"
+        And a customer message, "Hi, I’d like to schedule an appointment for tommorow at 18:00 with Dr. Gabi, please. Also, I have an appointment with Dr. Michael. Could you please reschedule with Dr. Michael for tommorow at 3:00 PM? Thank you!"
+        When processing is triggered
+        Then a single tool calls event is emitted
+        And the tool calls event contains 2 tool call(s)
+        And the tool calls event contains a call to "local:reschedule_appointment" to Hailey with Dr. Michael at 11-04-2025 15:00 and contains a call to "local:schedule_appointment" to Hailey with Dr. Gabi at 11-04-2025 18:00
+
+    Scenario: Drinks and toppings tools called from same guideline
+        Given a guideline "sell_pizza" to sell pizza when interacting with customers
+        And a guideline "check_drinks_or_toppings_in_stock" to check for drinks or toppings in stock when the customer specifies toppings or drinks
+        And the tool "get_available_drinks"
+        And the tool "get_available_toppings"
+        And an association between "check_drinks_or_toppings_in_stock" and "get_available_drinks"
+        And an association between "check_drinks_or_toppings_in_stock" and "get_available_toppings"
+        And a customer message, "Hey, can I order a large pepperoni pizza with Sprite?"
+        When processing is triggered
+        Then a single tool calls event is emitted
+        And the tool calls event contains 2 tool call(s)
+        And the tool calls event contains Sprite and Coca Cola under "get_available_drinks"
+        And the tool calls event contains Pepperoni, Mushrooms, and Olives under "get_available_toppings"
+    
+    Scenario: Tool caller use the more suitable tool for transfer when two overlap
+        Given a guideline "do_transcation" to transfer money for the customer when customer asks to transfer money
+        And the tool "transfer_shekels"
+        And the tool "transfer_money"
+        And an association between "do_transcation" and "transfer_shekels"
+        And an association between "do_transcation" and "transfer_money"
+        And a customer message, "Hey, can transfer to my friend Alisse 200 shekels? my name is Fredric"
+        And a tool relationship whereby "transfer_shekels" overlaps with "transfer_money"
+        When processing is triggered
+        Then a single tool calls event is emitted
+        And the tool calls event contains 1 tool call(s)
+        And the tool calls event contains a call to "transfer_shekels" with 200 as amount from Fredric to Alisse
+
+    Scenario: Tool caller want to use the more suitable tool for transfer when two overlap and there are missing parameters (1)
+        Given a guideline "do_transcation" to transfer money for the customer when customer asks to transfer money
+        And the tool "transfer_shekels"
+        And the tool "transfer_money"
+        And an association between "do_transcation" and "transfer_shekels"
+        And an association between "do_transcation" and "transfer_money"
+        And a tool relationship whereby "transfer_shekels" overlaps with "transfer_money"
+        And a customer message, "Hey, can transfer to my friend Alisse 200 shekels?"
+        When processing is triggered
+        Then no tool calls event is emitted
+
+    Scenario: Tool caller want to use the more suitable tool for transfer when two overlap and there are missing parameters (2)
+        Given a guideline "do_transcation" to transfer money for the customer when customer asks to transfer money
+        And the tool "transfer_shekels"
+        And the tool "transfer_money"
+        And an association between "do_transcation" and "transfer_shekels"
+        And an association between "do_transcation" and "transfer_money"
+        And a tool relationship whereby "transfer_shekels" overlaps with "transfer_money"
+        And a customer message, "Hey, can transfer to $200?"
+        When processing is triggered
+        Then no tool calls event is emitted
+
+    Scenario: Tool caller use both tools for the right transfer when two overlap 
+        Given a guideline "do_transcation" to transfer money for the customer when customer asks to transfer money
+        And a guideline to choose the more specific coin when customer asks to transfer money
+        And the tool "transfer_money"
+        And the tool "transfer_shekels"
+        And an association between "do_transcation" and "transfer_shekels"
+        And an association between "do_transcation" and "transfer_money"
+        And a customer message, "Hey, can transfer to my friend Alisse 200 shekels and to my friend Bob $300? my name is Fredric"
+        And a tool relationship whereby "transfer_shekels" overlaps with "transfer_money"
+        When processing is triggered
+        Then a single tool calls event is emitted
+        And the tool calls event contains 2 tool call(s)
+        And the tool calls event contains a call to "transfer_shekels" with 200 from Fredric to Alisse and a call to "transfer_money" with 300 from Fredric to Bob and no call to "transfer_money" with 200
+
+    Scenario: Tool caller use tools multiple times for the right transfer when two overlap 
+        Given a guideline "do_transcation" to transfer money for the customer when customer asks to transfer money
+        And a guideline to choose the more specific coin when customer asks to transfer money
+        And the tool "transfer_shekels"
+        And the tool "transfer_money"
+        And an association between "do_transcation" and "transfer_shekels"
+        And an association between "do_transcation" and "transfer_money"
+        And a tool relationship whereby "transfer_shekels" overlaps with "transfer_money"
+        And a customer message, "Hey, can transfer to my friend Alisse 200 shekels and to my friend Bob $300 and also 100 shekels to Bob? my name is Fredric"
+        When processing is triggered
+        Then a single tool calls event is emitted
+        And the tool calls event contains 3 tool call(s)
+        And the tool calls event contains a call to "transfer_shekels" with 200 from Fredric to Alisse a call to "transfer_shekels" with 100 from Fredric to Bob and a call to "transfer_money" with 300 from Fredric to Bob and no call to "transfer_money" with 200
+
+    Scenario: Tool caller use the more suitable tool for transfer when three overlap directly 
+        Given a guideline "do_transcation" to transfer money for the customer when customer asks to transfer money
+        And the tool "transfer_shekels"
+        And the tool "transfer_money"
+        And the tool "transfer_dollars"
+        And an association between "do_transcation" and "transfer_shekels"
+        And an association between "do_transcation" and "transfer_money"
+        And an association between "do_transcation" and "transfer_dollars"
+        And a tool relationship whereby "transfer_shekels" overlaps with "transfer_money"
+        And a tool relationship whereby "transfer_dollars" overlaps with "transfer_money"
+        And a tool relationship whereby "transfer_dollars" overlaps with "transfer_shekels"
+        And a customer message, "Hey, can transfer to my friend Alisse 200 shekels and to my friend Dan $40 and to my friend Ali 500 Dinar? my name is Fredric"
+        When processing is triggered
+        Then a single tool calls event is emitted
+        And the tool calls event contains 3 tool call(s)
+        And the tool calls event contains a call to "transfer_shekels" with 200 from Fredric to Alisse and a call to "transfer_dollars" with 40 from Fredric to Dan and a call to "transfer_money" with 500 from Fredric to Ali
+
+    Scenario: Tool caller use the more suitable tool for transfer when three overlap indirectly 
+        Given a guideline "do_transcation" to transfer money for the customer when customer asks to transfer money
+        And the tool "transfer_shekels"
+        And the tool "transfer_money"
+        And the tool "transfer_dollars"
+        And an association between "do_transcation" and "transfer_shekels"
+        And an association between "do_transcation" and "transfer_money"
+        And an association between "do_transcation" and "transfer_dollars"
+        And a tool relationship whereby "transfer_shekels" overlaps with "transfer_money"
+        And a tool relationship whereby "transfer_dollars" overlaps with "transfer_money"
+        And a customer message, "Hey, can transfer to my friend Alisse 200 shekels and to my friend Dan $40 and to my friend Ali 500 Dinar? my name is Fredric"
+        When processing is triggered
+        Then a single tool calls event is emitted
+        And the tool calls event contains 3 tool call(s)
+        And the tool calls event contains a call to "transfer_shekels" with 200 from Fredric to Alisse and a call to "transfer_dollars" with 40 from Fredric to Dan and a call to "transfer_money" with 500 from Fredric to Ali
+
+    Scenario: Tool caller user the more suitable tool for searching when two overlap (1)
+        Given a guideline "do_search" to retrieve relevant products that match the asked attributes when customer is interested in products with specific attributes
+        And the tool "search_products"
+        And the tool "search_electronic_products"
+        And an association between "do_search" and "search_products"
+        And an association between "do_search" and "search_electronic_products"
+        And a tool relationship whereby "search_electronic_products" overlaps with "search_products"
+        And a customer message, "Hey, Do you have trousers that costs no more than $5 for men?"
+        When processing is triggered
+        Then a single tool calls event is emitted
+        And the tool calls event contains 1 tool call(s)
+        And the tool calls event contains a call to "search_products" with trousers as keyword and max price of 5  
+
+    Scenario: Tool caller user the more suitable tool for searching when two overlap (2)
+        Given a guideline "do_search" to retrieve relevant products that match the asked attributes when customer is interested in products with specific attributes
+        And the tool "search_products"
+        And the tool "search_electronic_products"
+        And an association between "do_search" and "search_products"
+        And an association between "do_search" and "search_electronic_products"
+        And a tool relationship whereby "search_electronic_products" overlaps with "search_products"
+        And a customer message, "Hey, Do you have laptops that costs no more than $5?"
+        When processing is triggered
+        Then a single tool calls event is emitted
+        And the tool calls event contains 1 tool call(s)
+        And the tool calls event contains a call to "search_electronic_products" with laptop as keyword and max price of 5 
+
+    Scenario: The agent correctly chooses to call the right tool
+        Given an agent whose job is to sell groceries
+        And the term "carrot" defined as a kind of fruit
+        And a guideline "check_prices" to reply with the price of the item when a customer asks about an items price
+        And the tool "check_fruit_price"
+        And the tool "check_vegetable_price"
+        And an association between "check_prices" and "check_fruit_price"
+        And an association between "check_prices" and "check_vegetable_price"
+        And a tool relationship whereby "check_fruit_price" overlaps with "check_vegetable_price"
+        And a customer message, "What's the price of 1 kg of carrots?"
+        When processing is triggered
+        Then a single tool calls event is emitted
+        And the tool calls event contains 1 tool call(s)
+        And the tool calls event contains a call with tool_id of "local:check_fruit_price"
+        And a single message event is emitted
+        And the message contains that the price of 1 kg of carrots is 10 dollars
     Scenario: Tool caller chooses the right tool for scheduling when three are overlapping
         Given a customer named "Hailey"
         And an empty session with "Hailey"

--- a/tests/core/stable/engines/alpha/features/baseline/tools.feature
+++ b/tests/core/stable/engines/alpha/features/baseline/tools.feature
@@ -136,11 +136,11 @@ Feature: Tools
 
     Scenario: The agent distinguishes between tools from different services
         Given a guideline "system_check_scheduling" to schedule a system check if the error is critical when the customer complains about an error
-        And a guideline "cs_meeting_scheduleing" to schedule a new customer success meeting when the customer gives feedback regarding their use of the system
+        And a guideline "cs_meeting_scheduling" to schedule a new customer success meeting when the customer gives feedback regarding their use of the system
         And the tool "schedule" from "first_service"
         And the tool "schedule" from "second_service"
         And an association between "system_check_scheduling" and "schedule" from "first_service"
-        And an association between "cs_meeting_scheduleing" and "schedule" from "second_service"
+        And an association between "cs_meeting_scheduling" and "schedule" from "second_service"
         And a customer message, "I'm really happy about the system"
         When processing is triggered
         Then a single tool calls event is emitted
@@ -798,7 +798,7 @@ Feature: Tools
         Given a customer named "Hailey"
         And an empty session with "Hailey"
         And a guideline "to_schedule_appointment" to schedule an appointment with a doctor when user asks to make an appointment
-        And a guideline "to_reschedule_appointment" to rescedule existing appointment when user had an appointment and they want to change its time
+        And a guideline "to_reschedule_appointment" to reschedule existing appointment when user had an appointment and they want to change its time
         And a guideline "to_schedule_meeting" to schedule a meeting when customer asks to meet with someone
         And the tool "schedule_appointment"
         And an association between "to_schedule_appointment" and "schedule_appointment"
@@ -809,7 +809,7 @@ Feature: Tools
         And a tool relationship whereby "reschedule_appointment" overlaps with "schedule_appointment"
         And a tool relationship whereby "schedule_meeting" overlaps with "schedule_appointment"
         And a context variable "Current Date" set to "April 10th, 2025" for "Hailey"
-        And a customer message, "Hi I want to make an appointment with Dr Sara Goodman tommorow at 19:00. Can you help me with that?"
+        And a customer message, "Hi I want to make an appointment with Dr Sara Goodman tomorrow at 19:00. Can you help me with that?"
         When processing is triggered
         Then a single tool calls event is emitted
         And the tool calls event contains 1 tool call(s)
@@ -819,14 +819,14 @@ Feature: Tools
         Given a customer named "Hailey"
         And an empty session with "Hailey"
         And a guideline "to_schedule_appointment" to schedule an appointment with a doctor when user asks to make an appointment
-        And a guideline "to_reschedule_appointment" to rescedule existing appointment when user had an appointment and they want to change its time
+        And a guideline "to_reschedule_appointment" to reschedule existing appointment when user had an appointment and they want to change its time
         And the tool "schedule_appointment"
         And an association between "to_schedule_appointment" and "schedule_appointment"
         And the tool "reschedule_appointment"
         And an association between "to_reschedule_appointment" and "reschedule_appointment"
         And a tool relationship whereby "reschedule_appointment" overlaps with "schedule_appointment"
         And a context variable "Current Date" set to "April 10th, 2025" for "Hailey"
-        And a customer message, "Hi, I’d like to schedule an appointment for tommorow at 18:00 with Dr. Gabi, please. Also, I have an appointment with Dr. Michael. Could you please reschedule with Dr. Michael for tommorow at 3:00 PM? Thank you!"
+        And a customer message, "Hi, I’d like to schedule an appointment for tomorrow at 18:00 with Dr. Gabi, please. Also, I have an appointment with Dr. Michael. Could you please reschedule with Dr. Michael for tomorrow at 3:00 PM? Thank you!"
         When processing is triggered
         Then a single tool calls event is emitted
         And the tool calls event contains 2 tool call(s)
@@ -847,11 +847,11 @@ Feature: Tools
         And the tool calls event contains Pepperoni, Mushrooms, and Olives under "get_available_toppings"
     
     Scenario: Tool caller use the more suitable tool for transfer when two overlap
-        Given a guideline "do_transcation" to transfer money for the customer when customer asks to transfer money
+        Given a guideline "do_transaction" to transfer money for the customer when customer asks to transfer money
         And the tool "transfer_shekels"
         And the tool "transfer_money"
-        And an association between "do_transcation" and "transfer_shekels"
-        And an association between "do_transcation" and "transfer_money"
+        And an association between "do_transaction" and "transfer_shekels"
+        And an association between "do_transaction" and "transfer_money"
         And a customer message, "Hey, can transfer to my friend Alisse 200 shekels? my name is Fredric"
         And a tool relationship whereby "transfer_shekels" overlaps with "transfer_money"
         When processing is triggered
@@ -859,35 +859,35 @@ Feature: Tools
         And the tool calls event contains 1 tool call(s)
         And the tool calls event contains a call to "transfer_shekels" with 200 as amount from Fredric to Alisse
 
-    Scenario: Tool caller want to use the more suitable tool for transfer when two overlap and there are missing parameters (1)
-        Given a guideline "do_transcation" to transfer money for the customer when customer asks to transfer money
+    Scenario:Tool caller chooses the more suitable tool for transfer when two overlap and there are missing parameters (1)
+        Given a guideline "do_transaction" to transfer money for the customer when customer asks to transfer money
         And the tool "transfer_shekels"
         And the tool "transfer_money"
-        And an association between "do_transcation" and "transfer_shekels"
-        And an association between "do_transcation" and "transfer_money"
+        And an association between "do_transaction" and "transfer_shekels"
+        And an association between "do_transaction" and "transfer_money"
         And a tool relationship whereby "transfer_shekels" overlaps with "transfer_money"
         And a customer message, "Hey, can transfer to my friend Alisse 200 shekels?"
         When processing is triggered
         Then no tool calls event is emitted
 
-    Scenario: Tool caller want to use the more suitable tool for transfer when two overlap and there are missing parameters (2)
-        Given a guideline "do_transcation" to transfer money for the customer when customer asks to transfer money
+    Scenario: Tool caller chooses the more suitable tool for transfer when two overlap and there are missing parameters (2)
+        Given a guideline "do_transaction" to transfer money for the customer when customer asks to transfer money
         And the tool "transfer_shekels"
         And the tool "transfer_money"
-        And an association between "do_transcation" and "transfer_shekels"
-        And an association between "do_transcation" and "transfer_money"
+        And an association between "do_transaction" and "transfer_shekels"
+        And an association between "do_transaction" and "transfer_money"
         And a tool relationship whereby "transfer_shekels" overlaps with "transfer_money"
-        And a customer message, "Hey, can transfer to $200?"
+        And a customer message, "Hey, can transfer $200?"
         When processing is triggered
         Then no tool calls event is emitted
 
     Scenario: Tool caller use both tools for the right transfer when two overlap 
-        Given a guideline "do_transcation" to transfer money for the customer when customer asks to transfer money
+        Given a guideline "do_transaction" to transfer money for the customer when customer asks to transfer money
         And a guideline to choose the more specific coin when customer asks to transfer money
         And the tool "transfer_money"
         And the tool "transfer_shekels"
-        And an association between "do_transcation" and "transfer_shekels"
-        And an association between "do_transcation" and "transfer_money"
+        And an association between "do_transaction" and "transfer_shekels"
+        And an association between "do_transaction" and "transfer_money"
         And a customer message, "Hey, can transfer to my friend Alisse 200 shekels and to my friend Bob $300? my name is Fredric"
         And a tool relationship whereby "transfer_shekels" overlaps with "transfer_money"
         When processing is triggered
@@ -896,12 +896,12 @@ Feature: Tools
         And the tool calls event contains a call to "transfer_shekels" with 200 from Fredric to Alisse and a call to "transfer_money" with 300 from Fredric to Bob and no call to "transfer_money" with 200
 
     Scenario: Tool caller use tools multiple times for the right transfer when two overlap 
-        Given a guideline "do_transcation" to transfer money for the customer when customer asks to transfer money
+        Given a guideline "do_transaction" to transfer money for the customer when customer asks to transfer money
         And a guideline to choose the more specific coin when customer asks to transfer money
         And the tool "transfer_shekels"
         And the tool "transfer_money"
-        And an association between "do_transcation" and "transfer_shekels"
-        And an association between "do_transcation" and "transfer_money"
+        And an association between "do_transaction" and "transfer_shekels"
+        And an association between "do_transaction" and "transfer_money"
         And a tool relationship whereby "transfer_shekels" overlaps with "transfer_money"
         And a customer message, "Hey, can transfer to my friend Alisse 200 shekels and to my friend Bob $300 and also 100 shekels to Bob? my name is Fredric"
         When processing is triggered
@@ -910,13 +910,13 @@ Feature: Tools
         And the tool calls event contains a call to "transfer_shekels" with 200 from Fredric to Alisse a call to "transfer_shekels" with 100 from Fredric to Bob and a call to "transfer_money" with 300 from Fredric to Bob and no call to "transfer_money" with 200
 
     Scenario: Tool caller use the more suitable tool for transfer when three overlap directly 
-        Given a guideline "do_transcation" to transfer money for the customer when customer asks to transfer money
+        Given a guideline "do_transaction" to transfer money for the customer when customer asks to transfer money
         And the tool "transfer_shekels"
         And the tool "transfer_money"
         And the tool "transfer_dollars"
-        And an association between "do_transcation" and "transfer_shekels"
-        And an association between "do_transcation" and "transfer_money"
-        And an association between "do_transcation" and "transfer_dollars"
+        And an association between "do_transaction" and "transfer_shekels"
+        And an association between "do_transaction" and "transfer_money"
+        And an association between "do_transaction" and "transfer_dollars"
         And a tool relationship whereby "transfer_shekels" overlaps with "transfer_money"
         And a tool relationship whereby "transfer_dollars" overlaps with "transfer_money"
         And a tool relationship whereby "transfer_dollars" overlaps with "transfer_shekels"
@@ -927,13 +927,13 @@ Feature: Tools
         And the tool calls event contains a call to "transfer_shekels" with 200 from Fredric to Alisse and a call to "transfer_dollars" with 40 from Fredric to Dan and a call to "transfer_money" with 500 from Fredric to Ali
 
     Scenario: Tool caller use the more suitable tool for transfer when three overlap indirectly 
-        Given a guideline "do_transcation" to transfer money for the customer when customer asks to transfer money
+        Given a guideline "do_transaction" to transfer money for the customer when customer asks to transfer money
         And the tool "transfer_shekels"
         And the tool "transfer_money"
         And the tool "transfer_dollars"
-        And an association between "do_transcation" and "transfer_shekels"
-        And an association between "do_transcation" and "transfer_money"
-        And an association between "do_transcation" and "transfer_dollars"
+        And an association between "do_transaction" and "transfer_shekels"
+        And an association between "do_transaction" and "transfer_money"
+        And an association between "do_transaction" and "transfer_dollars"
         And a tool relationship whereby "transfer_shekels" overlaps with "transfer_money"
         And a tool relationship whereby "transfer_dollars" overlaps with "transfer_money"
         And a customer message, "Hey, can transfer to my friend Alisse 200 shekels and to my friend Dan $40 and to my friend Ali 500 Dinar? my name is Fredric"
@@ -968,7 +968,7 @@ Feature: Tools
         And the tool calls event contains 1 tool call(s)
         And the tool calls event contains a call to "search_electronic_products" with laptop as keyword and max price of 5 
 
-    Scenario: The agent correctly chooses to call the right tool
+    Scenario: The agent correctly chooses to call the right overlapping tool based on glossary
         Given an agent whose job is to sell groceries
         And the term "carrot" defined as a kind of fruit
         And a guideline "check_prices" to reply with the price of the item when a customer asks about an items price

--- a/tests/core/stable/engines/alpha/test_tool_caller.py
+++ b/tests/core/stable/engines/alpha/test_tool_caller.py
@@ -928,7 +928,7 @@ async def test_that_tool_calling_batchers_can_be_overridden(
     assert echo_tool_id.to_string() not in all_tool_ids
 
 
-async def test_one_batch_creation_for_overlapping_tools(
+async def test_that_two_non_overlapping_tools_are_overlapping_with_a_third_tool_they_are_all_considered_in_the_same_evaluation_batch(
     container: Container,
     agent: Agent,
 ) -> None:
@@ -1027,7 +1027,7 @@ async def test_one_batch_creation_for_overlapping_tools(
     assert len(batches) == 1
 
 
-async def test_multiple_batches_creation_for_overlapping_tools(
+async def test_that_a_tool_with_unmatched_guideline_is_not_included_in_the_evaluation_batch_when_its_overlapped_tools_are_with_a_matched_guideline_and_does_not_indirectly_cause_overlap_between_those_tools(
     container: Container,
     agent: Agent,
 ) -> None:

--- a/tests/core/stable/engines/alpha/test_tool_caller.py
+++ b/tests/core/stable/engines/alpha/test_tool_caller.py
@@ -36,6 +36,12 @@ from parlant.core.engines.alpha.tool_calling.tool_caller import (
 )
 from parlant.core.guidelines import Guideline, GuidelineId, GuidelineContent
 from parlant.core.nlp.generation_info import GenerationInfo, UsageInfo
+from parlant.core.relationships import (
+    EntityType,
+    RelationshipEntity,
+    RelationshipStore,
+    ToolRelationshipKind,
+)
 from parlant.core.services.tools.plugins import tool
 from parlant.core.services.tools.service_registry import ServiceRegistry
 from parlant.core.sessions import Event, EventSource, SessionStore
@@ -45,6 +51,7 @@ from parlant.core.tools import (
     Tool,
     ToolContext,
     ToolId,
+    ToolOverlap,
     ToolParameterOptions,
     ToolResult,
 )
@@ -919,3 +926,193 @@ async def test_that_tool_calling_batchers_can_be_overridden(
     all_tool_ids = {tc.tool_id.to_string() for tc in chain.from_iterable(res.batches)}
     assert ping_tool_id.to_string() in all_tool_ids
     assert echo_tool_id.to_string() not in all_tool_ids
+
+
+async def test_one_batch_creation_for_overlapping_tools(
+    container: Container,
+    agent: Agent,
+) -> None:
+    tool_caller = container[ToolCaller]
+    relationship_store = container[RelationshipStore]
+
+    interaction_history = [
+        create_event_message(
+            offset=0,
+            source=EventSource.CUSTOMER,
+            message="hello",
+        )
+    ]
+    _tool = Tool(
+        name="test_tool",
+        creation_utc=datetime.now(),
+        description="",
+        metadata={},
+        parameters={},
+        required=[],
+        consequential=True,
+        overlap=ToolOverlap.AUTO,
+    )
+
+    a_tool_id = ToolId(service_name="local", tool_name="aa")
+    b_tool_id = ToolId(service_name="local", tool_name="bb")
+    c_tool_id = ToolId(service_name="local", tool_name="cc")
+
+    tool_enabled_guideline_matches = {
+        create_guideline_match(
+            condition="customer asks to a",
+            action="do a",
+            score=9,
+            rationale="customer wants to a",
+            tags=[Tag.for_agent_id(agent.id)],
+        ): [a_tool_id],
+        create_guideline_match(
+            condition="customer asks to b",
+            action="do b",
+            score=9,
+            rationale="customer wants to b",
+            tags=[Tag.for_agent_id(agent.id)],
+        ): [b_tool_id],
+        create_guideline_match(
+            condition="customer asks to c",
+            action="do c",
+            score=9,
+            rationale="customer wants to c",
+            tags=[Tag.for_agent_id(agent.id)],
+        ): [c_tool_id],
+    }
+
+    await relationship_store.create_relationship(
+        source=RelationshipEntity(
+            id=a_tool_id,
+            type=EntityType.TOOL,
+        ),
+        target=RelationshipEntity(
+            id=b_tool_id,
+            type=EntityType.TOOL,
+        ),
+        kind=ToolRelationshipKind.OVERLAP,
+    )
+
+    await relationship_store.create_relationship(
+        source=RelationshipEntity(
+            id=b_tool_id,
+            type=EntityType.TOOL,
+        ),
+        target=RelationshipEntity(
+            id=c_tool_id,
+            type=EntityType.TOOL,
+        ),
+        kind=ToolRelationshipKind.OVERLAP,
+    )
+
+    tools: Mapping[tuple[ToolId, Tool], Sequence[GuidelineMatch]] = {
+        (a_tool_id, _tool): [],
+        (b_tool_id, _tool): [],
+        (c_tool_id, _tool): [],
+    }
+    tool_call_context = ToolCallContext(
+        agent=agent,
+        services={},
+        context_variables=[],
+        interaction_history=interaction_history,
+        terms=[],
+        ordinary_guideline_matches=[],
+        tool_enabled_guideline_matches=tool_enabled_guideline_matches,
+        staged_events=[],
+    )
+    batches: Sequence[ToolCallBatch] = await tool_caller.batcher.create_batches(
+        tools, context=tool_call_context
+    )
+
+    assert len(batches) == 1
+
+
+async def test_multiple_batches_creation_for_overlapping_tools(
+    container: Container,
+    agent: Agent,
+) -> None:
+    tool_caller = container[ToolCaller]
+    relationship_store = container[RelationshipStore]
+
+    interaction_history = [
+        create_event_message(
+            offset=0,
+            source=EventSource.CUSTOMER,
+            message="hello",
+        )
+    ]
+    _tool = Tool(
+        name="test_tool",
+        creation_utc=datetime.now(),
+        description="",
+        metadata={},
+        parameters={},
+        required=[],
+        consequential=True,
+        overlap=ToolOverlap.AUTO,
+    )
+
+    a_tool_id = ToolId(service_name="local", tool_name="aa")
+    b_tool_id = ToolId(service_name="local", tool_name="bb")
+    c_tool_id = ToolId(service_name="local", tool_name="cc")
+
+    tool_enabled_guideline_matches = {
+        create_guideline_match(
+            condition="customer asks to a",
+            action="do a",
+            score=9,
+            rationale="customer wants to a",
+            tags=[Tag.for_agent_id(agent.id)],
+        ): [a_tool_id],
+        create_guideline_match(
+            condition="customer asks to c",
+            action="do c",
+            score=9,
+            rationale="customer wants to c",
+            tags=[Tag.for_agent_id(agent.id)],
+        ): [c_tool_id],
+    }
+
+    await relationship_store.create_relationship(
+        source=RelationshipEntity(
+            id=a_tool_id,
+            type=EntityType.TOOL,
+        ),
+        target=RelationshipEntity(
+            id=b_tool_id,
+            type=EntityType.TOOL,
+        ),
+        kind=ToolRelationshipKind.OVERLAP,
+    )
+
+    await relationship_store.create_relationship(
+        source=RelationshipEntity(
+            id=b_tool_id,
+            type=EntityType.TOOL,
+        ),
+        target=RelationshipEntity(
+            id=c_tool_id,
+            type=EntityType.TOOL,
+        ),
+        kind=ToolRelationshipKind.OVERLAP,
+    )
+
+    tools: Mapping[tuple[ToolId, Tool], Sequence[GuidelineMatch]] = {
+        (a_tool_id, _tool): [],
+        (c_tool_id, _tool): [],
+    }
+    tool_call_context = ToolCallContext(
+        agent=agent,
+        services={},
+        context_variables=[],
+        interaction_history=interaction_history,
+        terms=[],
+        ordinary_guideline_matches=[],
+        tool_enabled_guideline_matches=tool_enabled_guideline_matches,
+        staged_events=[],
+    )
+    batches: Sequence[ToolCallBatch] = await tool_caller.batcher.create_batches(
+        tools, context=tool_call_context
+    )
+
+    assert len(batches) == 2

--- a/tests/core/stable/services/tools/test_plugin_client.py
+++ b/tests/core/stable/services/tools/test_plugin_client.py
@@ -801,12 +801,12 @@ async def test_that_a_plugin_tool_can_return_utterances(
             assert utterances[1] in result.utterances
 
 
-async def test_that_tool_decorator_has_default_overlap_always() -> None:
+async def test_that_tool_decorator_has_default_overlap_auto() -> None:
     @tool
     def my_tool(context: ToolContext) -> ToolResult:
         return ToolResult({})
 
-    assert my_tool.tool.overlap == ToolOverlap.ALWAYS
+    assert my_tool.tool.overlap == ToolOverlap.AUTO
 
 
 async def test_that_tool_decorator_can_set_overlap() -> None:

--- a/tests/core/unstable/engines/alpha/features/baseline/tools.feature
+++ b/tests/core/unstable/engines/alpha/features/baseline/tools.feature
@@ -27,7 +27,7 @@ Feature: Tools
         Then a single message event is emitted
         And the message contains an apology for missing data
     
-    Scenario: No tool call emitted when data is ambiguios (transfer_coins)
+    Scenario: No tool call emitted when data is ambiguous (transfer_coins)
         Given a guideline "make_transfer" to make a transfer when asked to transfer money from one account to another
         And the tool "transfer_coins"
         And an association between "make_transfer" and "transfer_coins"
@@ -38,7 +38,7 @@ Feature: Tools
     Scenario: Tool caller correctly infers arguments values with optional (3)
         Given a guideline "filter_electronic_products" to retrieve relevant products that match the asked attributes when customer is interested in electronic products with specific attributes
         And the tool "search_electronic_products"
-        And an association bsetween "filter_electronic_products" and "search_electronic_products"
+        And an association between "filter_electronic_products" and "search_electronic_products"
         And a customer message, "Hey, how much does a SSD of Samsung cost?"
         When processing is triggered
         Then a single tool calls event is emitted
@@ -60,8 +60,8 @@ Feature: Tools
         And a tool relationship whereby "schedule_meeting" overlaps with "schedule_appointment"
         # And a tool relationship whereby "schedule_meeting" overlaps with "send_email"
         And a context variable "Current Date" set to "April 9th, 2025" for "Harry"
-        And a customer message, "Can you reach out to Morgan and see if she’s free to meet tommorow at 10:30 about the hiring freeze?"
+        And a customer message, "Can you reach out to Morgan and see if she’s free to meet tomorrow at 10:30 about the hiring freeze?"
         When processing is triggered
         Then a single tool calls event is emitted
         And the tool calls event contains 1 tool call(s)
-        And the tool calls event contains a call to "local:send_email" to morgan with subject of a meeting tommorow and doesn't contains a call to "local:schedule_meeting"
+        And the tool calls event contains a call to "local:send_email" to morgan with subject of a meeting tomorrow and doesn't contains a call to "local:schedule_meeting"

--- a/tests/core/unstable/engines/alpha/features/baseline/tools.feature
+++ b/tests/core/unstable/engines/alpha/features/baseline/tools.feature
@@ -44,3 +44,24 @@ Feature: Tools
         Then a single tool calls event is emitted
         And the tool calls event contains 1 tool call(s)
         And the tool calls event contains SSD as keyword and Samsung as Vendor 
+    
+    Scenario: Tool caller chooses the right tool when two are activated 
+        Given a customer named "Harry"
+        And an empty session with "Harry"
+        And a guideline "to_schedule_meeting" to schedule a meeting when customer asks to schedule a meeting
+        And a guideline "to_schedule_appointment" to schedule an appointment with a doctor when user asks to make an appointment
+        And a guideline "to_send_email" to send an email to them when customer asks to reach out with someone
+        And the tool "send_email"
+        And an association between "to_send_email" and "send_email"
+        And the tool "schedule_meeting"
+        And an association between "to_schedule_meeting" and "schedule_meeting"
+        And the tool "schedule_appointment"
+        And an association between "to_schedule_appointment" and "schedule_appointment"
+        And a tool relationship whereby "schedule_meeting" overlaps with "schedule_appointment"
+        # And a tool relationship whereby "schedule_meeting" overlaps with "send_email"
+        And a context variable "Current Date" set to "April 9th, 2025" for "Harry"
+        And a customer message, "Can you reach out to Morgan and see if she’s free to meet tommorow at 10:30 about the hiring freeze?"
+        When processing is triggered
+        Then a single tool calls event is emitted
+        And the tool calls event contains 1 tool call(s)
+        And the tool calls event contains a call to "local:send_email" to morgan with subject of a meeting tommorow and doesn't contains a call to "local:schedule_meeting"

--- a/tests/core/unstable/engines/alpha/features/baseline/tools.feature
+++ b/tests/core/unstable/engines/alpha/features/baseline/tools.feature
@@ -35,23 +35,6 @@ Feature: Tools
         When processing is triggered
         Then no tool calls event is emitted
 
-    Scenario: The agent correctly chooses to call the right tool
-        Given an agent whose job is to sell groceries
-        And the term "carrot" defined as a kind of fruit
-        And a guideline "check_prices" to reply with the price of the item when a customer asks about an items price
-        And the tool "check_fruit_price"
-        And the tool "check_vegetable_price"
-        And an association between "check_prices" and "check_fruit_price"
-        And an association between "check_prices" and "check_vegetable_price"
-        And a tool relationship whereby "check_fruit_price" overlaps with "check_vegetable_price"
-        And a customer message, "What's the price of 1 kg of carrots?"
-        When processing is triggered
-        Then a single tool calls event is emitted
-        And the tool calls event contains 1 tool call(s)
-        And the tool calls event contains a call with tool_id of "local:check_fruit_price"
-        And a single message event is emitted
-        And the message contains that the price of 1 kg of carrots is 10 dollars
-
     Scenario: Tool caller correctly infers arguments values with optional (3)
         Given a guideline "filter_electronic_products" to retrieve relevant products that match the asked attributes when customer is interested in electronic products with specific attributes
         And the tool "search_electronic_products"

--- a/tests/core/unstable/engines/alpha/features/baseline/tools.feature
+++ b/tests/core/unstable/engines/alpha/features/baseline/tools.feature
@@ -2,10 +2,11 @@ Feature: Tools
     Background:
         Given the alpha engine
         And an agent
+        And an empty session
+
 
     Scenario: Guideline matcher and tool caller understand that a Q&A tool needs to be called multiple times to answer different questions
-        Given an empty session
-        And a guideline "answer_questions" to look up the answer and, if found, when the customer has a question related to the bank's services
+        Given a guideline "answer_questions" to look up the answer and, if found, when the customer has a question related to the bank's services
         And the tool "find_answer"
         And an association between "answer_questions" and "find_answer"
         And a customer message, "How do I pay my credit card bill?"
@@ -27,8 +28,7 @@ Feature: Tools
         And the message contains an apology for missing data
     
     Scenario: No tool call emitted when data is ambiguios (transfer_coins)
-        Given an empty session
-        And a guideline "make_transfer" to make a transfer when asked to transfer money from one account to another
+        Given a guideline "make_transfer" to make a transfer when asked to transfer money from one account to another
         And the tool "transfer_coins"
         And an association between "make_transfer" and "transfer_coins"
         And a customer message, "My name is Mark Corrigan and I want to transfer about 200-300 dollars from my account to Sophie Chapman account. My pincode is 1234"
@@ -43,6 +43,7 @@ Feature: Tools
         And the tool "check_vegetable_price"
         And an association between "check_prices" and "check_fruit_price"
         And an association between "check_prices" and "check_vegetable_price"
+        And a tool relationship whereby "check_fruit_price" overlaps with "check_vegetable_price"
         And a customer message, "What's the price of 1 kg of carrots?"
         When processing is triggered
         Then a single tool calls event is emitted
@@ -54,7 +55,7 @@ Feature: Tools
     Scenario: Tool caller correctly infers arguments values with optional (3)
         Given a guideline "filter_electronic_products" to retrieve relevant products that match the asked attributes when customer is interested in electronic products with specific attributes
         And the tool "search_electronic_products"
-        And an association between "filter_electronic_products" and "search_electronic_products"
+        And an association bsetween "filter_electronic_products" and "search_electronic_products"
         And a customer message, "Hey, how much does a SSD of Samsung cost?"
         When processing is triggered
         Then a single tool calls event is emitted

--- a/tests/tool_utilities.py
+++ b/tests/tool_utilities.py
@@ -116,8 +116,10 @@ def get_account_loans(account_name: str) -> ToolResult:
     return ToolResult(portfolios[account_name])
 
 
-def transfer_money(from_account: str, to_account: str) -> ToolResult:
-    return ToolResult(True)
+def transfer_money(amount: int, from_account: str, to_account: str) -> ToolResult:
+    return ToolResult(
+        data=f"Transferred {amount} coins from {from_account} to {to_account} successfully."
+    )
 
 
 def get_terrys_offering() -> ToolResult:
@@ -319,3 +321,100 @@ async def search_electronic_products(
         products = [item for item in products if item["vendor"].lower() == vendor.lower()]
 
     return ToolResult({"available_products": products, "total_results": len(products)})
+
+
+async def search_products(
+    keyword: str,
+    product_type: Optional[ElectronicProductType] = None,
+    min_price: Optional[int] = None,
+    max_price: Optional[int] = None,
+    in_stock_only: Optional[bool] = False,
+    brand: Optional[str] = None,
+) -> ToolResult:
+    with open("tests/data/get_products_by_type_data.json", "r") as f:
+        database = json.load(f)
+
+    # Start with all products
+    products = database
+
+    # Filter by keyword (required parameter)
+    keyword = keyword.lower()
+    products = [
+        item
+        for item in products
+        if keyword in item["title"].lower() or keyword in item["description"].lower()
+    ]
+
+    # Apply optional filters
+    if product_type:
+        products = [item for item in products if item["type"] == product_type]
+
+    if min_price is not None:
+        products = [item for item in products if item["price"] >= min_price]
+
+    if max_price is not None:
+        products = [item for item in products if item["price"] <= max_price]
+
+    if in_stock_only:
+        products = [item for item in products if item["qty"] > 0]
+
+    if brand:
+        products = [item for item in products if item["vendor"].lower() == brand.lower()]
+
+    return ToolResult({"available_products": products, "total_results": len(products)})
+
+
+def book_flight(
+    departure_city: str,
+    destination_city: str,
+    departure_date: str,
+    return_date: Optional[str] = None,
+    passenger_name: Optional[str] = None,
+) -> ToolResult:
+    # Imagine this performs some flight booking logic
+    return ToolResult(
+        data=f"Flight booked from {departure_city} to {destination_city} on {departure_date}."
+    )
+
+
+def send_email(to: str, subject: str, body: Optional[str] = None) -> ToolResult:
+    return ToolResult(data=f"Email sent to {to} with subject '{subject}'.")
+
+
+class Names(enum.Enum):
+    ELIZABETH = "Elizabeth"
+    MARRY = "Marry"
+
+
+def schedule_meeting(
+    participant: str, date: str, time: str, agenda: Optional[str] = None
+) -> ToolResult:
+    return ToolResult(data=f"Meeting scheduled with {', '.join(participant)} on {date} at {time}.")
+
+
+def schedule_appointment(
+    patient: str, doctor_name: str, date: str, time: str, reason: Optional[str] = None
+) -> ToolResult:
+    return ToolResult(
+        data=f"Appointment scheduled for {patient} with {doctor_name} on {date} at {time}."
+    )
+
+
+def reschedule_appointment(
+    patient: str, doctor_name: str, new_date: str, new_time: str
+) -> ToolResult:
+    return ToolResult(
+        data=f"Appointment for {patient} with {doctor_name} has been rescheduled to {new_date} at {new_time}."
+    )
+
+
+def transfer_shekels(amount: int, from_account: str, to_account: str) -> ToolResult:
+    return ToolResult(
+        data=f"Transferred ₪{amount} from {from_account} to {to_account} successfully."
+    )
+
+
+def transfer_dollars(amount: int, from_account: str, to_account: str) -> ToolResult:
+    return ToolResult(
+        data=f"Transferred ₪{amount} from {from_account} to {to_account} successfully."
+    )


### PR DESCRIPTION
Main changes:
1. Implement the inference of overlapping tools - when a batch of  tools marked as overlapped (directly or indirectly) we evaluate their execution together in one prompt.
2. Add tests with overlapping tools


Signed-off-by: Hadar Yosef <hadar@emcie.co>