### PR TITLE
Change all servers/clients in tests to use random ports + fixes

### DIFF
--- a/tests/api/test_guidelines.py
+++ b/tests/api/test_guidelines.py
@@ -34,7 +34,6 @@ from parlant.core.tools import LocalToolService, ToolId, ToolOverlap
 
 from tests.test_utilities import (
     OPENAPI_SERVER_URL,
-    rng_app,
     run_openapi_server,
     run_service_server,
 )
@@ -897,7 +896,7 @@ async def test_legacy_that_an_http_404_is_thrown_when_associating_with_a_nonexis
 
     tool_name = "nonexistent_tool"
 
-    async with run_openapi_server(rng_app()):
+    async with run_openapi_server():
         source = f"{OPENAPI_SERVER_URL}/openapi.json"
         await service_registry.update_tool_service(
             name="my_openapi_service",

--- a/tests/api/test_services.py
+++ b/tests/api/test_services.py
@@ -77,6 +77,7 @@ async def test_that_openapi_service_is_created_with_url_source(
 ) -> None:
     port = get_random_port(10000, 50000)
     url = f"{OPENAPI_SERVER_BASE_URL}:{port}"
+
     async with run_openapi_server(port=port):
         source = f"{url}/openapi.json"
 
@@ -173,6 +174,7 @@ async def test_that_openapi_service_is_created_and_deleted(
 ) -> None:
     port = get_random_port(10000, 50000)
     url = f"{OPENAPI_SERVER_BASE_URL}:{port}"
+
     async with run_openapi_server(port=port):
         source = f"{url}/openapi.json"
 
@@ -254,6 +256,7 @@ async def test_that_reading_an_existing_openapi_service_returns_its_metadata_and
     service_registry = container[ServiceRegistry]
     port = get_random_port(10000, 50000)
     url = f"{OPENAPI_SERVER_BASE_URL}:{port}"
+
     async with run_openapi_server(port=port):
         source = f"{url}/openapi.json"
         await service_registry.update_tool_service(

--- a/tests/api/test_services.py
+++ b/tests/api/test_services.py
@@ -14,6 +14,7 @@
 
 import json
 import os
+from random import randint
 import tempfile
 from fastapi import status
 import httpx
@@ -23,7 +24,12 @@ from parlant.core.services.tools.plugins import tool
 from parlant.core.tools import ToolResult, ToolContext
 from parlant.core.services.tools.service_registry import ServiceRegistry
 
-from tests.test_utilities import OPENAPI_SERVER_URL, rng_app, run_openapi_server, run_service_server
+from tests.test_utilities import (
+    OPENAPI_SERVER_BASE_URL,
+    rng_app,
+    run_openapi_server,
+    run_service_server,
+)
 
 
 async def test_that_sdk_service_is_created(
@@ -70,15 +76,17 @@ async def test_that_sdk_service_fails_to_create_due_to_url_not_starting_with_htt
 async def test_that_openapi_service_is_created_with_url_source(
     async_client: httpx.AsyncClient,
 ) -> None:
-    async with run_openapi_server(rng_app()):
-        source = f"{OPENAPI_SERVER_URL}/openapi.json"
+    port = randint(10000, 50000)
+    url = f"{OPENAPI_SERVER_BASE_URL}:{port}"
+    async with run_openapi_server(rng_app(port=port), port=port):
+        source = f"{url}/openapi.json"
 
         response = await async_client.put(
             "/services/my_openapi_service",
             json={
                 "kind": "openapi",
                 "openapi": {
-                    "url": OPENAPI_SERVER_URL,
+                    "url": url,
                     "source": source,
                 },
             },
@@ -88,7 +96,7 @@ async def test_that_openapi_service_is_created_with_url_source(
 
         assert content["name"] == "my_openapi_service"
         assert content["kind"] == "openapi"
-        assert content["url"] == OPENAPI_SERVER_URL
+        assert content["url"] == url
 
 
 async def test_that_openapi_service_is_created_with_file_source(
@@ -164,8 +172,10 @@ async def test_that_sdk_service_is_created_and_deleted(
 async def test_that_openapi_service_is_created_and_deleted(
     async_client: httpx.AsyncClient,
 ) -> None:
-    async with run_openapi_server(rng_app()):
-        source = f"{OPENAPI_SERVER_URL}/openapi.json"
+    port = randint(10000, 50000)
+    url = f"{OPENAPI_SERVER_BASE_URL}:{port}"
+    async with run_openapi_server(rng_app(port=port), port=port):
+        source = f"{url}/openapi.json"
 
         _ = (
             await async_client.put(
@@ -173,7 +183,7 @@ async def test_that_openapi_service_is_created_and_deleted(
                 json={
                     "kind": "openapi",
                     "openapi": {
-                        "url": OPENAPI_SERVER_URL,
+                        "url": url,
                         "source": source,
                     },
                 },
@@ -207,14 +217,16 @@ async def test_that_services_can_be_listed(
         .json()
     )
 
-    async with run_openapi_server(rng_app()):
-        source = f"{OPENAPI_SERVER_URL}/openapi.json"
+    port = randint(10000, 50000)
+    url = f"{OPENAPI_SERVER_BASE_URL}:{port}"
+    async with run_openapi_server(rng_app(port=port), port=port):
+        source = f"{url}/openapi.json"
         response = await async_client.put(
             "/services/my_openapi_service",
             json={
                 "kind": "openapi",
                 "openapi": {
-                    "url": OPENAPI_SERVER_URL,
+                    "url": url,
                     "source": source,
                 },
             },
@@ -233,7 +245,7 @@ async def test_that_services_can_be_listed(
     openapi_service = next((p for p in services if p["name"] == "my_openapi_service"), None)
     assert openapi_service is not None
     assert openapi_service["kind"] == "openapi"
-    assert openapi_service["url"] == OPENAPI_SERVER_URL
+    assert openapi_service["url"] == url
 
 
 async def test_that_reading_an_existing_openapi_service_returns_its_metadata_and_tools(
@@ -241,13 +253,14 @@ async def test_that_reading_an_existing_openapi_service_returns_its_metadata_and
     container: Container,
 ) -> None:
     service_registry = container[ServiceRegistry]
-
-    async with run_openapi_server(rng_app()):
-        source = f"{OPENAPI_SERVER_URL}/openapi.json"
+    port = randint(10000, 50000)
+    url = f"{OPENAPI_SERVER_BASE_URL}:{port}"
+    async with run_openapi_server(rng_app(port=port), port=port):
+        source = f"{url}/openapi.json"
         await service_registry.update_tool_service(
             name="my_openapi_service",
             kind="openapi",
-            url=OPENAPI_SERVER_URL,
+            url=url,
             source=source,
         )
 
@@ -257,7 +270,7 @@ async def test_that_reading_an_existing_openapi_service_returns_its_metadata_and
 
     assert service_data["name"] == "my_openapi_service"
     assert service_data["kind"] == "openapi"
-    assert service_data["url"] == OPENAPI_SERVER_URL
+    assert service_data["url"] == url
 
     tools = service_data["tools"]
     assert len(tools) > 0

--- a/tests/api/test_services.py
+++ b/tests/api/test_services.py
@@ -14,7 +14,6 @@
 
 import json
 import os
-from random import randint
 import tempfile
 from fastapi import status
 import httpx
@@ -26,7 +25,7 @@ from parlant.core.services.tools.service_registry import ServiceRegistry
 
 from tests.test_utilities import (
     OPENAPI_SERVER_BASE_URL,
-    rng_app,
+    get_random_port,
     run_openapi_server,
     run_service_server,
 )
@@ -76,9 +75,9 @@ async def test_that_sdk_service_fails_to_create_due_to_url_not_starting_with_htt
 async def test_that_openapi_service_is_created_with_url_source(
     async_client: httpx.AsyncClient,
 ) -> None:
-    port = randint(10000, 50000)
+    port = get_random_port(10000, 50000)
     url = f"{OPENAPI_SERVER_BASE_URL}:{port}"
-    async with run_openapi_server(rng_app(port=port), port=port):
+    async with run_openapi_server(port=port):
         source = f"{url}/openapi.json"
 
         response = await async_client.put(
@@ -172,9 +171,9 @@ async def test_that_sdk_service_is_created_and_deleted(
 async def test_that_openapi_service_is_created_and_deleted(
     async_client: httpx.AsyncClient,
 ) -> None:
-    port = randint(10000, 50000)
+    port = get_random_port(10000, 50000)
     url = f"{OPENAPI_SERVER_BASE_URL}:{port}"
-    async with run_openapi_server(rng_app(port=port), port=port):
+    async with run_openapi_server(port=port):
         source = f"{url}/openapi.json"
 
         _ = (
@@ -217,9 +216,9 @@ async def test_that_services_can_be_listed(
         .json()
     )
 
-    port = randint(10000, 50000)
+    port = get_random_port(10000, 50000)
     url = f"{OPENAPI_SERVER_BASE_URL}:{port}"
-    async with run_openapi_server(rng_app(port=port), port=port):
+    async with run_openapi_server(port=port):
         source = f"{url}/openapi.json"
         response = await async_client.put(
             "/services/my_openapi_service",
@@ -253,9 +252,9 @@ async def test_that_reading_an_existing_openapi_service_returns_its_metadata_and
     container: Container,
 ) -> None:
     service_registry = container[ServiceRegistry]
-    port = randint(10000, 50000)
+    port = get_random_port(10000, 50000)
     url = f"{OPENAPI_SERVER_BASE_URL}:{port}"
-    async with run_openapi_server(rng_app(port=port), port=port):
+    async with run_openapi_server(port=port):
         source = f"{url}/openapi.json"
         await service_registry.update_tool_service(
             name="my_openapi_service",

--- a/tests/core/stable/services/tools/test_openapi.py
+++ b/tests/core/stable/services/tools/test_openapi.py
@@ -35,6 +35,7 @@ from tests.test_utilities import (
 async def test_that_tools_are_exposed_via_an_openapi_server() -> None:
     port = randint(10000, 50000)
     url = f"{OPENAPI_SERVER_BASE_URL}:{port}"
+
     async with run_openapi_server(port=port):
         openapi_json = await get_openapi_spec(url)
 
@@ -49,6 +50,7 @@ async def test_that_tools_are_exposed_via_an_openapi_server() -> None:
 async def test_that_tools_can_be_read_via_an_openapi_server() -> None:
     port = randint(10000, 50000)
     url = f"{OPENAPI_SERVER_BASE_URL}:{port}"
+
     async with run_openapi_server(port=port):
         openapi_json = await get_openapi_spec(url)
 
@@ -96,6 +98,7 @@ async def test_that_a_tool_can_be_called_via_an_openapi_server(
 ) -> None:
     port = randint(10000, 50000)
     url = f"{OPENAPI_SERVER_BASE_URL}:{port}"
+
     async with run_openapi_server(port=port):
         openapi_json = await get_openapi_spec(url)
 
@@ -122,6 +125,7 @@ async def test_that_openapi_client_raises_tool_error_on_argument_mismatch(
 ) -> None:
     port = randint(10000, 50000)
     url = f"{OPENAPI_SERVER_BASE_URL}:{port}"
+
     async with run_openapi_server(port=port):
         openapi_json = await get_openapi_spec(url)
 
@@ -153,6 +157,7 @@ async def test_that_openapi_client_raises_tool_error_on_type_mismatch(
 ) -> None:
     port = randint(10000, 50000)
     url = f"{OPENAPI_SERVER_BASE_URL}:{port}"
+
     async with run_openapi_server(port=port):
         openapi_json = await get_openapi_spec(url)
 

--- a/tests/core/stable/services/tools/test_openapi.py
+++ b/tests/core/stable/services/tools/test_openapi.py
@@ -26,7 +26,6 @@ from tests.test_utilities import (
     one_required_body_param,
     one_required_query_param,
     one_required_query_param_one_required_body_param,
-    rng_app,
     run_openapi_server,
     two_required_body_params,
     two_required_query_params,
@@ -36,7 +35,7 @@ from tests.test_utilities import (
 async def test_that_tools_are_exposed_via_an_openapi_server() -> None:
     port = randint(10000, 50000)
     url = f"{OPENAPI_SERVER_BASE_URL}:{port}"
-    async with run_openapi_server(rng_app(port=port), port=port):
+    async with run_openapi_server(port=port):
         openapi_json = await get_openapi_spec(url)
 
         async with OpenAPIClient(url, openapi_json) as client:
@@ -50,7 +49,7 @@ async def test_that_tools_are_exposed_via_an_openapi_server() -> None:
 async def test_that_tools_can_be_read_via_an_openapi_server() -> None:
     port = randint(10000, 50000)
     url = f"{OPENAPI_SERVER_BASE_URL}:{port}"
-    async with run_openapi_server(rng_app(port=port), port=port):
+    async with run_openapi_server(port=port):
         openapi_json = await get_openapi_spec(url)
 
         async with OpenAPIClient(url, openapi_json) as client:
@@ -97,7 +96,7 @@ async def test_that_a_tool_can_be_called_via_an_openapi_server(
 ) -> None:
     port = randint(10000, 50000)
     url = f"{OPENAPI_SERVER_BASE_URL}:{port}"
-    async with run_openapi_server(rng_app(port=port), port=port):
+    async with run_openapi_server(port=port):
         openapi_json = await get_openapi_spec(url)
 
         async with OpenAPIClient(url, openapi_json) as client:
@@ -123,7 +122,7 @@ async def test_that_openapi_client_raises_tool_error_on_argument_mismatch(
 ) -> None:
     port = randint(10000, 50000)
     url = f"{OPENAPI_SERVER_BASE_URL}:{port}"
-    async with run_openapi_server(rng_app(port=port), port=port):
+    async with run_openapi_server(port=port):
         openapi_json = await get_openapi_spec(url)
 
         async with OpenAPIClient(url, openapi_json) as client:
@@ -154,7 +153,7 @@ async def test_that_openapi_client_raises_tool_error_on_type_mismatch(
 ) -> None:
     port = randint(10000, 50000)
     url = f"{OPENAPI_SERVER_BASE_URL}:{port}"
-    async with run_openapi_server(rng_app(port=port), port=port):
+    async with run_openapi_server(port=port):
         openapi_json = await get_openapi_spec(url)
 
         async with OpenAPIClient(url, openapi_json) as client:

--- a/tests/core/stable/services/tools/test_openapi.py
+++ b/tests/core/stable/services/tools/test_openapi.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from random import randint
 from typing import Any
 from pytest import mark, raises
 
@@ -19,7 +20,7 @@ from parlant.core.tools import ToolContext, ToolError
 from parlant.core.services.tools.openapi import OpenAPIClient
 
 from tests.test_utilities import (
-    OPENAPI_SERVER_URL,
+    OPENAPI_SERVER_BASE_URL,
     TOOLS,
     get_openapi_spec,
     one_required_body_param,
@@ -33,10 +34,12 @@ from tests.test_utilities import (
 
 
 async def test_that_tools_are_exposed_via_an_openapi_server() -> None:
-    async with run_openapi_server(rng_app()):
-        openapi_json = await get_openapi_spec(OPENAPI_SERVER_URL)
+    port = randint(10000, 50000)
+    url = f"{OPENAPI_SERVER_BASE_URL}:{port}"
+    async with run_openapi_server(rng_app(port=port), port=port):
+        openapi_json = await get_openapi_spec(url)
 
-        async with OpenAPIClient(OPENAPI_SERVER_URL, openapi_json) as client:
+        async with OpenAPIClient(url, openapi_json) as client:
             tools = await client.list_tools()
 
             for tool_name, tool in {t.__name__: t for t in TOOLS}.items():
@@ -45,10 +48,12 @@ async def test_that_tools_are_exposed_via_an_openapi_server() -> None:
 
 
 async def test_that_tools_can_be_read_via_an_openapi_server() -> None:
-    async with run_openapi_server(rng_app()):
-        openapi_json = await get_openapi_spec(OPENAPI_SERVER_URL)
+    port = randint(10000, 50000)
+    url = f"{OPENAPI_SERVER_BASE_URL}:{port}"
+    async with run_openapi_server(rng_app(port=port), port=port):
+        openapi_json = await get_openapi_spec(url)
 
-        async with OpenAPIClient(OPENAPI_SERVER_URL, openapi_json) as client:
+        async with OpenAPIClient(url, openapi_json) as client:
             tools = await client.list_tools()
 
             for t in tools:
@@ -90,10 +95,12 @@ async def test_that_a_tool_can_be_called_via_an_openapi_server(
     tool_args: dict[str, Any],
     expected_result: Any,
 ) -> None:
-    async with run_openapi_server(rng_app()):
-        openapi_json = await get_openapi_spec(OPENAPI_SERVER_URL)
+    port = randint(10000, 50000)
+    url = f"{OPENAPI_SERVER_BASE_URL}:{port}"
+    async with run_openapi_server(rng_app(port=port), port=port):
+        openapi_json = await get_openapi_spec(url)
 
-        async with OpenAPIClient(OPENAPI_SERVER_URL, openapi_json) as client:
+        async with OpenAPIClient(url, openapi_json) as client:
             stub_context = ToolContext(
                 agent_id="test-agent",
                 session_id="test_session",
@@ -114,10 +121,12 @@ async def test_that_openapi_client_raises_tool_error_on_argument_mismatch(
     tool_name: str,
     arguments: dict[str, Any],
 ) -> None:
-    async with run_openapi_server(rng_app()):
-        openapi_json = await get_openapi_spec(OPENAPI_SERVER_URL)
+    port = randint(10000, 50000)
+    url = f"{OPENAPI_SERVER_BASE_URL}:{port}"
+    async with run_openapi_server(rng_app(port=port), port=port):
+        openapi_json = await get_openapi_spec(url)
 
-        async with OpenAPIClient(OPENAPI_SERVER_URL, openapi_json) as client:
+        async with OpenAPIClient(url, openapi_json) as client:
             stub_context = ToolContext(
                 agent_id="test-agent",
                 session_id="test_session",
@@ -143,10 +152,12 @@ async def test_that_openapi_client_raises_tool_error_on_type_mismatch(
     tool_name: str,
     arguments: dict[str, Any],
 ) -> None:
-    async with run_openapi_server(rng_app()):
-        openapi_json = await get_openapi_spec(OPENAPI_SERVER_URL)
+    port = randint(10000, 50000)
+    url = f"{OPENAPI_SERVER_BASE_URL}:{port}"
+    async with run_openapi_server(rng_app(port=port), port=port):
+        openapi_json = await get_openapi_spec(url)
 
-        async with OpenAPIClient(OPENAPI_SERVER_URL, openapi_json) as client:
+        async with OpenAPIClient(url, openapi_json) as client:
             stub_context = ToolContext(
                 agent_id="test-agent",
                 session_id="test_session",

--- a/tests/e2e/test_client_cli_via_api.py
+++ b/tests/e2e/test_client_cli_via_api.py
@@ -18,7 +18,6 @@ import os
 import tempfile
 from typing import Any, Optional
 import httpx
-import pytest
 
 from parlant.core.services.tools.plugins import tool
 from parlant.core.tools import ToolResult, ToolContext
@@ -543,77 +542,6 @@ async def test_that_a_guideline_can_be_deleted(
         assert len(guidelines) == 0
 
 
-<<<<<<< HEAD
-=======
-async def test_that_a_connection_can_be_deleted(
-    context: ContextOfTest,
-) -> None:
-    with run_server(context, randomize_port=True):
-        async with httpx.AsyncClient(
-            follow_redirects=True,
-            timeout=httpx.Timeout(30),
-        ) as client:
-            guidelines_response = await client.post(
-                f"{context.api.server_address}/guidelines/",
-                json={
-                    "condition": "the customer greets you",
-                    "action": "greet them back with 'Hello'",
-                },
-            )
-            guidelines_response.raise_for_status()
-
-            first = guidelines_response.json()
-
-            guidelines_response = await client.post(
-                f"{context.api.server_address}/guidelines/",
-                json={
-                    "condition": "greeting the customer",
-                    "action": "ask for his health condition",
-                },
-            )
-            guidelines_response.raise_for_status()
-
-            second = guidelines_response.json()
-
-            first = first["id"]
-            second = second["id"]
-
-            connection_response = await client.patch(
-                f"{context.api.server_address}/guidelines/{first}",
-                json={
-                    "connections": {
-                        "add": [
-                            {
-                                "source": first,
-                                "target": second,
-                            }
-                        ],
-                    },
-                },
-            )
-            connection_response.raise_for_status()
-
-        process = await run_cli(
-            "guideline",
-            "disentail",
-            "--source",
-            first,
-            "--target",
-            second,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-            address=context.api.server_address,
-        )
-        stdout_view, stderr_view = await process.communicate()
-        output_view = stdout_view.decode() + stderr_view.decode()
-        assert "Traceback (most recent call last):" not in output_view
-        assert process.returncode == os.EX_OK
-
-        guideline = await context.api.read_guideline(guideline_id=first)
-        assert len(guideline["connections"]) == 0
-
-
->>>>>>> 74af4cbd (Added the ability to randomize server port and pass it to the client. Changed test_client_cli_via_api tests to use it.)
 async def test_that_a_tool_can_be_enabled_for_a_guideline(
     context: ContextOfTest,
 ) -> None:
@@ -1585,30 +1513,6 @@ async def test_that_tags_can_be_listed(context: ContextOfTest) -> None:
         assert "SecondTag" in output
 
 
-<<<<<<< HEAD
-=======
-async def test_that_a_tag_can_be_viewed(context: ContextOfTest) -> None:
-    with run_server(context, randomize_port=True):
-        tag_id = (await context.api.create_tag("TestViewTag"))["id"]
-
-        process = await run_cli(
-            "tag",
-            "view",
-            "--id",
-            tag_id,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-            address=context.api.server_address,
-        )
-        stdout, stderr = await process.communicate()
-        output = stdout.decode() + stderr.decode()
-        assert process.returncode == os.EX_OK
-
-        assert "TestViewTag" in output
-        assert tag_id in output
-
-
->>>>>>> 74af4cbd (Added the ability to randomize server port and pass it to the client. Changed test_client_cli_via_api tests to use it.)
 async def test_that_a_tag_can_be_updated(context: ContextOfTest) -> None:
     with run_server(context, randomize_port=True):
         tag_id = (await context.api.create_tag("TestViewTag"))["id"]

--- a/tests/e2e/test_client_cli_via_api.py
+++ b/tests/e2e/test_client_cli_via_api.py
@@ -573,7 +573,7 @@ async def test_that_a_tool_can_be_enabled_for_a_guideline(
                     service_kind,
                     "--url",
                     server.url,
-                    context.api.server_address,
+                    address=context.api.server_address,
                 )
                 == os.EX_OK
             )
@@ -588,7 +588,7 @@ async def test_that_a_tool_can_be_enabled_for_a_guideline(
                     service_name,
                     "--tool",
                     tool_name,
-                    context.api.server_address,
+                    address=context.api.server_address,
                 )
                 == os.EX_OK
             )
@@ -631,7 +631,7 @@ async def test_that_a_tool_can_be_disabled_for_a_guideline(
                     service_kind,
                     "--url",
                     server.url,
-                    context.api.server_address,
+                    address=context.api.server_address,
                 )
                 == os.EX_OK
             )
@@ -648,7 +648,7 @@ async def test_that_a_tool_can_be_disabled_for_a_guideline(
                     service_name,
                     "--tool",
                     tool_name,
-                    context.api.server_address,
+                    address=context.api.server_address,
                 )
                 == os.EX_OK
             )
@@ -717,7 +717,7 @@ async def test_that_a_variable_can_be_added(
                     service_kind,
                     "--url",
                     server.url,
-                    context.api.server_address,
+                    address=context.api.server_address,
                 )
                 == os.EX_OK
             )
@@ -736,7 +736,7 @@ async def test_that_a_variable_can_be_added(
                     tool_name,
                     "--freshness-rules",
                     freshness_rules,
-                    context.api.server_address,
+                    address=context.api.server_address,
                 )
                 == os.EX_OK
             )
@@ -795,7 +795,7 @@ async def test_that_a_variable_can_be_updated(
                     service_kind,
                     "--url",
                     server.url,
-                    context.api.server_address,
+                    address=context.api.server_address,
                 )
                 == os.EX_OK
             )
@@ -814,7 +814,7 @@ async def test_that_a_variable_can_be_updated(
                     tool_name,
                     "--freshness-rules",
                     freshness_rules,
-                    context.api.server_address,
+                    address=context.api.server_address,
                 )
                 == os.EX_OK
             )
@@ -1742,6 +1742,7 @@ async def test_that_a_guideline_can_be_created_with_tool_id(
                     condition,
                     "--tool-id",
                     tool_id,
+                    address=context.api.server_address,
                 )
             ) == os.EX_OK
 

--- a/tests/e2e/test_client_cli_via_api.py
+++ b/tests/e2e/test_client_cli_via_api.py
@@ -1082,6 +1082,7 @@ async def test_that_an_openapi_service_can_be_added_via_file(
     with run_server(context):
         port = randint(10000, 50000)
         url = f"{OPENAPI_SERVER_BASE_URL}:{port}"
+
         async with run_openapi_server(port=port):
             async with httpx.AsyncClient() as client:
                 response = await client.get(f"{url}/openapi.json")
@@ -1128,6 +1129,7 @@ async def test_that_an_openapi_service_can_be_added_via_url(
     with run_server(context):
         port = randint(10000, 50000)
         url = f"{OPENAPI_SERVER_BASE_URL}:{port}"
+
         async with run_openapi_server(port=port):
             source = url + "/openapi.json"
 

--- a/tests/e2e/test_client_cli_via_api.py
+++ b/tests/e2e/test_client_cli_via_api.py
@@ -31,7 +31,6 @@ from tests.e2e.test_utilities import (
 from tests.test_utilities import (
     OPENAPI_SERVER_BASE_URL,
     SERVER_ADDRESS,
-    rng_app,
     run_openapi_server,
     run_service_server,
 )
@@ -72,7 +71,7 @@ async def test_that_an_agent_can_be_added(context: ContextOfTest) -> None:
     name = "TestAgent"
     description = "This is a test agent"
 
-    with run_server(context, randomize_port=True):
+    with run_server(context):
         process = await run_cli(
             "agent",
             "create",
@@ -126,7 +125,7 @@ async def test_that_an_agent_can_be_updated(
     new_description = "Updated description"
     new_max_engine_iterations = 5
 
-    with run_server(context, randomize_port=True):
+    with run_server(context):
         process = await run_cli(
             "agent",
             "update",
@@ -159,7 +158,7 @@ async def test_that_an_agent_can_be_deleted(
 ) -> None:
     name = "Test Agent"
 
-    with run_server(context, randomize_port=True):
+    with run_server(context):
         agent = await context.api.create_agent(name=name)
 
         assert (
@@ -182,7 +181,7 @@ async def test_that_sessions_can_be_listed(
     second_title = "Second Title"
     third_title = "Third Title"
 
-    with run_server(context, randomize_port=True):
+    with run_server(context):
         agent_id = (await context.api.get_first_agent())["id"]
         _ = await context.api.create_session(
             agent_id=agent_id, customer_id=first_customer, title=first_title
@@ -232,7 +231,7 @@ async def test_that_session_can_be_updated(
 ) -> None:
     session_title = "Old Title"
 
-    with run_server(context, randomize_port=True):
+    with run_server(context):
         agent_id = (await context.api.get_first_agent())["id"]
         session_id = (await context.api.create_session(agent_id=agent_id, title=session_title))[
             "id"
@@ -262,7 +261,7 @@ async def test_that_a_term_can_be_created_with_synonyms(
     description = "when and then statements"
     synonyms = "rule, principle"
 
-    with run_server(context, randomize_port=True):
+    with run_server(context):
         process = await run_cli(
             "glossary",
             "create",
@@ -288,7 +287,7 @@ async def test_that_a_term_can_be_created_without_synonyms(
     term_name = "guideline_no_synonyms"
     description = "simple guideline with no synonyms"
 
-    with run_server(context, randomize_port=True):
+    with run_server(context):
         process = await run_cli(
             "glossary",
             "create",
@@ -322,7 +321,7 @@ async def test_that_a_term_can_be_updated(
     new_description = "then and when statements "
     new_synonyms = "instructions"
 
-    with run_server(context, randomize_port=True):
+    with run_server(context):
         term_to_update = await context.api.create_term(name, description, synonyms)
 
         process = await run_cli(
@@ -358,7 +357,7 @@ async def test_that_a_term_can_be_deleted(
     description = "to be deleted"
     synonyms = "rule, principle"
 
-    with run_server(context, randomize_port=True):
+    with run_server(context):
         term = await context.api.create_term(name, description, synonyms)
 
         process = await run_cli(
@@ -385,7 +384,7 @@ async def test_that_a_guideline_can_be_added(
     condition = "the customer greets you"
     action = "greet them back with 'Hello'"
 
-    with run_server(context, randomize_port=True):
+    with run_server(context):
         process = await run_cli(
             "guideline",
             "create",
@@ -413,7 +412,7 @@ async def test_that_a_guideline_can_be_updated(
     initial_action = "offer assistance"
     updated_action = "provide detailed support information"
 
-    with run_server(context, randomize_port=True):
+    with run_server(context):
         guideline = await context.api.create_guideline(condition=condition, action=initial_action)
 
         process = await run_cli(
@@ -451,7 +450,7 @@ async def test_that_guidelines_can_be_entailed(
     condition2 = "customer ask about a certain subject"
     action2 = "offer detailed explanation"
 
-    with run_server(context, randomize_port=True):
+    with run_server(context):
         process = await run_cli(
             "guideline",
             "create",
@@ -522,7 +521,7 @@ async def test_that_guidelines_can_be_entailed(
 async def test_that_a_guideline_can_be_deleted(
     context: ContextOfTest,
 ) -> None:
-    with run_server(context, randomize_port=True):
+    with run_server(context):
         guideline = await context.api.create_guideline(
             condition="the customer greets you", action="greet them back with 'Hello'"
         )
@@ -548,7 +547,7 @@ async def test_that_a_guideline_can_be_deleted(
 async def test_that_a_tool_can_be_enabled_for_a_guideline(
     context: ContextOfTest,
 ) -> None:
-    with run_server(context, randomize_port=True):
+    with run_server(context):
         guideline = await context.api.create_guideline(
             condition="the customer wants to get meeting details",
             action="get meeting event information",
@@ -606,7 +605,7 @@ async def test_that_a_tool_can_be_enabled_for_a_guideline(
 async def test_that_a_tool_can_be_disabled_for_a_guideline(
     context: ContextOfTest,
 ) -> None:
-    with run_server(context, randomize_port=True):
+    with run_server(context):
         guideline = await context.api.create_guideline(
             condition="the customer wants to get meeting details",
             action="get meeting event information",
@@ -668,7 +667,7 @@ async def test_that_variables_can_be_listed(
     name2 = "VAR2"
     description2 = "SECOND"
 
-    with run_server(context, randomize_port=True):
+    with run_server(context):
         _ = await context.api.create_context_variable(name1, description1)
         _ = await context.api.create_context_variable(name2, description2)
 
@@ -696,7 +695,7 @@ async def test_that_a_variable_can_be_added(
     name = "test_variable_cli"
     description = "Variable added via CLI"
 
-    with run_server(context, randomize_port=True):
+    with run_server(context):
         service_name = "local_service"
         tool_name = "fetch_event_data"
         service_kind = "sdk"
@@ -772,7 +771,7 @@ async def test_that_a_variable_can_be_updated(
     tool_name = "fetch_account_balance"
     freshness_rules = "0 0,6,12,18 * * *"
 
-    with run_server(context, randomize_port=True):
+    with run_server(context):
         variable = await context.api.create_context_variable(name, description)
 
         service_name = "local_service"
@@ -836,7 +835,7 @@ async def test_that_a_variable_can_be_deleted(
     name = "test_variable_to_delete"
     description = "Variable to be deleted via CLI"
 
-    with run_server(context, randomize_port=True):
+    with run_server(context):
         variable = await context.api.create_context_variable(name, description)
 
         process = await run_cli(
@@ -865,7 +864,7 @@ async def test_that_a_variable_value_can_be_set_with_json(
     key = "test_key"
     data: dict[str, Any] = {"test": "data", "type": 27}
 
-    with run_server(context, randomize_port=True):
+    with run_server(context):
         variable = await context.api.create_context_variable(variable_name, variable_description)
 
         process = await run_cli(
@@ -898,7 +897,7 @@ async def test_that_a_variable_value_can_be_set_with_string(
     key = "test_key"
     data = "test_string"
 
-    with run_server(context, randomize_port=True):
+    with run_server(context):
         variable = await context.api.create_context_variable(variable_name, variable_description)
 
         process = await run_cli(
@@ -935,7 +934,7 @@ async def test_that_a_variables_values_can_be_retrieved(
         "key3": "data3",
     }
 
-    with run_server(context, randomize_port=True):
+    with run_server(context):
         variable = await context.api.create_context_variable(variable_name, variable_description)
 
         for key, data in values.items():
@@ -989,7 +988,7 @@ async def test_that_a_variable_value_can_be_deleted(
     key = "DEFAULT"
     value = "test-value"
 
-    with run_server(context, randomize_port=True):
+    with run_server(context):
         variable = await context.api.create_context_variable(name, description="")
         _ = await context.api.update_context_variable_value(
             variable_id=variable["id"],
@@ -1017,7 +1016,7 @@ async def test_that_a_variable_value_can_be_deleted(
 async def test_that_a_message_can_be_inspected(
     context: ContextOfTest,
 ) -> None:
-    with run_server(context, randomize_port=True):
+    with run_server(context):
         guideline = await context.api.create_guideline(
             condition="the customer talks about cows",
             action="address the customer by his first name and say you like Pepsi",
@@ -1080,10 +1079,10 @@ async def test_that_an_openapi_service_can_be_added_via_file(
     service_name = "test_openapi_service"
     service_kind = "openapi"
 
-    with run_server(context, randomize_port=True):
+    with run_server(context):
         port = randint(10000, 50000)
         url = f"{OPENAPI_SERVER_BASE_URL}:{port}"
-        async with run_openapi_server(rng_app(port=port), port=port):
+        async with run_openapi_server(port=port):
             async with httpx.AsyncClient() as client:
                 response = await client.get(f"{url}/openapi.json")
                 response.raise_for_status()
@@ -1126,10 +1125,10 @@ async def test_that_an_openapi_service_can_be_added_via_url(
     service_name = "test_openapi_service_via_url"
     service_kind = "openapi"
 
-    with run_server(context, randomize_port=True):
+    with run_server(context):
         port = randint(10000, 50000)
         url = f"{OPENAPI_SERVER_BASE_URL}:{port}"
-        async with run_openapi_server(rng_app(port=port), port=port):
+        async with run_openapi_server(port=port):
             source = url + "/openapi.json"
 
             assert (
@@ -1172,7 +1171,7 @@ async def test_that_a_sdk_service_can_be_added(
         and displayed such that the customer can easily read and understand it."""
         return ToolResult(param * 2)
 
-    with run_server(context, randomize_port=True):
+    with run_server(context):
         async with run_service_server([sample_tool]) as server:
             assert (
                 await run_cli_and_get_exit_status(
@@ -1203,10 +1202,10 @@ async def test_that_a_service_can_be_deleted(
 ) -> None:
     service_name = "test_service_to_delete"
 
-    with run_server(context, randomize_port=True):
+    with run_server(context):
         port = randint(10000, 50000)
         url = f"{OPENAPI_SERVER_BASE_URL}:{port}"
-        async with run_openapi_server(rng_app(port=port), port=port):
+        async with run_openapi_server(port=port):
             await context.api.create_openapi_service(service_name, url)
 
         process = await run_cli(
@@ -1236,10 +1235,10 @@ async def test_that_services_can_be_listed(
     service_name_1 = "test_openapi_service_1"
     service_name_2 = "test_openapi_service_2"
 
-    with run_server(context, randomize_port=True):
+    with run_server(context):
         port = randint(10000, 50000)
         url = f"{OPENAPI_SERVER_BASE_URL}:{port}"
-        async with run_openapi_server(rng_app(port=port), port=port):
+        async with run_openapi_server(port=port):
             await context.api.create_openapi_service(service_name_1, url)
             await context.api.create_openapi_service(service_name_2, url)
 
@@ -1267,8 +1266,8 @@ async def test_that_a_service_can_be_viewed(
     service_name = "test_service_view"
     service_url = f"{OPENAPI_SERVER_BASE_URL}:{port}"
 
-    with run_server(context, randomize_port=True):
-        async with run_openapi_server(rng_app(port=port), port=port):
+    with run_server(context):
+        async with run_openapi_server(port=port):
             await context.api.create_openapi_service(service_name, service_url)
 
         process = await run_cli(
@@ -1298,7 +1297,7 @@ async def test_that_a_service_can_be_viewed(
 
 
 async def test_that_customers_can_be_listed(context: ContextOfTest) -> None:
-    with run_server(context, randomize_port=True):
+    with run_server(context):
         await context.api.create_customer(name="First Customer")
         await context.api.create_customer(name="Second Customer")
 
@@ -1318,7 +1317,7 @@ async def test_that_customers_can_be_listed(context: ContextOfTest) -> None:
 
 
 async def test_that_a_customer_can_be_added(context: ContextOfTest) -> None:
-    with run_server(context, randomize_port=True):
+    with run_server(context):
         assert (
             await run_cli_and_get_exit_status(
                 "customer",
@@ -1335,7 +1334,7 @@ async def test_that_a_customer_can_be_added(context: ContextOfTest) -> None:
 
 
 async def test_that_a_customer_can_be_updated(context: ContextOfTest) -> None:
-    with run_server(context, randomize_port=True):
+    with run_server(context):
         customer = await context.api.create_customer("TestCustomer")
 
         assert (
@@ -1356,7 +1355,7 @@ async def test_that_a_customer_can_be_updated(context: ContextOfTest) -> None:
 
 
 async def test_that_a_customer_can_be_viewed(context: ContextOfTest) -> None:
-    with run_server(context, randomize_port=True):
+    with run_server(context):
         customer_id = (await context.api.create_customer(name="TestCustomer"))["id"]
 
         process = await run_cli(
@@ -1377,7 +1376,7 @@ async def test_that_a_customer_can_be_viewed(context: ContextOfTest) -> None:
 
 
 async def test_that_a_customer_can_be_deleted(context: ContextOfTest) -> None:
-    with run_server(context, randomize_port=True):
+    with run_server(context):
         customer_id = (await context.api.create_customer(name="TestCustomer"))["id"]
 
         assert (
@@ -1396,7 +1395,7 @@ async def test_that_a_customer_can_be_deleted(context: ContextOfTest) -> None:
 
 
 async def test_that_a_customer_extra_can_be_added(context: ContextOfTest) -> None:
-    with run_server(context, randomize_port=True):
+    with run_server(context):
         customer_id = (await context.api.create_customer(name="TestCustomer"))["id"]
 
         assert (
@@ -1419,7 +1418,7 @@ async def test_that_a_customer_extra_can_be_added(context: ContextOfTest) -> Non
 
 
 async def test_that_a_customer_extra_can_be_deleted(context: ContextOfTest) -> None:
-    with run_server(context, randomize_port=True):
+    with run_server(context):
         customer_id = (
             await context.api.create_customer(name="TestCustomer", extra={"key1": "value1"})
         )["id"]
@@ -1442,7 +1441,7 @@ async def test_that_a_customer_extra_can_be_deleted(context: ContextOfTest) -> N
 
 
 async def test_that_a_customer_tag_can_be_added(context: ContextOfTest) -> None:
-    with run_server(context, randomize_port=True):
+    with run_server(context):
         customer_id = (await context.api.create_customer(name="TestCustomer"))["id"]
         tag_id = (await context.api.create_tag(name="TestTag"))["id"]
 
@@ -1464,7 +1463,7 @@ async def test_that_a_customer_tag_can_be_added(context: ContextOfTest) -> None:
 
 
 async def test_that_a_customer_tag_can_be_deleted(context: ContextOfTest) -> None:
-    with run_server(context, randomize_port=True):
+    with run_server(context):
         customer_id = (await context.api.create_customer(name="TestCustomer"))["id"]
         tag_id = (await context.api.create_tag(name="TestTag"))["id"]
         await context.api.add_customer_tag(customer_id, tag_id)
@@ -1487,7 +1486,7 @@ async def test_that_a_customer_tag_can_be_deleted(context: ContextOfTest) -> Non
 
 
 async def test_that_a_tag_can_be_added(context: ContextOfTest) -> None:
-    with run_server(context, randomize_port=True):
+    with run_server(context):
         tag_name = "TestTag"
 
         assert (
@@ -1506,7 +1505,7 @@ async def test_that_a_tag_can_be_added(context: ContextOfTest) -> None:
 
 
 async def test_that_tags_can_be_listed(context: ContextOfTest) -> None:
-    with run_server(context, randomize_port=True):
+    with run_server(context):
         await context.api.create_tag("FirstTag")
         await context.api.create_tag("SecondTag")
 
@@ -1526,7 +1525,7 @@ async def test_that_tags_can_be_listed(context: ContextOfTest) -> None:
 
 
 async def test_that_a_tag_can_be_updated(context: ContextOfTest) -> None:
-    with run_server(context, randomize_port=True):
+    with run_server(context):
         tag_id = (await context.api.create_tag("TestViewTag"))["id"]
         new_name = "UpdatedTagName"
 
@@ -1548,7 +1547,7 @@ async def test_that_a_tag_can_be_updated(context: ContextOfTest) -> None:
 
 
 async def test_that_utterances_can_be_initialized(context: ContextOfTest) -> None:
-    with run_server(context, randomize_port=True):
+    with run_server(context):
         tmp_file = tempfile.NamedTemporaryFile(delete=False)
         tmp_file_path = tmp_file.name
         tmp_file.close()
@@ -1573,7 +1572,7 @@ async def test_that_utterances_can_be_initialized(context: ContextOfTest) -> Non
 
 
 async def test_that_utterances_can_be_loaded(context: ContextOfTest) -> None:
-    with run_server(context, randomize_port=True):
+    with run_server(context):
         await context.api.create_tag("testTag1")
         await context.api.create_tag("testTag2")
 
@@ -1631,7 +1630,7 @@ async def test_that_utterances_can_be_loaded(context: ContextOfTest) -> None:
 
 
 async def test_that_guidelines_can_be_enabled(context: ContextOfTest) -> None:
-    with run_server(context, randomize_port=True):
+    with run_server(context):
         first_guideline = await context.api.create_guideline(
             condition="the customer greets you",
             action="greet them back with 'Hello'",
@@ -1675,7 +1674,7 @@ async def test_that_guidelines_can_be_enabled(context: ContextOfTest) -> None:
 
 
 async def test_that_guidelines_can_be_disabled(context: ContextOfTest) -> None:
-    with run_server(context, randomize_port=True):
+    with run_server(context):
         first_guideline = await context.api.create_guideline(
             condition="the customer greets you",
             action="greet them back with 'Hello'",
@@ -1712,9 +1711,6 @@ async def test_that_a_guideline_can_be_created_with_tool_id(
     tool_id = "parameter_types:give_number_types"
 
     with run_server(context):
-        while not is_server_responsive(SERVER_PORT):
-            pass
-
         service_name = "parameter_types"
         tool_name = "give_number_types"
 

--- a/tests/e2e/test_server_cli.py
+++ b/tests/e2e/test_server_cli.py
@@ -169,9 +169,7 @@ async def test_that_glossary_terms_load_after_server_restart(context: ContextOfT
 
 
 async def test_that_server_starts_with_single_module(context: ContextOfTest) -> None:
-    with run_server(
-        context, randomize_port=True, extra_args=["--module", "tests.modules.tech_store"]
-    ):
+    with run_server(context, extra_args=["--module", "tests.modules.tech_store"]):
         await asyncio.sleep(EXTENDED_AMOUNT_OF_TIME)
 
         agent = await context.api.get_first_agent()

--- a/tests/e2e/test_server_cli.py
+++ b/tests/e2e/test_server_cli.py
@@ -33,7 +33,7 @@ EXTENDED_AMOUNT_OF_TIME = 10
 async def test_that_the_server_starts_and_shuts_down_cleanly_on_interrupt(
     context: ContextOfTest,
 ) -> None:
-    with run_server(context) as server_process:
+    with run_server(context, randomize_port=True) as server_process:
         await asyncio.sleep(EXTENDED_AMOUNT_OF_TIME)
         server_process.send_signal(signal.SIGINT)
         server_process.wait(timeout=REASONABLE_AMOUNT_OF_TIME)
@@ -43,7 +43,7 @@ async def test_that_the_server_starts_and_shuts_down_cleanly_on_interrupt(
 async def test_that_the_server_starts_and_generates_a_message(
     context: ContextOfTest,
 ) -> None:
-    with run_server(context):
+    with run_server(context, randomize_port=True):
         await asyncio.sleep(EXTENDED_AMOUNT_OF_TIME)
 
         agent = await context.api.get_first_agent()
@@ -65,7 +65,7 @@ async def test_that_the_server_starts_and_generates_a_message(
 async def test_that_guidelines_are_loaded_after_server_restarts(
     context: ContextOfTest,
 ) -> None:
-    with run_server(context) as server_process:
+    with run_server(context, randomize_port=True) as server_process:
         await asyncio.sleep(EXTENDED_AMOUNT_OF_TIME)
 
         first = await context.api.create_guideline(
@@ -82,7 +82,7 @@ async def test_that_guidelines_are_loaded_after_server_restarts(
         server_process.wait(timeout=EXTENDED_AMOUNT_OF_TIME)
         assert server_process.returncode == os.EX_OK
 
-    with run_server(context) as server_process:
+    with run_server(context, randomize_port=True) as server_process:
         await asyncio.sleep(EXTENDED_AMOUNT_OF_TIME)
 
         guidelines = await context.api.list_guidelines()
@@ -102,7 +102,7 @@ async def test_that_context_variable_values_load_after_server_restart(
     key = "test_key"
     data = "test_value"
 
-    with run_server(context) as server_process:
+    with run_server(context, randomize_port=True) as server_process:
         await asyncio.sleep(EXTENDED_AMOUNT_OF_TIME)
 
         variable = await context.api.create_context_variable(variable_name, variable_description)
@@ -112,7 +112,7 @@ async def test_that_context_variable_values_load_after_server_restart(
         server_process.wait(timeout=EXTENDED_AMOUNT_OF_TIME)
         assert server_process.returncode == os.EX_OK
 
-    with run_server(context):
+    with run_server(context, randomize_port=True):
         await asyncio.sleep(EXTENDED_AMOUNT_OF_TIME)
 
         variable_value = await context.api.read_context_variable_value(variable["id"], key)
@@ -128,7 +128,7 @@ async def test_that_services_load_after_server_restart(context: ContextOfTest) -
     def sample_tool(context: ToolContext, param: int) -> ToolResult:
         return ToolResult(param * 2)
 
-    with run_server(context) as server_process:
+    with run_server(context, randomize_port=True) as server_process:
         await asyncio.sleep(EXTENDED_AMOUNT_OF_TIME)
 
         async with run_service_server([sample_tool]) as server:
@@ -138,7 +138,7 @@ async def test_that_services_load_after_server_restart(context: ContextOfTest) -
         server_process.wait(timeout=EXTENDED_AMOUNT_OF_TIME)
         assert server_process.returncode == os.EX_OK
 
-    with run_server(context):
+    with run_server(context, randomize_port=True):
         await asyncio.sleep(EXTENDED_AMOUNT_OF_TIME)
 
         services = await context.api.list_services()
@@ -150,7 +150,7 @@ async def test_that_glossary_terms_load_after_server_restart(context: ContextOfT
     term_name = "test_term"
     description = "Term added before server restart"
 
-    with run_server(context) as server_process:
+    with run_server(context, randomize_port=True) as server_process:
         await asyncio.sleep(EXTENDED_AMOUNT_OF_TIME)
 
         await context.api.create_term(term_name, description)
@@ -159,7 +159,7 @@ async def test_that_glossary_terms_load_after_server_restart(context: ContextOfT
         server_process.wait(timeout=REASONABLE_AMOUNT_OF_TIME)
         assert server_process.returncode == os.EX_OK
 
-    with run_server(context):
+    with run_server(context, randomize_port=True):
         await asyncio.sleep(EXTENDED_AMOUNT_OF_TIME)
 
         terms = await context.api.list_terms()
@@ -169,7 +169,9 @@ async def test_that_glossary_terms_load_after_server_restart(context: ContextOfT
 
 
 async def test_that_server_starts_with_single_module(context: ContextOfTest) -> None:
-    with run_server(context, extra_args=["--module", "tests.modules.tech_store"]):
+    with run_server(
+        context, randomize_port=True, extra_args=["--module", "tests.modules.tech_store"]
+    ):
         await asyncio.sleep(EXTENDED_AMOUNT_OF_TIME)
 
         agent = await context.api.get_first_agent()

--- a/tests/e2e/test_server_cli.py
+++ b/tests/e2e/test_server_cli.py
@@ -33,7 +33,7 @@ EXTENDED_AMOUNT_OF_TIME = 10
 async def test_that_the_server_starts_and_shuts_down_cleanly_on_interrupt(
     context: ContextOfTest,
 ) -> None:
-    with run_server(context, randomize_port=True) as server_process:
+    with run_server(context) as server_process:
         await asyncio.sleep(EXTENDED_AMOUNT_OF_TIME)
         server_process.send_signal(signal.SIGINT)
         server_process.wait(timeout=REASONABLE_AMOUNT_OF_TIME)
@@ -43,7 +43,7 @@ async def test_that_the_server_starts_and_shuts_down_cleanly_on_interrupt(
 async def test_that_the_server_starts_and_generates_a_message(
     context: ContextOfTest,
 ) -> None:
-    with run_server(context, randomize_port=True):
+    with run_server(context):
         await asyncio.sleep(EXTENDED_AMOUNT_OF_TIME)
 
         agent = await context.api.get_first_agent()
@@ -65,7 +65,7 @@ async def test_that_the_server_starts_and_generates_a_message(
 async def test_that_guidelines_are_loaded_after_server_restarts(
     context: ContextOfTest,
 ) -> None:
-    with run_server(context, randomize_port=True) as server_process:
+    with run_server(context) as server_process:
         await asyncio.sleep(EXTENDED_AMOUNT_OF_TIME)
 
         first = await context.api.create_guideline(
@@ -82,7 +82,7 @@ async def test_that_guidelines_are_loaded_after_server_restarts(
         server_process.wait(timeout=EXTENDED_AMOUNT_OF_TIME)
         assert server_process.returncode == os.EX_OK
 
-    with run_server(context, randomize_port=True) as server_process:
+    with run_server(context) as server_process:
         await asyncio.sleep(EXTENDED_AMOUNT_OF_TIME)
 
         guidelines = await context.api.list_guidelines()
@@ -102,7 +102,7 @@ async def test_that_context_variable_values_load_after_server_restart(
     key = "test_key"
     data = "test_value"
 
-    with run_server(context, randomize_port=True) as server_process:
+    with run_server(context) as server_process:
         await asyncio.sleep(EXTENDED_AMOUNT_OF_TIME)
 
         variable = await context.api.create_context_variable(variable_name, variable_description)
@@ -112,7 +112,7 @@ async def test_that_context_variable_values_load_after_server_restart(
         server_process.wait(timeout=EXTENDED_AMOUNT_OF_TIME)
         assert server_process.returncode == os.EX_OK
 
-    with run_server(context, randomize_port=True):
+    with run_server(context):
         await asyncio.sleep(EXTENDED_AMOUNT_OF_TIME)
 
         variable_value = await context.api.read_context_variable_value(variable["id"], key)
@@ -128,7 +128,7 @@ async def test_that_services_load_after_server_restart(context: ContextOfTest) -
     def sample_tool(context: ToolContext, param: int) -> ToolResult:
         return ToolResult(param * 2)
 
-    with run_server(context, randomize_port=True) as server_process:
+    with run_server(context) as server_process:
         await asyncio.sleep(EXTENDED_AMOUNT_OF_TIME)
 
         async with run_service_server([sample_tool]) as server:
@@ -138,7 +138,7 @@ async def test_that_services_load_after_server_restart(context: ContextOfTest) -
         server_process.wait(timeout=EXTENDED_AMOUNT_OF_TIME)
         assert server_process.returncode == os.EX_OK
 
-    with run_server(context, randomize_port=True):
+    with run_server(context):
         await asyncio.sleep(EXTENDED_AMOUNT_OF_TIME)
 
         services = await context.api.list_services()
@@ -150,7 +150,7 @@ async def test_that_glossary_terms_load_after_server_restart(context: ContextOfT
     term_name = "test_term"
     description = "Term added before server restart"
 
-    with run_server(context, randomize_port=True) as server_process:
+    with run_server(context) as server_process:
         await asyncio.sleep(EXTENDED_AMOUNT_OF_TIME)
 
         await context.api.create_term(term_name, description)
@@ -159,7 +159,7 @@ async def test_that_glossary_terms_load_after_server_restart(context: ContextOfT
         server_process.wait(timeout=REASONABLE_AMOUNT_OF_TIME)
         assert server_process.returncode == os.EX_OK
 
-    with run_server(context, randomize_port=True):
+    with run_server(context):
         await asyncio.sleep(EXTENDED_AMOUNT_OF_TIME)
 
         terms = await context.api.list_terms()

--- a/tests/e2e/test_utilities.py
+++ b/tests/e2e/test_utilities.py
@@ -64,7 +64,9 @@ class ContextOfTest:
 
 
 def _wait_for_port_ready(
-    server_address: str, max_attempts: int = 30, initial_delay: float = 0.1
+    server_address: str,
+    max_attempts: int = 30,
+    initial_delay: float = 0.1,
 ) -> None:
     """Wait for the server port to be ready to accept connections."""
     # Parse the server address to get host and port

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -680,7 +680,10 @@ async def run_openapi_server(app: Optional[FastAPI] = None, port: int = 0) -> As
     task = asyncio.create_task(server.serve())
 
     try:
-        await asyncio.sleep(0.1)
+        while not server.started:
+            await asyncio.sleep(0.01)
+
+        await asyncio.sleep(0.05)
         yield
     finally:
         server.should_exit = True

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -555,10 +555,10 @@ async def create_schematic_generation_result_collection(
 
 @asynccontextmanager
 async def run_service_server(
-    tools: list[ToolEntry], plugin_data: Mapping[str, Any] = {}, port: int = 0
+    tools: list[ToolEntry],
+    plugin_data: Mapping[str, Any] = {},
 ) -> AsyncIterator[PluginServer]:
-    if port == 0:
-        port = get_random_port(50001, 65535)
+    port = get_random_port(50001, 65535)
     async with PluginServer(
         tools=tools,
         port=port,
@@ -668,7 +668,10 @@ async def dto_object(dto: DummyDTO) -> JSONResponse:
 
 
 @asynccontextmanager
-async def run_openapi_server(app: Optional[FastAPI] = None, port: int = 0) -> AsyncIterator[None]:
+async def run_openapi_server(
+    app: Optional[FastAPI] = None,
+    port: int = 0,
+) -> AsyncIterator[None]:
     if port == 0:
         port = get_random_port(10001, 65535)
 

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -90,7 +90,8 @@ T = TypeVar("T")
 GLOBAL_CACHE_FILE = Path("schematic_generation_test_cache.json")
 
 SERVER_PORT = 8089
-SERVER_ADDRESS = f"http://localhost:{SERVER_PORT}"
+SERVER_ADDRESS_BASE = "http://localhost"
+SERVER_ADDRESS = f"{SERVER_ADDRESS_BASE}:{SERVER_PORT}"
 
 PLUGIN_SERVER_PORT = 8091
 OPENAPI_SERVER_PORT = 8092
@@ -551,12 +552,11 @@ async def create_schematic_generation_result_collection(
 
 @asynccontextmanager
 async def run_service_server(
-    tools: list[ToolEntry],
-    plugin_data: Mapping[str, Any] = {},
+    tools: list[ToolEntry], plugin_data: Mapping[str, Any] = {}, port=PLUGIN_SERVER_PORT
 ) -> AsyncIterator[PluginServer]:
     async with PluginServer(
         tools=tools,
-        port=PLUGIN_SERVER_PORT,
+        port=port,
         host="127.0.0.1",
         plugin_data=plugin_data,
     ) as server:


### PR DESCRIPTION
* Changed the test context API class to randomize the port it uses
* Changed run_server wrapper to use randomized port from test context API (which holds the client)
* Reworked run_server termination so it won't leave so many zombie procs
* Changed run_service servrer to use random port
* Changed run_openapi_server to use random port
* Changed error handling of openapi's call_tool to pass exceptions as ToolError (fix for a failed test)
* Added waits for server runners that test they are serving before returning them to the test
* Fixed some more spelling typos