### PR TITLE
Feature/mc 793 fix potential hallucinated ids for guideline matchers

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -6512,4 +6512,4 @@ together = ["together", "torch", "transformers"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "576780bd541187081ff26ced4ea10a0a01c09f46da8c85488342807dfa2b94f6"
+content-hash = "2109b4e3524ef16bd6f034917e100df4c22aa78523b36a353cbd6751adfe5e46"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,8 +56,8 @@ uvicorn = "^0.32.1"
 # --- optional packages ---
 anthropic = { version = "^0.37.1", optional = true }
 cerebras-cloud-sdk = { version = "^1.25.0", optional = true }
-google-api-core = { version = "^2.24.1", optional = true }
-google-genai = { version = "^1.2.0", optional = true }
+google-api-core = { version = "^2.24.2", optional = true }
+google-genai = { version = "^1.16.1", optional = true }
 together = { version = "^1.2.12", optional = true }
 torch = { version = "^2.6.0", optional = true }
 transformers = { version = "^4.46.2", optional = true }

--- a/src/parlant/core/engines/alpha/guideline_matching/generic_actionable_batch.py
+++ b/src/parlant/core/engines/alpha/guideline_matching/generic_actionable_batch.py
@@ -95,8 +95,9 @@ class GenericActionableGuidelineMatchingBatch(GuidelineMatchingBatch):
             for batch_id in self._guidelines.keys()
         ):
             self._logger.warning(
-                "Completion:\nGuideline matching results are missing for some guidelines."
+                "Completion:\nActionable guideline matching results are missing for some guidelines."
             )
+
         matches = []
 
         for match in inference.content.checks:
@@ -190,7 +191,7 @@ class GenericActionableGuidelineMatchingBatch(GuidelineMatchingBatch):
     ) -> PromptBuilder:
         result_structure = [
             {
-                "guideline_id": g.id,
+                "guideline_id": batch_id,
                 "condition": g.content.condition,
                 "condition_application_rationale": "<Explanation for why the condition is or isn't met>",
                 "condition_applies": "<BOOL>",
@@ -209,7 +210,7 @@ class GenericActionableGuidelineMatchingBatch(GuidelineMatchingBatch):
                 "guideline_should_reapply": "<BOOL: Optional, only necessary if guideline_previously_applied is not 'no'>",
                 "applies_score": "<Relevance score of the guideline between 1 and 10. A higher score indicates that the guideline should be active>",
             }
-            for g in self._guidelines.values()
+            for batch_id, g in self._guidelines.items()
         ]
         guidelines_text = "\n".join(
             f"{i}) Condition: {g.content.condition}. Action: {g.content.action}"
@@ -323,9 +324,6 @@ Expected Output
                 "guidelines_len": len(self._guidelines),
             },
         )
-        with open("actionable batch prompt.txt", "w") as f:
-            f.write(builder.build())  # TODO delete
-
         return builder
 
 

--- a/src/parlant/core/engines/alpha/guideline_matching/generic_observational_batch.py
+++ b/src/parlant/core/engines/alpha/guideline_matching/generic_observational_batch.py
@@ -57,7 +57,9 @@ class GenericObservationalGuidelineMatchingBatch(GuidelineMatchingBatch):
     ) -> None:
         self._logger = logger
         self._schematic_generator = schematic_generator
-        self._guidelines = {g.id: g for g in guidelines}
+        self._guidelines = {
+            g.id: g for g in guidelines
+        }  # {str(i): g for i, g in enumerate(guidelines)}
         self._context = context
 
     @override

--- a/src/parlant/core/engines/alpha/guideline_matching/generic_observational_batch.py
+++ b/src/parlant/core/engines/alpha/guideline_matching/generic_observational_batch.py
@@ -57,9 +57,7 @@ class GenericObservationalGuidelineMatchingBatch(GuidelineMatchingBatch):
     ) -> None:
         self._logger = logger
         self._schematic_generator = schematic_generator
-        self._guidelines = {
-            g.id: g for g in guidelines
-        }  # {str(i): g for i, g in enumerate(guidelines)}
+        self._guidelines = {str(i): g for i, g in enumerate(guidelines, start=1)}
         self._context = context
 
     @override
@@ -78,16 +76,22 @@ class GenericObservationalGuidelineMatchingBatch(GuidelineMatchingBatch):
             self._logger.warning("Completion:\nNo checks generated! This shouldn't happen.")
         else:
             self._logger.debug(f"Completion:\n{inference.content.model_dump_json(indent=2)}")
+        if not all(
+            any(batch_id == g.id for g in self._guidelines.values())
+            for batch_id in self._guidelines.keys()
+        ):
+            self._logger.warning(
+                "Completion:\n Observational guideline matching results are missing for some guidelines."
+            )
 
         matches = []
 
         for match in inference.content.checks:
-            if match.applies:
+            if match.guideline_id in self._guidelines and match.applies:
                 self._logger.debug(f"Completion::Activated:\n{match.model_dump_json(indent=2)}")
-
                 matches.append(
                     GuidelineMatch(
-                        guideline=self._guidelines[GuidelineId(match.guideline_id)],
+                        guideline=self._guidelines[match.guideline_id],
                         score=10 if match.applies else 1,
                         rationale=f'''Condition Application: "{match.rationale}"''',
                         guideline_previously_applied=PreviouslyAppliedType("irrelevant"),
@@ -160,12 +164,12 @@ class GenericObservationalGuidelineMatchingBatch(GuidelineMatchingBatch):
     ) -> PromptBuilder:
         result_structure = [
             {
-                "guideline_id": g.id,
+                "guideline_id": batch_id,
                 "condition": g.content.condition,
                 "rationale": "<Explanation for why the condition is or isn't met>",
                 "applies": "<BOOL>",
             }
-            for g in self._guidelines.values()
+            for batch_id, g in self._guidelines.items()
         ]
         conditions_text = "\n".join(
             f"{i}) {g.content.condition}." for i, g in self._guidelines.items()


### PR DESCRIPTION
2 small changes:
1. In guideline matching prompts, guidelines are now recognized by natural numbers, instead of by their ID. This reduces the chance of the LLM hallucinating a guideline ID.
2. If the guideline matcher inference returns an invalid ID, it will be skipped instead of raising an exception.

A future change would add an extra batch for recovering guideline propositions with invalid IDs