### PR TITLE
Feature/mc 823 alter how guideline ids are managed in all prompts

### DIFF
--- a/src/parlant/core/engines/alpha/guideline_matching/generic/guideline_actionable_batch.py
+++ b/src/parlant/core/engines/alpha/guideline_matching/generic/guideline_actionable_batch.py
@@ -51,7 +51,7 @@ class GenericActionableGuidelineMatchingBatch(GuidelineMatchingBatch):
     ) -> None:
         self._logger = logger
         self._schematic_generator = schematic_generator
-        self._guidelines = {g.id: g for g in guidelines}
+        self._guidelines = {str(i): g for i, g in enumerate(guidelines)}
         self._context = context
 
     @override
@@ -79,7 +79,7 @@ class GenericActionableGuidelineMatchingBatch(GuidelineMatchingBatch):
 
                 matches.append(
                     GuidelineMatch(
-                        guideline=self._guidelines[GuidelineId(match.guideline_id)],
+                        guideline=self._guidelines[match.guideline_id],
                         score=10 if match.applies else 1,
                         rationale=f'''Not previously applied matcher rationale: "{match.rationale}"''',
                         guideline_previously_applied=PreviouslyAppliedType.NO,
@@ -249,12 +249,12 @@ OUTPUT FORMAT
     def _format_of_guideline_check_json_description(self) -> str:
         result_structure = [
             {
-                "guideline_id": g.id,
+                "guideline_id": i,
                 "condition": g.content.condition,
                 "rationale": "<Explanation for why the condition is or isn't met when focusing on the most recent interaction>",
                 "applies": "<BOOL>",
             }
-            for g in self._guidelines.values()
+            for i, g in self._guidelines.items()
         ]
         result = {"checks": result_structure}
         return json.dumps(result, indent=4)

--- a/src/parlant/core/engines/alpha/guideline_matching/generic/guideline_actionable_batch.py
+++ b/src/parlant/core/engines/alpha/guideline_matching/generic/guideline_actionable_batch.py
@@ -243,8 +243,6 @@ OUTPUT FORMAT
                 "guidelines_len": len(self._guidelines),
             },
         )
-        with open("guideline actionable prompt.txt", "w") as f:
-            f.write(builder.build())
 
         return builder
 

--- a/src/parlant/core/engines/alpha/guideline_matching/generic/guideline_actionable_batch.py
+++ b/src/parlant/core/engines/alpha/guideline_matching/generic/guideline_actionable_batch.py
@@ -51,7 +51,7 @@ class GenericActionableGuidelineMatchingBatch(GuidelineMatchingBatch):
     ) -> None:
         self._logger = logger
         self._schematic_generator = schematic_generator
-        self._guidelines = {str(i): g for i, g in enumerate(guidelines)}
+        self._guidelines = {str(i): g for i, g in enumerate(guidelines, start=1)}
         self._context = context
 
     @override
@@ -243,6 +243,8 @@ OUTPUT FORMAT
                 "guidelines_len": len(self._guidelines),
             },
         )
+        with open("guideline actionable prompt.txt", "w") as f:
+            f.write(builder.build())
 
         return builder
 

--- a/src/parlant/core/engines/alpha/guideline_matching/generic/guideline_previously_applied_actionable_batch.py
+++ b/src/parlant/core/engines/alpha/guideline_matching/generic/guideline_previously_applied_actionable_batch.py
@@ -260,8 +260,6 @@ OUTPUT FORMAT
                 "guidelines_len": len(self._guidelines),
             },
         )
-        with open("previously applied prompt.txt", "w") as f:
-            f.write(builder.build())
         return builder
 
     def _format_of_guideline_check_json_description(self) -> str:

--- a/src/parlant/core/engines/alpha/guideline_matching/generic/guideline_previously_applied_actionable_batch.py
+++ b/src/parlant/core/engines/alpha/guideline_matching/generic/guideline_previously_applied_actionable_batch.py
@@ -56,7 +56,7 @@ class GenericPreviouslyAppliedActionableGuidelineMatchingBatch(GuidelineMatching
     ) -> None:
         self._logger = logger
         self._schematic_generator = schematic_generator
-        self._guidelines = {g.id: g for g in guidelines}
+        self._guidelines = {str(i): g for i, g in enumerate(guidelines, start=1)}
         self._context = context
 
     @override
@@ -84,7 +84,7 @@ class GenericPreviouslyAppliedActionableGuidelineMatchingBatch(GuidelineMatching
 
                 matches.append(
                     GuidelineMatch(
-                        guideline=self._guidelines[GuidelineId(match.guideline_id)],
+                        guideline=self._guidelines[match.guideline_id],
                         score=10 if match.should_reapply else 1,
                         rationale='''reapply rational: ""''',
                         guideline_previously_applied=PreviouslyAppliedType.FULLY,
@@ -260,21 +260,21 @@ OUTPUT FORMAT
                 "guidelines_len": len(self._guidelines),
             },
         )
-
+        with open("previously applied prompt.txt", "w") as f:
+            f.write(builder.build())
         return builder
 
     def _format_of_guideline_check_json_description(self) -> str:
         result_structure = [
             {
-                "guideline_id": g.id,
+                "guideline_id": i,
                 "condition": g.content.condition,
                 "action": g.content.action,
                 "condition_met_again": "<BOOL. Whether the condition met again in a new or subtly different context or information>",
                 "action_wasnt_taken": "<BOOL. include only condition_met_again is True if The action wasn't already taken for this new reason>",
-                # "tldr": "<str, Explanation for why the guideline condition is met AGAIN and should reapply when focusing on the MOST RECENT interaction>",
                 "should_reapply": "<BOOL>",
             }
-            for g in self._guidelines.values()
+            for i, g in self._guidelines.items()
         ]
         result = {"checks": result_structure}
         return json.dumps(result, indent=4)

--- a/src/parlant/core/engines/alpha/guideline_matching/generic/guideline_previously_applied_actionable_customer_dependent_batch.py
+++ b/src/parlant/core/engines/alpha/guideline_matching/generic/guideline_previously_applied_actionable_customer_dependent_batch.py
@@ -263,8 +263,6 @@ OUTPUT FORMAT
                 "guidelines_len": len(self._guidelines),
             },
         )
-        with open("customer dependent prompt.txt", "w") as f:
-            f.write(builder.build())
         return builder
 
     def _format_of_guideline_check_json_description(self) -> str:

--- a/src/parlant/core/engines/alpha/guideline_matching/generic/observational_batch.py
+++ b/src/parlant/core/engines/alpha/guideline_matching/generic/observational_batch.py
@@ -248,8 +248,6 @@ Expected Output
                 "guidelines_len": len(self._guidelines),
             },
         )
-        with open(f"observational batch prompt {datetime.now()}.txt", "w") as f:
-            f.write(builder.build())
         return builder
 
 

--- a/src/parlant/core/engines/alpha/guideline_matching/generic/observational_batch.py
+++ b/src/parlant/core/engines/alpha/guideline_matching/generic/observational_batch.py
@@ -248,7 +248,7 @@ Expected Output
                 "guidelines_len": len(self._guidelines),
             },
         )
-        with open("observational batch prompt.txt", "w") as f:
+        with open(f"observational batch prompt {datetime.now()}.txt", "w") as f:
             f.write(builder.build())
         return builder
 

--- a/src/parlant/core/engines/alpha/guideline_matching/generic/observational_batch.py
+++ b/src/parlant/core/engines/alpha/guideline_matching/generic/observational_batch.py
@@ -57,7 +57,7 @@ class GenericObservationalGuidelineMatchingBatch(GuidelineMatchingBatch):
     ) -> None:
         self._logger = logger
         self._schematic_generator = schematic_generator
-        self._guidelines = {g.id: g for g in guidelines}
+        self._guidelines = {str(i): g for i, g in enumerate(guidelines, start=1)}
         self._context = context
 
     @override
@@ -83,7 +83,7 @@ class GenericObservationalGuidelineMatchingBatch(GuidelineMatchingBatch):
 
                 matches.append(
                     GuidelineMatch(
-                        guideline=self._guidelines[GuidelineId(match.guideline_id)],
+                        guideline=self._guidelines[match.guideline_id],
                         score=10 if match.applies else 1,
                         rationale=f'''Condition Application Rationale: "{match.rationale}"''',
                         guideline_previously_applied=PreviouslyAppliedType.IRRELEVANT,
@@ -154,12 +154,12 @@ class GenericObservationalGuidelineMatchingBatch(GuidelineMatchingBatch):
     ) -> PromptBuilder:
         result_structure = [
             {
-                "guideline_id": g.id,
+                "guideline_id": i,
                 "condition": g.content.condition,
                 "rationale": "<Explanation for why the condition is or isn't met>",
                 "applies": "<BOOL>",
             }
-            for g in self._guidelines.values()
+            for i, g in self._guidelines.items()
         ]
         conditions_text = "\n".join(
             f"{i}) {g.content.condition}." for i, g in self._guidelines.items()
@@ -248,7 +248,8 @@ Expected Output
                 "guidelines_len": len(self._guidelines),
             },
         )
-
+        with open("observational batch prompt.txt", "w") as f:
+            f.write(builder.build())
         return builder
 
 

--- a/src/parlant/core/engines/alpha/guideline_matching/generic/response_analysis_batch.py
+++ b/src/parlant/core/engines/alpha/guideline_matching/generic/response_analysis_batch.py
@@ -344,8 +344,6 @@ OUTPUT FORMAT
                 "guidelines_len": len(guidelines),
             },
         )
-        with open("response analysis batch prompt.txt", "w") as f:
-            f.write(builder.build())
         return builder
 
     def _format_of_guideline_check_json_description(

--- a/tests/core/stable/services/indexing/test_customer_dependent_action_detector.py
+++ b/tests/core/stable/services/indexing/test_customer_dependent_action_detector.py
@@ -101,10 +101,6 @@ async def test_that_actions_which_are_customer_dependent_are_classified_correctl
             condition="The customer wants to schedule a callback",
             action="ask for their preferred time and phone number, then confirm the appointment details",
         ),
-        GuidelineContent(
-            condition="The customer seems confused about our return policy",
-            action="clearly explain our 30-day return policy and provide examples of eligible items",
-        ),
     ]
 
     for g in guidelines:


### PR DESCRIPTION

Changed the guideline ID in all guideline matching prompts so they are counting numbers (1,2,3…) instead of their hash IDs. This should reduce instances of hallucinated IDs.