### PR TITLE
Feature/mc-792-support-guidelines-with-conditions-that-apply-to-the-agents

### DIFF
--- a/src/parlant/bin/server.py
+++ b/src/parlant/bin/server.py
@@ -90,6 +90,9 @@ from parlant.core.engines.alpha.utterance_selector import (
     UtteranceRevisionSchema,
     UtteranceSelector,
 )
+from parlant.core.services.indexing.guideline_agent_intention_proposer import (
+    AgentIntentionProposerSchema,
+)
 from parlant.core.journeys import JourneyDocumentStore, JourneyStore
 from parlant.core.persistence.vector_database import VectorDatabase
 from parlant.core.services.indexing.customer_dependent_action_detector import (
@@ -612,6 +615,7 @@ async def initialize_container(
         GuidelineActionPropositionSchema,
         GuidelineContinuousPropositionSchema,
         CustomerDependentActionSchema,
+        AgentIntentionProposerSchema,
     ):
         try_define(
             SchematicGenerator[schema],  # type: ignore

--- a/src/parlant/core/engines/alpha/guideline_matching/generic/common.py
+++ b/src/parlant/core/engines/alpha/guideline_matching/generic/common.py
@@ -1,0 +1,17 @@
+from dataclasses import dataclass
+from typing import Optional
+
+from parlant.core.guidelines import Guideline
+
+
+@dataclass
+class GuidelineInternalRepresentation:
+    condition: str
+    action: Optional[str]
+
+
+def internal_representation(g: Guideline) -> GuidelineInternalRepresentation:
+    condition = g.metadata.get("internal_condition")
+    if isinstance(condition, str):
+        return GuidelineInternalRepresentation(condition, g.content.action)
+    return GuidelineInternalRepresentation(g.content.condition, g.content.action)

--- a/src/parlant/core/engines/alpha/guideline_matching/generic/common.py
+++ b/src/parlant/core/engines/alpha/guideline_matching/generic/common.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Optional
+from typing import Optional, cast
 
 from parlant.core.guidelines import Guideline
 
@@ -11,7 +11,8 @@ class GuidelineInternalRepresentation:
 
 
 def internal_representation(g: Guideline) -> GuidelineInternalRepresentation:
-    condition = g.metadata.get("agent_intention_condition")
-    if isinstance(condition, str):
-        return GuidelineInternalRepresentation(condition, g.content.action)
-    return GuidelineInternalRepresentation(g.content.condition, g.content.action)
+    action, condition = g.content.action, g.content.condition
+
+    condition = cast(str, g.metadata.get("agent_intention_condition", condition))
+
+    return GuidelineInternalRepresentation(condition, action)

--- a/src/parlant/core/engines/alpha/guideline_matching/generic/common.py
+++ b/src/parlant/core/engines/alpha/guideline_matching/generic/common.py
@@ -13,6 +13,7 @@ class GuidelineInternalRepresentation:
 def internal_representation(g: Guideline) -> GuidelineInternalRepresentation:
     action, condition = g.content.action, g.content.condition
 
-    condition = cast(str, g.metadata.get("agent_intention_condition", condition))
+    if agent_intention_condition := g.metadata.get("agent_intention_condition"):
+        condition = cast(str, agent_intention_condition) or condition
 
     return GuidelineInternalRepresentation(condition, action)

--- a/src/parlant/core/engines/alpha/guideline_matching/generic/common.py
+++ b/src/parlant/core/engines/alpha/guideline_matching/generic/common.py
@@ -11,7 +11,7 @@ class GuidelineInternalRepresentation:
 
 
 def internal_representation(g: Guideline) -> GuidelineInternalRepresentation:
-    condition = g.metadata.get("internal_condition")
+    condition = g.metadata.get("agent_intention_condition")
     if isinstance(condition, str):
         return GuidelineInternalRepresentation(condition, g.content.action)
     return GuidelineInternalRepresentation(g.content.condition, g.content.action)

--- a/src/parlant/core/engines/alpha/guideline_matching/generic/guideline_actionable_batch.py
+++ b/src/parlant/core/engines/alpha/guideline_matching/generic/guideline_actionable_batch.py
@@ -66,6 +66,9 @@ class GenericActionableGuidelineMatchingBatch(GuidelineMatchingBatch):
                 hints={"temperature": 0.15},
             )
 
+        with open("output_intention_checks.txt", "a") as f:
+            f.write(inference.content.model_dump_json(indent=2))
+
         if not inference.content.checks:
             self._logger.warning("Completion:\nNo checks generated! This shouldn't happen.")
         else:
@@ -152,7 +155,7 @@ class GenericActionableGuidelineMatchingBatch(GuidelineMatchingBatch):
         shots: Sequence[GenericActionableGuidelineGuidelineMatchingShot],
     ) -> PromptBuilder:
         guidelines_text = "\n".join(
-            f"{i}) Condition: {g.content.condition}. Action: {g.content.action}"
+            f"{i}) Condition: {g.internal_condition}. Action: {g.content.action}"
             for i, g in self._guidelines.items()
         )
 

--- a/src/parlant/core/engines/alpha/guideline_matching/generic/guideline_actionable_batch.py
+++ b/src/parlant/core/engines/alpha/guideline_matching/generic/guideline_actionable_batch.py
@@ -66,9 +66,6 @@ class GenericActionableGuidelineMatchingBatch(GuidelineMatchingBatch):
                 hints={"temperature": 0.15},
             )
 
-        with open("output_intention_checks.txt", "a") as f:
-            f.write(inference.content.model_dump_json(indent=2))
-
         if not inference.content.checks:
             self._logger.warning("Completion:\nNo checks generated! This shouldn't happen.")
         else:

--- a/src/parlant/core/engines/alpha/guideline_matching/generic/guideline_actionable_batch.py
+++ b/src/parlant/core/engines/alpha/guideline_matching/generic/guideline_actionable_batch.py
@@ -5,6 +5,7 @@ import json
 import math
 from typing_extensions import override
 from parlant.core.common import DefaultBaseModel, JSONSerializable
+from parlant.core.engines.alpha.guideline_matching.generic.common import internal_representation
 from parlant.core.engines.alpha.guideline_matching.guideline_match import (
     GuidelineMatch,
     PreviouslyAppliedType,
@@ -152,7 +153,7 @@ class GenericActionableGuidelineMatchingBatch(GuidelineMatchingBatch):
         shots: Sequence[GenericActionableGuidelineGuidelineMatchingShot],
     ) -> PromptBuilder:
         guidelines_text = "\n".join(
-            f"{i}) Condition: {g.internal_condition}. Action: {g.content.action}"
+            f"{i}) Condition: {internal_representation(g).condition}. Action: {g.content.action}"
             for i, g in self._guidelines.items()
         )
 

--- a/src/parlant/core/engines/alpha/guideline_matching/generic/guideline_actionable_batch.py
+++ b/src/parlant/core/engines/alpha/guideline_matching/generic/guideline_actionable_batch.py
@@ -5,7 +5,10 @@ import json
 import math
 from typing_extensions import override
 from parlant.core.common import DefaultBaseModel, JSONSerializable
-from parlant.core.engines.alpha.guideline_matching.generic.common import internal_representation
+from parlant.core.engines.alpha.guideline_matching.generic.common import (
+    GuidelineInternalRepresentation,
+    internal_representation,
+)
 from parlant.core.engines.alpha.guideline_matching.guideline_match import (
     GuidelineMatch,
     PreviouslyAppliedType,
@@ -152,8 +155,12 @@ class GenericActionableGuidelineMatchingBatch(GuidelineMatchingBatch):
         self,
         shots: Sequence[GenericActionableGuidelineGuidelineMatchingShot],
     ) -> PromptBuilder:
+        guideline_representations = {
+            g.id: internal_representation(g) for g in self._guidelines.values()
+        }
+
         guidelines_text = "\n".join(
-            f"{i}) Condition: {internal_representation(g).condition}. Action: {g.content.action}"
+            f"{i}) Condition: {guideline_representations[g.id].condition}. Action: {guideline_representations[g.id].action}"
             for i, g in self._guidelines.items()
         )
 
@@ -240,18 +247,23 @@ OUTPUT FORMAT
 ```
 """,
             props={
-                "result_structure_text": self._format_of_guideline_check_json_description(),
+                "result_structure_text": self._format_of_guideline_check_json_description(
+                    guideline_representations=guideline_representations
+                ),
                 "guidelines_len": len(self._guidelines),
             },
         )
 
         return builder
 
-    def _format_of_guideline_check_json_description(self) -> str:
+    def _format_of_guideline_check_json_description(
+        self,
+        guideline_representations: dict[GuidelineId, GuidelineInternalRepresentation],
+    ) -> str:
         result_structure = [
             {
                 "guideline_id": i,
-                "condition": g.content.condition,
+                "condition": guideline_representations[g.id].condition,
                 "rationale": "<Explanation for why the condition is or isn't met when focusing on the most recent interaction>",
                 "applies": "<BOOL>",
             }

--- a/src/parlant/core/engines/alpha/guideline_matching/generic/guideline_previously_applied_actionable_batch.py
+++ b/src/parlant/core/engines/alpha/guideline_matching/generic/guideline_previously_applied_actionable_batch.py
@@ -160,7 +160,7 @@ class GenericPreviouslyAppliedActionableGuidelineMatchingBatch(GuidelineMatching
         shots: Sequence[GenericPreviouslyAppliedActionableGuidelineGuidelineMatchingShot],
     ) -> PromptBuilder:
         guidelines_text = "\n".join(
-            f"{i}) Condition: {g.content.condition}. Action: {g.content.action}"
+            f"{i}) Condition: {g.internal_condition}. Action: {g.content.action}"
             for i, g in self._guidelines.items()
         )
 

--- a/src/parlant/core/engines/alpha/guideline_matching/generic/guideline_previously_applied_actionable_batch.py
+++ b/src/parlant/core/engines/alpha/guideline_matching/generic/guideline_previously_applied_actionable_batch.py
@@ -5,6 +5,7 @@ import math
 from typing import Optional, Sequence
 from typing_extensions import override
 from parlant.core.common import DefaultBaseModel, JSONSerializable
+from parlant.core.engines.alpha.guideline_matching.generic.common import internal_representation
 from parlant.core.engines.alpha.guideline_matching.guideline_match import (
     GuidelineMatch,
     PreviouslyAppliedType,
@@ -160,7 +161,7 @@ class GenericPreviouslyAppliedActionableGuidelineMatchingBatch(GuidelineMatching
         shots: Sequence[GenericPreviouslyAppliedActionableGuidelineGuidelineMatchingShot],
     ) -> PromptBuilder:
         guidelines_text = "\n".join(
-            f"{i}) Condition: {g.internal_condition}. Action: {g.content.action}"
+            f"{i}) Condition: {internal_representation(g).condition}. Action: {g.content.action}"
             for i, g in self._guidelines.items()
         )
 

--- a/src/parlant/core/engines/alpha/guideline_matching/generic/guideline_previously_applied_actionable_customer_dependent_batch.py
+++ b/src/parlant/core/engines/alpha/guideline_matching/generic/guideline_previously_applied_actionable_customer_dependent_batch.py
@@ -5,6 +5,7 @@ import math
 from typing import Optional, Sequence
 from typing_extensions import override
 from parlant.core.common import DefaultBaseModel, JSONSerializable
+from parlant.core.engines.alpha.guideline_matching.generic.common import internal_representation
 from parlant.core.engines.alpha.guideline_matching.guideline_match import (
     GuidelineMatch,
     PreviouslyAppliedType,
@@ -166,7 +167,7 @@ class GenericPreviouslyAppliedActionableCustomerDependentGuidelineMatchingBatch(
         shots: Sequence[GenericPreviouslyAppliedActionableCustomerDependentGuidelineMatchingShot],
     ) -> PromptBuilder:
         guidelines_text = "\n".join(
-            f"{i}) Condition: {g.internal_condition}. Action: {g.content.action}"
+            f"{i}) Condition: {internal_representation(g).condition}. Action: {g.content.action}"
             for i, g in self._guidelines.items()
         )
 

--- a/src/parlant/core/engines/alpha/guideline_matching/generic/guideline_previously_applied_actionable_customer_dependent_batch.py
+++ b/src/parlant/core/engines/alpha/guideline_matching/generic/guideline_previously_applied_actionable_customer_dependent_batch.py
@@ -166,7 +166,7 @@ class GenericPreviouslyAppliedActionableCustomerDependentGuidelineMatchingBatch(
         shots: Sequence[GenericPreviouslyAppliedActionableCustomerDependentGuidelineMatchingShot],
     ) -> PromptBuilder:
         guidelines_text = "\n".join(
-            f"{i}) Condition: {g.content.condition}. Action: {g.content.action}"
+            f"{i}) Condition: {g.internal_condition}. Action: {g.content.action}"
             for i, g in self._guidelines.items()
         )
 

--- a/src/parlant/core/engines/alpha/guideline_matching/generic/observational_batch.py
+++ b/src/parlant/core/engines/alpha/guideline_matching/generic/observational_batch.py
@@ -6,6 +6,7 @@ import math
 from typing_extensions import override
 
 from parlant.core.common import DefaultBaseModel, JSONSerializable
+from parlant.core.engines.alpha.guideline_matching.generic.common import internal_representation
 from parlant.core.engines.alpha.guideline_matching.guideline_match import (
     GuidelineMatch,
     PreviouslyAppliedType,
@@ -152,17 +153,22 @@ class GenericObservationalGuidelineMatchingBatch(GuidelineMatchingBatch):
         self,
         shots: Sequence[GenericObservationalGuidelineMatchingShot],
     ) -> PromptBuilder:
+        guideline_representations = {
+            g.id: internal_representation(g) for g in self._guidelines.values()
+        }
+
         result_structure = [
             {
                 "guideline_id": i,
-                "condition": g.content.condition,
+                "condition": guideline_representations[g.id].condition,
                 "rationale": "<Explanation for why the condition is or isn't met>",
                 "applies": "<BOOL>",
             }
             for i, g in self._guidelines.items()
         ]
         conditions_text = "\n".join(
-            f"{i}) {g.content.condition}." for i, g in self._guidelines.items()
+            f"{i}) {guideline_representations[g.id].condition}."
+            for i, g in self._guidelines.items()
         )
 
         builder = PromptBuilder(on_build=lambda prompt: self._logger.debug(f"Prompt:\n{prompt}"))

--- a/src/parlant/core/engines/alpha/guideline_matching/generic/response_analysis_batch.py
+++ b/src/parlant/core/engines/alpha/guideline_matching/generic/response_analysis_batch.py
@@ -220,7 +220,7 @@ class GenericResponseAnalysisBatch(ResponseAnalysisBatch):
         guidelines: dict[str, Guideline],
     ) -> str:
         guidelines_text = "\n".join(
-            f"{i}) Condition: {g.content.condition}. Action: {g.content.action}"
+            f"{i}) Condition: {g.internal_condition}. Action: {g.content.action}"
             for i, g in guidelines.items()
         )
 

--- a/src/parlant/core/engines/alpha/guideline_matching/generic/response_analysis_batch.py
+++ b/src/parlant/core/engines/alpha/guideline_matching/generic/response_analysis_batch.py
@@ -7,6 +7,7 @@ from more_itertools import chunked
 
 from parlant.core import async_utils
 from parlant.core.common import DefaultBaseModel, JSONSerializable
+from parlant.core.engines.alpha.guideline_matching.generic.common import internal_representation
 from parlant.core.engines.alpha.guideline_matching.generic.guideline_actionable_batch import (
     _make_event,
 )
@@ -220,7 +221,7 @@ class GenericResponseAnalysisBatch(ResponseAnalysisBatch):
         guidelines: dict[str, Guideline],
     ) -> str:
         guidelines_text = "\n".join(
-            f"{i}) Condition: {g.internal_condition}. Action: {g.content.action}"
+            f"{i}) Condition: {internal_representation(g).condition}. Action: {g.content.action}"
             for i, g in guidelines.items()
         )
 

--- a/src/parlant/core/engines/alpha/message_generator.py
+++ b/src/parlant/core/engines/alpha/message_generator.py
@@ -954,7 +954,7 @@ example_2_expected = MessageSchema(
     guidelines=[
         "When the customer chooses and orders a burger, then provide it",
         "When the customer chooses specific ingredients on the burger, only provide those ingredients if we have them fresh in stock; otherwise, reject the order",
-        "Agent intention guideline: When the agent processes a new order, confirm with the customer the order details and the price",
+        "Agent intention guideline: When processing a new order, confirm the order details and price with the customer",
     ],
     context_evaluation=ContextEvaluation(
         most_recent_customer_inquiries_or_needs="The customer ordered an American burger with cheese",
@@ -980,7 +980,7 @@ example_2_expected = MessageSchema(
         ),
         InstructionEvaluation(
             number=3,
-            instruction="When the agent processes a new order, confirm with the customer the order details and the price",
+            instruction="When you processes a new order, confirm with the customer the order details and the price",
             evaluation="The agent is not going to process the order, so no need to make a confirmation",
             data_available="No relevant data",
         ),
@@ -1558,7 +1558,7 @@ example_9_shot = MessageGeneratorShot(
 example_10_expected = MessageSchema(
     last_message_of_customer=("I want to return my shoes, I purchased them a month ago"),
     guidelines=[
-        "When the agent suggests refund options, suggest a refund either as website credit or to their credit card.",
+        "When you suggests refund options, suggest a refund either as website credit or to their credit card.",
         "When the customer wants to return an item they purchased more than a week ago, do not suggest a refund to the credit card",
     ],
     context_evaluation=ContextEvaluation(

--- a/src/parlant/core/engines/alpha/message_generator.py
+++ b/src/parlant/core/engines/alpha/message_generator.py
@@ -640,8 +640,7 @@ Produce a valid JSON object in the following format: ###
                 "guidelines": actionable_guidelines,
             },
         )
-        with open("prompt_message_generator.txt", "w") as f:
-            f.write(builder.build())
+
         return builder
 
     def _format_missing_data(self, missing_data: Sequence[MissingToolData]) -> str:
@@ -784,8 +783,7 @@ Produce a valid JSON object in the following format: ###
             prompt=prompt,
             hints={"temperature": temperature},
         )
-        with open("output_message_generator.txt", "w") as f:
-            f.write(message_event_response.content.model_dump_json(indent=2))
+
         self._logger.debug(
             f"Completion:\n{message_event_response.content.model_dump_json(indent=2)}"
         )

--- a/src/parlant/core/engines/alpha/message_generator.py
+++ b/src/parlant/core/engines/alpha/message_generator.py
@@ -301,33 +301,57 @@ you don't need to specifically double-check if you followed or broke any guideli
                 {},
             )
         guidelines = []
-
+        agent_intention_guidelines = []
         for i, p in enumerate(all_matches, start=1):
-            guideline = f"Guideline #{i}) When {p.guideline.content.condition}, then {p.guideline.content.action}"
-
-            guideline += f"\n    [Priority (1-10): {p.score}; Rationale: {p.rationale}]"
-            guidelines.append(guideline)
+            if p.guideline.content.action:
+                guideline = f"Guideline #{i}) When {p.guideline.content.condition}, then {p.guideline.content.action}"
+                guideline += f"\n   Rationale: {p.rationale}]"
+                if p.guideline.metadata.get("agent_intention_condition"):
+                    agent_intention_guidelines.append(guideline)
+                else:
+                    guidelines.append(guideline)
 
         guideline_list = "\n".join(guidelines)
+        agent_intention_guidelines_list = "\n".join(agent_intention_guidelines)
 
-        return (
-            """
+        guideline_instruction = """
 When crafting your reply, you must follow the behavioral guidelines provided below, which have been identified as relevant to the current state of the interaction.
-These guidelines were provided by the business you are representing.
-Each guideline includes a priority score to indicate its importance and a rationale for its relevance.
+"""
+        if agent_intention_guidelines_list:
+            guideline_instruction += f"""
+Some guidelines are tied to condition that related to you, the agent. These guidelines are considered relevant because it is likely that you intends to output
+a message that will trigger the associated condition. You should only follow these guidelines if you are actually going to output a message that activates the condition.
+- **Guidelines with agent intention condition**:
+{agent_intention_guidelines_list}
+
+"""
+        if guideline_list:
+            guideline_instruction += f"""
+
+For any other guidelines, do not disregard a guideline because you believe its 'when' condition or rationale does not apply—this filtering has already been handled.
+- **Guidelines**:
+{guideline_list}
+
+"""
+        guideline_instruction += """
 
 You may choose not to follow a guideline only in the following cases:
     - It conflicts with a previous customer request.
-    - It contradicts another guideline of equal or higher priority.
     - It is clearly inappropriate given the current context of the conversation.
+    - It lacks sufficient context or data to apply reliably.
+    - It conflicts with an insight.
+    - It depends on an agent intention condition that does not apply in the current situation (as mentioned above)
+    - If a guideline offers multiple options (e.g., "do X or Y") and another more specific guideline restricts one of those options (e.g., "don’t do X"), follow both by 
+        choosing the permitted alternative (i.e., do Y).
 In all other situations, you are expected to adhere to the guidelines.
 These guidelines have already been pre-filtered based on the interaction's context and other considerations outside your scope.
-Do not disregard a guideline because you believe its 'when' condition or rationale does not apply—this filtering has already been handled.
-
-- **Guidelines**:
-{guideline_list}
-""",
-            {"guideline_list": guideline_list},
+"""
+        return (
+            guideline_instruction,
+            {
+                "guideline_list": guideline_list,
+                "agent_intention_guidelines_list": agent_intention_guidelines_list,
+            },
         )
 
     def _format_shots(self, shots: Sequence[MessageGeneratorShot]) -> str:
@@ -487,11 +511,14 @@ To generate an optimal response that aligns with all guidelines and the current 
 
 PRIORITIZING INSTRUCTIONS (GUIDELINES VS. INSIGHTS)
 -----------------
-Deviating from an instruction (either guideline or insight) is acceptable only when the deviation arises from a deliberate prioritization, based on:
-    - Conflicts with a higher-priority guideline (according to their priority scores).
-    - Contradictions with a customer request.
-    - Lack of sufficient context or data.
-    - Conflicts with an insight (see below).
+Deviating from an instruction (either guideline or insight) is acceptable only when the deviation arises from a deliberate prioritization. 
+Consider the following valid reasons for such deviations:
+    - The instruction contradicts a customer request.
+    - The instruction lacks sufficient context or data to apply reliably.
+    - The instruction conflicts with an insight (see below).
+    - The instruction depends on an agent intention condition that does not apply in the current situation.
+    - When a guideline offers multiple options (e.g., "do X or Y") and another more specific guideline restricts one of those options (e.g., "don’t do X"), 
+    follow both by choosing the permitted alternative (i.e., do Y). 
 In all other cases, even if you believe that a guideline's condition does not apply, you must follow it.
 If fulfilling a guideline is not possible, explicitly justify why in your response.
 
@@ -613,7 +640,8 @@ Produce a valid JSON object in the following format: ###
                 "guidelines": actionable_guidelines,
             },
         )
-
+        with open("prompt_message_generator.txt", "w") as f:
+            f.write(builder.build())
         return builder
 
     def _format_missing_data(self, missing_data: Sequence[MissingToolData]) -> str:
@@ -756,7 +784,8 @@ Produce a valid JSON object in the following format: ###
             prompt=prompt,
             hints={"temperature": temperature},
         )
-
+        with open("output_message_generator.txt", "w") as f:
+            f.write(message_event_response.content.model_dump_json(indent=2))
         self._logger.debug(
             f"Completion:\n{message_event_response.content.model_dump_json(indent=2)}"
         )
@@ -927,6 +956,7 @@ example_2_expected = MessageSchema(
     guidelines=[
         "When the customer chooses and orders a burger, then provide it",
         "When the customer chooses specific ingredients on the burger, only provide those ingredients if we have them fresh in stock; otherwise, reject the order",
+        "Agent intention guideline: When the agent processes a new order, confirm with the customer the order details and the price",
     ],
     context_evaluation=ContextEvaluation(
         most_recent_customer_inquiries_or_needs="The customer ordered an American burger with cheese",
@@ -949,6 +979,12 @@ example_2_expected = MessageSchema(
             instruction="When the customer chooses specific ingredients on the burger, only provide those ingredients if we have them fresh in stock; otherwise, reject the order.",
             evaluation="The customer chose cheese on the burger, but all of the cheese we currently have is expired",
             data_available="The relevant stock availability is given in the tool calls' data. Our cheese has expired.",
+        ),
+        InstructionEvaluation(
+            number=3,
+            instruction="When the agent processes a new order, confirm with the customer the order details and the price",
+            evaluation="The agent is not going to process the order, so no need to make a confirmation",
+            data_available="No relevant data",
         ),
     ],
     revisions=[
@@ -1517,7 +1553,76 @@ example_9_expected = MessageSchema(
 
 example_9_shot = MessageGeneratorShot(
     description="Handling a frustrated customer when no options for assistance are available to the agent. Assume the agent works for a large electronic store, and that its role (as described in its prompt) is to assist potential customers. Assume the prompt did not specify a method for transferring customers to human representatives",
-    expected_result=example_7_expected,
+    expected_result=example_9_expected,
+)
+
+
+example_10_expected = MessageSchema(
+    last_message_of_customer=("I want to return my shoes, I purchased them a month ago"),
+    guidelines=[
+        "When the agent suggests refund options, suggest a refund either as website credit or to their credit card.",
+        "When the customer wants to return an item they purchased more than a week ago, do not suggest a refund to the credit card",
+    ],
+    context_evaluation=ContextEvaluation(
+        most_recent_customer_inquiries_or_needs="The customer wants to return their shoes",
+        parts_of_the_context_i_have_here_if_any_with_specific_information_on_how_to_address_these_needs="I can offer a return according to the guidelines",
+        topics_for_which_i_have_sufficient_information_and_can_therefore_help_with="I can refund the order to website credit",
+        what_i_do_not_have_enough_information_to_help_with_with_based_on_the_provided_information_that_i_have=None,
+        was_i_given_specific_information_here_on_how_to_address_some_of_these_specific_needs=True,
+        should_i_tell_the_customer_i_cannot_help_with_some_of_those_needs=False,
+    ),
+    insights=["The customer purchased the item over a week ago"],
+    evaluation_for_each_instruction=[
+        InstructionEvaluation(
+            number=1,
+            instruction="do not suggest a refund to the credit card",
+            evaluation="It's been purchased more than a week ago so can't offer return to credit card",
+            data_available="Not needed",
+        ),
+        InstructionEvaluation(
+            number=2,
+            instruction="suggest a refund either as website credit or to their credit card.",
+            evaluation="Refunds are usually to credit or card. Since this purchase was over a week ago, I’ll offer website credit",
+            data_available="Not needed",
+        ),
+        InstructionEvaluation(
+            number=3,
+            instruction="The customer purchased the item over a week ago",
+            evaluation="As mentioned by the user they purchased more than a week ago, so the more restrictive refund option should apply",
+            data_available="Not needed",
+        ),
+    ],
+    revisions=[
+        Revision(
+            revision_number=1,
+            content=(
+                "Sure, I can help with that.Since the shoes were purchased over a month ago, I can offer a refund in the form of website credit. Let me know if you’d like to proceed, or if you have any questions"
+            ),
+            factual_information_provided=[],
+            offered_services=[
+                OfferedServiceEvaluation(
+                    service="Do a refund",
+                    source="Guideline",
+                    is_source_based_in_this_prompt=True,
+                )
+            ],
+            instructions_followed=[
+                "#1; do not suggest a refund to the credit card",
+                "#2; suggest a refund either as website credit or to their credit card",
+                "#3; The customer purchased the item over a week ago",
+            ],
+            instructions_broken=[],
+            is_repeat_message=False,
+            followed_all_instructions=True,
+            all_facts_and_services_sourced_from_prompt=True,
+            further_revisions_required=False,
+        ),
+    ],
+)
+
+example_10_shot = MessageGeneratorShot(
+    description="Follow the more specific guideline when multiple guidelines apply to a situation, especially if one addresses a narrower scenario within the broader case",
+    expected_result=example_10_expected,
 )
 
 _baseline_shots: Sequence[MessageGeneratorShot] = [
@@ -1530,6 +1635,7 @@ _baseline_shots: Sequence[MessageGeneratorShot] = [
     example_7_shot,
     example_8_shot,
     example_9_shot,
+    example_10_shot,
 ]
 
 shot_collection = ShotCollection[MessageGeneratorShot](_baseline_shots)

--- a/src/parlant/core/engines/alpha/message_generator.py
+++ b/src/parlant/core/engines/alpha/message_generator.py
@@ -302,6 +302,7 @@ you don't need to specifically double-check if you followed or broke any guideli
             )
         guidelines = []
         agent_intention_guidelines = []
+
         for i, p in enumerate(all_matches, start=1):
             if p.guideline.content.action:
                 guideline = f"Guideline #{i}) When {p.guideline.content.condition}, then {p.guideline.content.action}"
@@ -319,8 +320,8 @@ When crafting your reply, you must follow the behavioral guidelines provided bel
 """
         if agent_intention_guidelines_list:
             guideline_instruction += f"""
-Some guidelines are tied to condition that related to you, the agent. These guidelines are considered relevant because it is likely that you intends to output
-a message that will trigger the associated condition. You should only follow these guidelines if you are actually going to output a message that activates the condition.
+Some guidelines are tied to conditions related to you, the agent. These guidelines are considered relevant because it is likely that you intend to produce a message that will trigger the associated condition.
+You should only follow these guidelines if you are actually going to produce a message that activates the condition.
 - **Guidelines with agent intention condition**:
 {agent_intention_guidelines_list}
 

--- a/src/parlant/core/engines/alpha/utterance_selector.py
+++ b/src/parlant/core/engines/alpha/utterance_selector.py
@@ -1046,6 +1046,7 @@ EXAMPLES
             template=self._get_guideline_matches_text(
                 ordinary_guideline_matches,
                 tool_enabled_guideline_matches,
+                guideline_representations,
             ),
             props={
                 "ordinary_guideline_matches": ordinary_guideline_matches,

--- a/src/parlant/core/engines/alpha/utterance_selector.py
+++ b/src/parlant/core/engines/alpha/utterance_selector.py
@@ -1113,8 +1113,7 @@ Produce a valid JSON object according to the following spec. Use the values prov
                 ],
             },
         )
-        with open("prompt_draft.txt", "w") as f:
-            f.write(builder.build())
+
         return builder
 
     def _get_draft_output_format(
@@ -1286,8 +1285,7 @@ Output a JSON object with three properties:
             prompt=draft_prompt,
             hints={"temperature": temperature},
         )
-        with open("output_utterance_draft.txt", "a") as f:
-            f.write(draft_response.content.model_dump_json(indent=2))
+
         self._logger.debug(
             f"Utterance Draft Completion:\n{draft_response.content.model_dump_json(indent=2)}"
         )
@@ -1324,8 +1322,7 @@ Output a JSON object with three properties:
             ),
             hints={"temperature": 0.1},
         )
-        with open("output_utterance_selection.txt", "a") as f:
-            f.write(selection_response.content.model_dump_json(indent=2))
+
         self._logger.debug(
             f"Utterance Selection Completion:\n{selection_response.content.model_dump_json(indent=2)}"
         )

--- a/src/parlant/core/guidelines.py
+++ b/src/parlant/core/guidelines.py
@@ -56,13 +56,6 @@ class Guideline:
     def __hash__(self) -> int:
         return hash(self.id)
 
-    @property
-    def internal_condition(self) -> str:
-        val = self.metadata.get("internal_condition")
-        if isinstance(val, str):
-            return val
-        return self.content.condition
-
 
 class GuidelineUpdateParams(TypedDict, total=False):
     condition: str

--- a/src/parlant/core/guidelines.py
+++ b/src/parlant/core/guidelines.py
@@ -58,11 +58,10 @@ class Guideline:
 
     @property
     def internal_condition(self) -> str:
-        return (
-            self.metadata["internal_condition"]
-            if self.metadata["internal_condition"]
-            else self.content.condition
-        )
+        val = self.metadata.get("internal_condition")
+        if isinstance(val, str):
+            return val
+        return self.content.condition
 
 
 class GuidelineUpdateParams(TypedDict, total=False):

--- a/src/parlant/core/guidelines.py
+++ b/src/parlant/core/guidelines.py
@@ -56,6 +56,14 @@ class Guideline:
     def __hash__(self) -> int:
         return hash(self.id)
 
+    @property
+    def internal_condition(self) -> str:
+        return (
+            self.metadata["internal_condition"]
+            if self.metadata["internal_condition"]
+            else self.content.condition
+        )
+
 
 class GuidelineUpdateParams(TypedDict, total=False):
     condition: str

--- a/src/parlant/core/services/indexing/behavioral_change_evaluation.py
+++ b/src/parlant/core/services/indexing/behavioral_change_evaluation.py
@@ -555,7 +555,7 @@ class GuidelineEvaluator:
                 "customer_dependent_action_data": payload_customer_dependent.model_dump()
                 if payload_customer_dependent
                 else None,
-                "internal_condition": agent_intention.rewritten_condition
+                "agent_intention_condition": agent_intention.rewritten_condition
                 if agent_intention
                 and agent_intention.rewritten_condition
                 and agent_intention.is_agent_intention

--- a/src/parlant/core/services/indexing/guideline_agent_intention_proposer.py
+++ b/src/parlant/core/services/indexing/guideline_agent_intention_proposer.py
@@ -68,11 +68,11 @@ class AgentIntentionProposer:
             template="""
 GENERAL INSTRUCTIONS
 -----------------
-In our system, the behavior of a conversational AI agent is guided by "guidelines". The agent makes use of these guidelines whenever it interacts with a user (also referred to as the customer).
+In our system, the behavior of a conversational AI agent is guided by "guidelines". You make use of these guidelines whenever it interacts with a user (also referred to as the customer).
 Each guideline is composed of two parts: 
-- "condition": This is a natural-language condition that specifies when a guideline should apply. We test against this condition to determine whether this guideline should be applied when generating the agent's next reply.
-- "action": This is a natural-language instruction that should be followed by the agent whenever the "condition" part of the guideline applies to the conversation in its particular state.
-Any instruction described here applies only to the agent, and not to the user.
+- "condition": This is a natural-language condition that specifies when a guideline should apply. We test against this condition to determine whether this guideline should be applied when generating your next reply.
+- "action": This is a natural-language instruction that should be followed by you whenever the "condition" part of the guideline applies to the conversation in its particular state.
+Any instruction described here applies only to you, and not to the user.
 
 """,
         )
@@ -82,18 +82,18 @@ Any instruction described here applies only to the agent, and not to the user.
             template="""
 TASK DESCRIPTION
 -----------------
-Your task is to determine whether a guideline condition reflects the agent’s intention. That is, whether it describes something the agent is doing or is about to do (e.g., "The agent discusses a patient's 
-medical record" or "The agent explains the conditions and terms"). Note: If the condition refers to something the agent has already done, it should not be considered an agent intention.
+Your task is to determine whether a guideline condition reflects your intention. That is, whether it describes something you are doing or is about to do (e.g., "You discusses a patient's 
+medical record" or "You explain the conditions and terms"). Note: If the condition refers to something you have already done, it should not be considered an agent intention.
 
-If the condition reflects agent intention, rephrase it to describe what the agent is likely to do next, using the following format:
-"The agent is likely to (do something)."
+If the condition reflects agent intention, rephrase it to describe what you are likely to do next, using the following format:
+"You are likely to (do something)."
 
 For example:
-Original: "The agent discusses a patient's medical record"
-Rewritten: "The agent is likely to discuss a patient's medical record"
+Original: "You discusses a patient's medical record"
+Rewritten: "You are likely to discuss a patient's medical record"
 
 Why this matters:
-Although the original condition can be written in present tense, guideline matching happens before the agent replies. So we need the condition to reflect the agent’s probable upcoming behavior, based on the customer's latest message.
+Although the original condition can be written in present tense, guideline matching happens before you reply. So we need the condition to reflect your probable upcoming behavior, based on the customer's latest message.
 
 
 
@@ -129,7 +129,7 @@ Expected output (JSON):
 {{
   "condition": "{condition}",
   "is_agent_intention": "<BOOL>",
-  "rewritten_condition": "<STR, include it is_agent_intention is True. Rewrite the condition in the format of "The agent is likely to (do something)" >",
+  "rewritten_condition": "<STR, include it is_agent_intention is True. Rewrite the condition in the format of "You are likely to (do something)" >",
 }}
 ```
 """,
@@ -173,7 +173,7 @@ Expected Response:
 
 
 example_1_guideline = GuidelineContent(
-    condition="The agent discusses a patient's medical record",
+    condition="You discuss a patient's medical record",
     action="Do not send any personal information",
 )
 example_1_shot = AgentIntentionProposerShot(
@@ -182,12 +182,12 @@ example_1_shot = AgentIntentionProposerShot(
     expected_result=AgentIntentionProposerSchema(
         condition=example_1_guideline.condition,
         is_agent_intention=True,
-        rewritten_condition="The agent is likely to discuss a patient's medical record",
+        rewritten_condition="You are likely to discuss a patient's medical record",
     ),
 )
 
 example_2_guideline = GuidelineContent(
-    condition="The agent intends to interpret a contract or legal term",
+    condition="You intend to interpret a contract or legal term",
     action="Add a disclaimer clarifying that the response is not legal advice",
 )
 example_2_shot = AgentIntentionProposerShot(
@@ -196,12 +196,12 @@ example_2_shot = AgentIntentionProposerShot(
     expected_result=AgentIntentionProposerSchema(
         condition=example_2_guideline.condition,
         is_agent_intention=True,
-        rewritten_condition="The agent is likely to interpret a contract or legal term",
+        rewritten_condition="You are likely to interpret a contract or legal term",
     ),
 )
 
 example_3_guideline = GuidelineContent(
-    condition="the agent just confirmed that the order will be shipped to the customer",
+    condition="You just confirmed that the order will be shipped to the customer",
     action="provide the package's tracking information",
 )
 example_3_shot = AgentIntentionProposerShot(
@@ -214,7 +214,7 @@ example_3_shot = AgentIntentionProposerShot(
 )
 
 example_4_guideline = GuidelineContent(
-    condition="The agent is likely to interpret a contract or legal term",
+    condition="You are likely to interpret a contract or legal term",
     action="Add a disclaimer clarifying that the response is not legal advice",
 )
 example_4_shot = AgentIntentionProposerShot(
@@ -223,7 +223,7 @@ example_4_shot = AgentIntentionProposerShot(
     expected_result=AgentIntentionProposerSchema(
         condition=example_4_guideline.condition,
         is_agent_intention=True,
-        rewritten_condition="The agent is likely to interpret a contract or legal term",
+        rewritten_condition="You are likely to interpret a contract or legal term",
     ),
 )
 

--- a/src/parlant/core/services/indexing/guideline_agent_intention_proposer.py
+++ b/src/parlant/core/services/indexing/guideline_agent_intention_proposer.py
@@ -82,8 +82,8 @@ Any instruction described here applies only to the agent, and not to the user.
             template="""
 TASK DESCRIPTION
 -----------------
-Your task is to determine whether a guideline condition describes the agent’s intention - that is, whether it refers to something the agent is doing or planning to do (e.g., "The agent discusses a patient's medical record" or "The agent 
-explains the conditions and terms"). Note: If the condition refers to something the agent has already done, it should not be considered an agent intention.
+Your task is to determine whether a guideline condition reflects the agent’s intention. That is, whether it describes something the agent is doing or is about to do (e.g., "The agent discusses a patient's 
+medical record" or "The agent explains the conditions and terms"). Note: If the condition refers to something the agent has already done, it should not be considered an agent intention.
 
 If the condition reflects agent intention, rephrase it to describe what the agent is likely to do next, using the following format:
 "The agent is likely to (do something)."
@@ -92,8 +92,9 @@ For example:
 Original: "The agent discusses a patient's medical record"
 Rewritten: "The agent is likely to discuss a patient's medical record"
 
-Why:
-Although the condition is written in the present tense, we evaluate whether it applies before the agent's next message. Therefore, we want the phrasing to reflect the agent’s probable next action, based on the current customer message.
+Why this matters:
+Although the original condition can be written in present tense, guideline matching happens before the agent replies. So we need the condition to reflect the agent’s probable upcoming behavior, based on the customer's latest message.
+
 
 
 
@@ -219,19 +220,32 @@ example_4_guideline = GuidelineContent(
 )
 example_4_shot = AgentIntentionShot(
     description="",
-    guideline=example_3_guideline,
+    guideline=example_4_guideline,
     expected_result=AgentIntentionSchema(
-        condition=example_3_guideline.condition,
+        condition=example_4_guideline.condition,
         is_agent_intention=True,
         rewritten_condition="The agent is likely to interpret a contract or legal term",
     ),
 )
 
+example_5_guideline = GuidelineContent(
+    condition="The customer is asking about the opening hours",
+    action="Provide our opening hours as described on out website",
+)
+example_5_shot = AgentIntentionShot(
+    description="",
+    guideline=example_5_guideline,
+    expected_result=AgentIntentionSchema(
+        condition=example_5_guideline.condition,
+        is_agent_intention=False,
+    ),
+)
 _baseline_shots: Sequence[AgentIntentionShot] = [
     example_1_shot,
     example_2_shot,
     example_3_shot,
     example_4_shot,
+    example_5_shot,
 ]
 
 shot_collection = ShotCollection[AgentIntentionShot](_baseline_shots)

--- a/src/parlant/core/services/indexing/guideline_agent_intention_proposer.py
+++ b/src/parlant/core/services/indexing/guideline_agent_intention_proposer.py
@@ -223,7 +223,7 @@ example_4_shot = AgentIntentionShot(
     expected_result=AgentIntentionSchema(
         condition=example_3_guideline.condition,
         is_agent_intention=True,
-        rewritten_condition="Add a disclaimer clarifying that the response is not legal advice",
+        rewritten_condition="The agent is likely to interpret a contract or legal term",
     ),
 )
 

--- a/src/parlant/core/services/indexing/guideline_agent_intention_proposer.py
+++ b/src/parlant/core/services/indexing/guideline_agent_intention_proposer.py
@@ -16,23 +16,23 @@ class AgentIntentionProposition(DefaultBaseModel):
     rewritten_condition: Optional[str] = ""
 
 
-class AgentIntentionSchema(DefaultBaseModel):
+class AgentIntentionProposerSchema(DefaultBaseModel):
     condition: str
     is_agent_intention: bool
     rewritten_condition: Optional[str] = ""
 
 
 @dataclass
-class AgentIntentionShot(Shot):
+class AgentIntentionProposerShot(Shot):
     guideline: GuidelineContent
-    expected_result: AgentIntentionSchema
+    expected_result: AgentIntentionProposerSchema
 
 
 class AgentIntentionProposer:
     def __init__(
         self,
         logger: Logger,
-        schematic_generator: SchematicGenerator[AgentIntentionSchema],
+        schematic_generator: SchematicGenerator[AgentIntentionProposerSchema],
         service_registry: ServiceRegistry,
     ) -> None:
         self._logger = logger
@@ -59,7 +59,7 @@ class AgentIntentionProposer:
         )
 
     async def _build_prompt(
-        self, guideline: GuidelineContent, shots: Sequence[AgentIntentionShot]
+        self, guideline: GuidelineContent, shots: Sequence[AgentIntentionProposerShot]
     ) -> PromptBuilder:
         builder = PromptBuilder()
 
@@ -141,7 +141,7 @@ Expected output (JSON):
     async def _generate_agent_intention(
         self,
         guideline: GuidelineContent,
-    ) -> AgentIntentionSchema:
+    ) -> AgentIntentionProposerSchema:
         prompt = await self._build_prompt(guideline, _baseline_shots)
 
         response = await self._schematic_generator.generate(
@@ -156,7 +156,7 @@ Expected output (JSON):
             f.write(response.content.model_dump_json(indent=2))
         return response.content
 
-    def _format_shots(self, shots: Sequence[AgentIntentionShot]) -> str:
+    def _format_shots(self, shots: Sequence[AgentIntentionProposerShot]) -> str:
         return "\n".join(
             [
                 f"""Example {i}: {shot.description}
@@ -177,10 +177,10 @@ example_1_guideline = GuidelineContent(
     condition="The agent discusses a patient's medical record",
     action="Do not send any personal information",
 )
-example_1_shot = AgentIntentionShot(
+example_1_shot = AgentIntentionProposerShot(
     description="",
     guideline=example_1_guideline,
-    expected_result=AgentIntentionSchema(
+    expected_result=AgentIntentionProposerSchema(
         condition=example_1_guideline.condition,
         is_agent_intention=True,
         rewritten_condition="The agent is likely to discuss a patient's medical record",
@@ -191,10 +191,10 @@ example_2_guideline = GuidelineContent(
     condition="The agent intends to interpret a contract or legal term",
     action="Add a disclaimer clarifying that the response is not legal advice",
 )
-example_2_shot = AgentIntentionShot(
+example_2_shot = AgentIntentionProposerShot(
     description="",
     guideline=example_2_guideline,
-    expected_result=AgentIntentionSchema(
+    expected_result=AgentIntentionProposerSchema(
         condition=example_2_guideline.condition,
         is_agent_intention=True,
         rewritten_condition="The agent is likely to interpret a contract or legal term",
@@ -205,10 +205,10 @@ example_3_guideline = GuidelineContent(
     condition="the agent just confirmed that the order will be shipped to the customer",
     action="provide the package's tracking information",
 )
-example_3_shot = AgentIntentionShot(
+example_3_shot = AgentIntentionProposerShot(
     description="",
     guideline=example_3_guideline,
-    expected_result=AgentIntentionSchema(
+    expected_result=AgentIntentionProposerSchema(
         condition=example_3_guideline.condition,
         is_agent_intention=False,
     ),
@@ -218,10 +218,10 @@ example_4_guideline = GuidelineContent(
     condition="The agent is likely to interpret a contract or legal term",
     action="Add a disclaimer clarifying that the response is not legal advice",
 )
-example_4_shot = AgentIntentionShot(
+example_4_shot = AgentIntentionProposerShot(
     description="",
     guideline=example_4_guideline,
-    expected_result=AgentIntentionSchema(
+    expected_result=AgentIntentionProposerSchema(
         condition=example_4_guideline.condition,
         is_agent_intention=True,
         rewritten_condition="The agent is likely to interpret a contract or legal term",
@@ -232,15 +232,15 @@ example_5_guideline = GuidelineContent(
     condition="The customer is asking about the opening hours",
     action="Provide our opening hours as described on out website",
 )
-example_5_shot = AgentIntentionShot(
+example_5_shot = AgentIntentionProposerShot(
     description="",
     guideline=example_5_guideline,
-    expected_result=AgentIntentionSchema(
+    expected_result=AgentIntentionProposerSchema(
         condition=example_5_guideline.condition,
         is_agent_intention=False,
     ),
 )
-_baseline_shots: Sequence[AgentIntentionShot] = [
+_baseline_shots: Sequence[AgentIntentionProposerShot] = [
     example_1_shot,
     example_2_shot,
     example_3_shot,
@@ -248,4 +248,4 @@ _baseline_shots: Sequence[AgentIntentionShot] = [
     example_5_shot,
 ]
 
-shot_collection = ShotCollection[AgentIntentionShot](_baseline_shots)
+shot_collection = ShotCollection[AgentIntentionProposerShot](_baseline_shots)

--- a/src/parlant/core/services/indexing/guideline_agent_intention_proposer.py
+++ b/src/parlant/core/services/indexing/guideline_agent_intention_proposer.py
@@ -152,8 +152,7 @@ Expected output (JSON):
             self._logger.warning("Completion:\nNo checks generated! This shouldn't happen.")
         else:
             self._logger.debug(f"Completion:\n{response.content.model_dump_json(indent=2)}")
-        with open("output_agent_intention.txt", "a") as f:
-            f.write(response.content.model_dump_json(indent=2))
+
         return response.content
 
     def _format_shots(self, shots: Sequence[AgentIntentionProposerShot]) -> str:

--- a/src/parlant/core/services/indexing/guideline_agent_intention_proposer.py
+++ b/src/parlant/core/services/indexing/guideline_agent_intention_proposer.py
@@ -1,0 +1,237 @@
+from dataclasses import dataclass
+import json
+from typing import Optional, Sequence
+from parlant.core.common import DefaultBaseModel
+from parlant.core.engines.alpha.prompt_builder import PromptBuilder
+from parlant.core.guidelines import GuidelineContent
+from parlant.core.loggers import Logger
+from parlant.core.nlp.generation import SchematicGenerator
+from parlant.core.services.indexing.common import ProgressReport
+from parlant.core.services.tools.service_registry import ServiceRegistry
+from parlant.core.shots import Shot, ShotCollection
+
+
+class AgentIntentionProposition(DefaultBaseModel):
+    is_agent_intention: bool
+    rewritten_condition: Optional[str] = ""
+
+
+class AgentIntentionSchema(DefaultBaseModel):
+    condition: str
+    is_agent_intention: bool
+    rewritten_condition: Optional[str] = ""
+
+
+@dataclass
+class AgentIntentionShot(Shot):
+    guideline: GuidelineContent
+    expected_result: AgentIntentionSchema
+
+
+class AgentIntentionProposer:
+    def __init__(
+        self,
+        logger: Logger,
+        schematic_generator: SchematicGenerator[AgentIntentionSchema],
+        service_registry: ServiceRegistry,
+    ) -> None:
+        self._logger = logger
+        self._schematic_generator = schematic_generator
+        self._service_registry = service_registry
+
+    async def propose_agent_intention(
+        self,
+        guideline: GuidelineContent,
+        progress_report: Optional[ProgressReport] = None,
+    ) -> AgentIntentionProposition:
+        if progress_report:
+            await progress_report.stretch(1)
+
+        with self._logger.scope("AgentIntentionProposer"):
+            proposition = await self._generate_agent_intention(guideline)
+
+        if progress_report:
+            await progress_report.increment(1)
+
+        return AgentIntentionProposition(
+            is_agent_intention=proposition.is_agent_intention,
+            rewritten_condition=proposition.rewritten_condition,
+        )
+
+    async def _build_prompt(
+        self, guideline: GuidelineContent, shots: Sequence[AgentIntentionShot]
+    ) -> PromptBuilder:
+        builder = PromptBuilder()
+
+        builder.add_section(
+            name="agent-intention-general-instructions",
+            template="""
+GENERAL INSTRUCTIONS
+-----------------
+In our system, the behavior of a conversational AI agent is guided by "guidelines". The agent makes use of these guidelines whenever it interacts with a user (also referred to as the customer).
+Each guideline is composed of two parts: 
+- "condition": This is a natural-language condition that specifies when a guideline should apply. We test against this condition to determine whether this guideline should be applied when generating the agent's next reply.
+- "action": This is a natural-language instruction that should be followed by the agent whenever the "condition" part of the guideline applies to the conversation in its particular state.
+Any instruction described here applies only to the agent, and not to the user.
+
+""",
+        )
+
+        builder.add_section(
+            name="agent-intention-task-description",
+            template="""
+TASK DESCRIPTION
+-----------------
+Your task is to determine whether a guideline condition describes the agent’s intention - that is, whether it refers to something the agent is doing or planning to do (e.g., "The agent discusses a patient's medical record" or "The agent 
+explains the conditions and terms"). Note: If the condition refers to something the agent has already done, it should not be considered an agent intention.
+
+If the condition reflects agent intention, rephrase it to describe what the agent is likely to do next, using the following format:
+"The agent is likely to (do something)."
+
+For example:
+Original: "The agent discusses a patient's medical record"
+Rewritten: "The agent is likely to discuss a patient's medical record"
+
+Why:
+Although the condition is written in the present tense, we evaluate whether it applies before the agent's next message. Therefore, we want the phrasing to reflect the agent’s probable next action, based on the current customer message.
+
+
+
+""",
+        )
+        builder.add_section(
+            name="agent-intention-shots",
+            template="""
+EXAMPLES
+-----------
+{shots_text}""",
+            props={"shots_text": self._format_shots(shots)},
+        )
+        builder.add_section(
+            name="agent-intention-guideline",
+            template="""
+GUIDELINE
+-----------
+condition: {condition}
+action: {action}
+""",
+            props={"condition": guideline.condition, "action": guideline.action},
+        )
+
+        builder.add_section(
+            name="guideline-action-proposer-output-format",
+            template="""OUTPUT FORMAT
+-----------
+Use the following format to evaluate whether the guideline has a customer dependent action:
+Expected output (JSON):
+```json
+{{
+  "condition": "{condition}",
+  "is_agent_intention": "<BOOL>",
+  "rewritten_condition": "<STR, include it is_agent_intention is True. Rewrite the condition in the format of "The agent is likely to (do something)" >",
+}}
+```
+""",
+            props={"condition": guideline.condition},
+        )
+
+        return builder
+
+    async def _generate_agent_intention(
+        self,
+        guideline: GuidelineContent,
+    ) -> AgentIntentionSchema:
+        prompt = await self._build_prompt(guideline, _baseline_shots)
+
+        response = await self._schematic_generator.generate(
+            prompt=prompt,
+            hints={"temperature": 0.0},
+        )
+        if not response.content:
+            self._logger.warning("Completion:\nNo checks generated! This shouldn't happen.")
+        else:
+            self._logger.debug(f"Completion:\n{response.content.model_dump_json(indent=2)}")
+        with open("output_agent_intention.txt", "a") as f:
+            f.write(response.content.model_dump_json(indent=2))
+        return response.content
+
+    def _format_shots(self, shots: Sequence[AgentIntentionShot]) -> str:
+        return "\n".join(
+            [
+                f"""Example {i}: {shot.description}
+Guideline:
+    Condition: {shot.guideline.condition}
+    Action: {shot.guideline.action}
+
+Expected Response:
+{json.dumps(shot.expected_result.model_dump(mode="json", exclude_unset=True), indent=2)}
+###
+"""
+                for i, shot in enumerate(shots, start=1)
+            ]
+        )
+
+
+example_1_guideline = GuidelineContent(
+    condition="The agent discusses a patient's medical record",
+    action="Do not send any personal information",
+)
+example_1_shot = AgentIntentionShot(
+    description="",
+    guideline=example_1_guideline,
+    expected_result=AgentIntentionSchema(
+        condition=example_1_guideline.condition,
+        is_agent_intention=True,
+        rewritten_condition="The agent is likely to discuss a patient's medical record",
+    ),
+)
+
+example_2_guideline = GuidelineContent(
+    condition="The agent intends to interpret a contract or legal term",
+    action="Add a disclaimer clarifying that the response is not legal advice",
+)
+example_2_shot = AgentIntentionShot(
+    description="",
+    guideline=example_2_guideline,
+    expected_result=AgentIntentionSchema(
+        condition=example_2_guideline.condition,
+        is_agent_intention=True,
+        rewritten_condition="The agent is likely to interpret a contract or legal term",
+    ),
+)
+
+example_3_guideline = GuidelineContent(
+    condition="the agent just confirmed that the order will be shipped to the customer",
+    action="provide the package's tracking information",
+)
+example_3_shot = AgentIntentionShot(
+    description="",
+    guideline=example_3_guideline,
+    expected_result=AgentIntentionSchema(
+        condition=example_3_guideline.condition,
+        is_agent_intention=False,
+    ),
+)
+
+example_4_guideline = GuidelineContent(
+    condition="The agent is likely to interpret a contract or legal term",
+    action="Add a disclaimer clarifying that the response is not legal advice",
+)
+example_4_shot = AgentIntentionShot(
+    description="",
+    guideline=example_3_guideline,
+    expected_result=AgentIntentionSchema(
+        condition=example_3_guideline.condition,
+        is_agent_intention=True,
+        rewritten_condition="Add a disclaimer clarifying that the response is not legal advice",
+    ),
+)
+
+_baseline_shots: Sequence[AgentIntentionShot] = [
+    example_1_shot,
+    example_2_shot,
+    example_3_shot,
+    example_4_shot,
+]
+
+shot_collection = ShotCollection[AgentIntentionShot](_baseline_shots)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -103,6 +103,10 @@ from parlant.core.services.indexing.guideline_action_proposer import (
     GuidelineActionProposer,
     GuidelineActionPropositionSchema,
 )
+from parlant.core.services.indexing.guideline_agent_intention_proposer import (
+    AgentIntentionProposer,
+    AgentIntentionSchema,
+)
 from parlant.core.services.indexing.guideline_continuous_proposer import (
     GuidelineContinuousProposer,
     GuidelineContinuousPropositionSchema,
@@ -370,6 +374,7 @@ async def container(
             GuidelineContinuousPropositionSchema,
             CustomerDependentActionSchema,
             GenericResponseAnalysisSchema,
+            AgentIntentionSchema,
         ):
             container[SchematicGenerator[generation_schema]] = await make_schematic_generator(  # type: ignore
                 container,
@@ -405,7 +410,7 @@ async def container(
         container[GuidelineActionProposer] = Singleton(GuidelineActionProposer)
         container[GuidelineContinuousProposer] = Singleton(GuidelineContinuousProposer)
         container[CustomerDependentActionDetector] = Singleton(CustomerDependentActionDetector)
-
+        container[AgentIntentionProposer] = Singleton(AgentIntentionProposer)
         container[LocalToolService] = cast(
             LocalToolService,
             await container[ServiceRegistry].update_tool_service(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -105,7 +105,7 @@ from parlant.core.services.indexing.guideline_action_proposer import (
 )
 from parlant.core.services.indexing.guideline_agent_intention_proposer import (
     AgentIntentionProposer,
-    AgentIntentionSchema,
+    AgentIntentionProposerSchema,
 )
 from parlant.core.services.indexing.guideline_continuous_proposer import (
     GuidelineContinuousProposer,
@@ -374,7 +374,7 @@ async def container(
             GuidelineContinuousPropositionSchema,
             CustomerDependentActionSchema,
             GenericResponseAnalysisSchema,
-            AgentIntentionSchema,
+            AgentIntentionProposerSchema,
         ):
             container[SchematicGenerator[generation_schema]] = await make_schematic_generator(  # type: ignore
                 container,

--- a/tests/core/stable/engines/alpha/features/baseline/conversation.feature
+++ b/tests/core/stable/engines/alpha/features/baseline/conversation.feature
@@ -147,9 +147,9 @@ Feature: Conversation
     Scenario: The agent follows a regular guideline when it overrides an agent intention guideline 2
         Given an agent
         And an empty session
-        Given a guideline to recommend on either pineapple or pepperoni when the agent recommends on pizza toppings
-        Given a guideline to recommend only on the recommended vegetarian toppings options when the agent recommends on pizza topping and the customer is vegetarian
-        And a customer message, "Hi, I want to buy pizza. What do you recommend? I'm vegetarian."
+        Given a guideline to recommend on our recommended toppings - either pineapple or pepperoni when the agent recommends on pizza toppings
+        Given a guideline to recommend on our vegetarian recommended toppings when the customer asks about topping recommendation and the customer is from India
+        And a customer message, "Hi, I want to buy pizza. What do you recommend? I'm from India if it matters."
         When processing is triggered
         Then a single message event is emitted
         And the message contains a recommendation only on pineapple as topping  
@@ -168,8 +168,8 @@ Feature: Conversation
     Scenario: The agent follows an agent intention guideline when it overrides an agent intention guideline 2
         Given an agent
         And an empty session
-        Given a guideline to recommend on either pineapple or pepperoni when the agent recommends on pizza toppings
-        Given a guideline to recommend only on the recommended vegetarian toppings options when the agent recommends on pizza topping and the customer is vegetarian
+        Given a guideline to recommend on our recommended toppings - either pineapple or pepperoni when the agent recommends on pizza toppings
+        Given a guideline to recommend on our vegetarian recommended toppings when the customer asks about topping recommendation and the customer is from India
         And a customer message, "Hi, I want to buy pizza. What do you recommend? I'm vegetarian."
         When processing is triggered
         Then a single message event is emitted

--- a/tests/core/stable/engines/alpha/features/baseline/conversation.feature
+++ b/tests/core/stable/engines/alpha/features/baseline/conversation.feature
@@ -148,7 +148,7 @@ Feature: Conversation
         Given an agent
         And an empty session
         Given a guideline to recommend on our recommended toppings - either pineapple or pepperoni when the agent recommends on pizza toppings
-        Given a guideline to recommend on our vegetarian recommended toppings when the customer asks about topping recommendation and the customer is from India
+        Given a guideline to recommend from our vegetarian recommended toppings when the customer asks about topping recommendation and the customer is from India
         And a customer message, "Hi, I want to buy pizza. What do you recommend? I'm from India if it matters."
         When processing is triggered
         Then a single message event is emitted
@@ -169,7 +169,7 @@ Feature: Conversation
         Given an agent
         And an empty session
         Given a guideline to recommend on our recommended toppings - either pineapple or pepperoni when the agent recommends on pizza toppings
-        Given a guideline to recommend on our vegetarian recommended toppings when the customer asks about topping recommendation and the customer is from India
+        Given a guideline to recommend from our vegetarian recommended toppings when the customer asks about topping recommendation and the customer is from India
         And a customer message, "Hi, I want to buy pizza. What do you recommend? I'm vegetarian."
         When processing is triggered
         Then a single message event is emitted

--- a/tests/core/stable/engines/alpha/features/baseline/conversation.feature
+++ b/tests/core/stable/engines/alpha/features/baseline/conversation.feature
@@ -109,3 +109,70 @@ Feature: Conversation
         When processing is triggered
         Then a single message event is emitted
         And the message contains no specific information about how to reach out, like a phone number or an exact address. 
+
+    Scenario: The agent follows a guideline with agent intention 
+        Given an agent
+        And an empty session
+        Given a guideline to do not provide any personal medical information even if you have it when the agent discusses a patient's medical record
+        And a customer named "Alex Smith"
+        And an empty session with "Alex Smith"
+        And a context variable "medical_record" set to "Amoxicillin and Lisinopril" for "Alex Smith" 
+        And a customer message, "Hi, I need to know what medications I was prescribed during my visit last month. Can you pull up my medical record?"
+        When processing is triggered
+        Then a single message event is emitted
+        And the message contains no prescription of medications 
+        And the message contains explanation that can't provide personal medical information
+
+    Scenario: The agent ignores a matched agent intention guideline when the agent doesn't intend to do its condition
+        Given an agent
+        And an empty session
+        Given a guideline to remind that we have a special sale if they book today when the agent recommends on flights options
+        Given a guideline to suggest only ground based travel options when the customer asks about travel options
+        And a customer message, "Hi, I want to go to California from New york next week. What are my options?"
+        When processing is triggered
+        Then a single message event is emitted
+        And the message contains a suggestion to travel with bus or train but not with a flight
+        And the message contains no sale option
+
+    Scenario: The agent follows a regular guideline when it overrides an agent intention guideline
+        Given an agent
+        And an empty session
+        Given a guideline to suggest direct flights when the agent recommends on travel options
+        Given a guideline to suggest only ground-based travel options when the customer asks about domestic US travel options 
+        And a customer message, "Hi, I want to go to California from New york next week. What are my options?"
+        When processing is triggered
+        Then a single message event is emitted
+        And the message contains a suggestion to travel with ground-based travel options but not with a flight
+
+    Scenario: The agent follows a regular guideline when it overrides an agent intention guideline 2
+        Given an agent
+        And an empty session
+        Given a guideline to recommend on either pineapple or pepperoni when the agent recommends on pizza toppings
+        Given a guideline to recommend only on the vegetarian toppings options when the customer asks for pizza topping recommendation and they are vegetarian
+        And a customer message, "Hi, I want to buy pizza. What do you recommend? I'm vegetarian."
+        When processing is triggered
+        Then a single message event is emitted
+        And the message contains a recommendation only on pineapple as topping  
+
+    Scenario: The agent follows an agent intention guideline when it overrides an agent intention guideline
+        Given an agent
+        And an empty session
+        Given a guideline to suggest direct flights when the agent recommends on travel options
+        Given a guideline to suggest only ground-based travel options when the agent recommends on domestic US travel options 
+        And a customer message, "Hi, I want to go to California from New york next week. What are my options?"
+        When processing is triggered
+        Then a single message event is emitted
+        And the message contains a suggestion to travel with ground-based travel options but not with a flight
+
+    Scenario: The agent follows an agent intention guideline when it overrides an agent intention guideline 2
+        Given an agent
+        And an empty session
+        Given a guideline to recommend on either pineapple or pepperoni when the agent recommends on pizza toppings
+        Given a guideline to recommend only on the vegetarian toppings options when the agent recommends on pizza topping and the customer is vegetarian
+        And a customer message, "Hi, I want to buy pizza. What do you recommend? I'm vegetarian."
+        When processing is triggered
+        Then a single message event is emitted
+        And the message contains a recommendation on pineapple pizza only
+        And the message contains no recommendation on pepperoni pizza 
+
+    

--- a/tests/core/stable/engines/alpha/features/baseline/conversation.feature
+++ b/tests/core/stable/engines/alpha/features/baseline/conversation.feature
@@ -137,7 +137,7 @@ Feature: Conversation
     Scenario: The agent follows a regular guideline when it overrides an agent intention guideline
         Given an agent
         And an empty session
-        Given a guideline to suggest direct flights when the agent recommends on travel options
+        Given a guideline to suggest direct flights or ground-based transportation when the agent recommends on travel options
         Given a guideline to suggest only ground-based travel options when the customer asks about domestic US travel options 
         And a customer message, "Hi, I want to go to California from New york next week. What are my options?"
         When processing is triggered
@@ -148,16 +148,17 @@ Feature: Conversation
         Given an agent
         And an empty session
         Given a guideline to recommend on either pineapple or pepperoni when the agent recommends on pizza toppings
-        Given a guideline to recommend only on the vegetarian toppings options when the customer asks for pizza topping recommendation and they are vegetarian
+        Given a guideline to recommend only on the recommended vegetarian toppings options when the agent recommends on pizza topping and the customer is vegetarian
         And a customer message, "Hi, I want to buy pizza. What do you recommend? I'm vegetarian."
         When processing is triggered
         Then a single message event is emitted
         And the message contains a recommendation only on pineapple as topping  
+        And the message contains no recommendation on pepperoni pizza 
 
     Scenario: The agent follows an agent intention guideline when it overrides an agent intention guideline
         Given an agent
         And an empty session
-        Given a guideline to suggest direct flights when the agent recommends on travel options
+        Given a guideline to suggest direct flights or ground-based transportation when the agent recommends on travel options
         Given a guideline to suggest only ground-based travel options when the agent recommends on domestic US travel options 
         And a customer message, "Hi, I want to go to California from New york next week. What are my options?"
         When processing is triggered
@@ -168,11 +169,11 @@ Feature: Conversation
         Given an agent
         And an empty session
         Given a guideline to recommend on either pineapple or pepperoni when the agent recommends on pizza toppings
-        Given a guideline to recommend only on the vegetarian toppings options when the agent recommends on pizza topping and the customer is vegetarian
+        Given a guideline to recommend only on the recommended vegetarian toppings options when the agent recommends on pizza topping and the customer is vegetarian
         And a customer message, "Hi, I want to buy pizza. What do you recommend? I'm vegetarian."
         When processing is triggered
         Then a single message event is emitted
-        And the message contains a recommendation on pineapple pizza only
+        And the message contains a recommendation only on pineapple as topping  
         And the message contains no recommendation on pepperoni pizza 
 
     

--- a/tests/core/stable/engines/alpha/features/baseline/conversation.feature
+++ b/tests/core/stable/engines/alpha/features/baseline/conversation.feature
@@ -113,7 +113,7 @@ Feature: Conversation
     Scenario: The agent follows a guideline with agent intention 
         Given an agent
         And an empty session
-        Given a guideline to do not provide any personal medical information even if you have it when the agent discusses a patient's medical record
+        Given a guideline to do not provide any personal medical information even if you have it when you discusses a patient's medical record
         And a customer named "Alex Smith"
         And an empty session with "Alex Smith"
         And a context variable "medical_record" set to "Amoxicillin and Lisinopril" for "Alex Smith" 
@@ -123,10 +123,10 @@ Feature: Conversation
         And the message contains no prescription of medications 
         And the message contains explanation that can't provide personal medical information
 
-    Scenario: The agent ignores a matched agent intention guideline when the agent doesn't intend to do its condition
+    Scenario: The agent ignores a matched agent intention guideline when you doesn't intend to do its condition
         Given an agent
         And an empty session
-        Given a guideline to remind that we have a special sale if they book today when the agent recommends on flights options
+        Given a guideline to remind that we have a special sale if they book today when you recommends on flights options
         Given a guideline to suggest only ground based travel options when the customer asks about travel options
         And a customer message, "Hi, I want to go to California from New york next week. What are my options?"
         When processing is triggered
@@ -137,7 +137,7 @@ Feature: Conversation
     Scenario: The agent follows a regular guideline when it overrides an agent intention guideline
         Given an agent
         And an empty session
-        Given a guideline to suggest direct flights or ground-based transportation when the agent recommends on travel options
+        Given a guideline to suggest direct flights or ground-based transportation when you recommends on travel options
         Given a guideline to suggest only ground-based travel options when the customer asks about domestic US travel options 
         And a customer message, "Hi, I want to go to California from New york next week. What are my options?"
         When processing is triggered
@@ -147,7 +147,7 @@ Feature: Conversation
     Scenario: The agent follows a regular guideline when it overrides an agent intention guideline 2
         Given an agent
         And an empty session
-        Given a guideline to recommend on our recommended toppings - either pineapple or pepperoni when the agent recommends on pizza toppings
+        Given a guideline to recommend on our recommended toppings - either pineapple or pepperoni when you recommends on pizza toppings
         Given a guideline to recommend from our vegetarian recommended toppings when the customer asks about topping recommendation and the customer is from India
         And a customer message, "Hi, I want to buy pizza. What do you recommend? I'm from India if it matters."
         When processing is triggered
@@ -158,8 +158,8 @@ Feature: Conversation
     Scenario: The agent follows an agent intention guideline when it overrides an agent intention guideline
         Given an agent
         And an empty session
-        Given a guideline to suggest direct flights or ground-based transportation when the agent recommends on travel options
-        Given a guideline to suggest only ground-based travel options when the agent recommends on domestic US travel options 
+        Given a guideline to suggest direct flights or ground-based transportation when you recommends on travel options
+        Given a guideline to suggest only ground-based travel options when you recommends on domestic US travel options 
         And a customer message, "Hi, I want to go to California from New york next week. What are my options?"
         When processing is triggered
         Then a single message event is emitted
@@ -168,7 +168,7 @@ Feature: Conversation
     Scenario: The agent follows an agent intention guideline when it overrides an agent intention guideline 2
         Given an agent
         And an empty session
-        Given a guideline to recommend on our recommended toppings - either pineapple or pepperoni when the agent recommends on pizza toppings
+        Given a guideline to recommend on our recommended toppings - either pineapple or pepperoni when you recommends on pizza toppings
         Given a guideline to recommend from our vegetarian recommended toppings when the customer asks about topping recommendation and the customer is from India
         And a customer message, "Hi, I want to buy pizza. What do you recommend? I'm vegetarian."
         When processing is triggered

--- a/tests/core/stable/engines/alpha/features/baseline/fluid_utterances.feature
+++ b/tests/core/stable/engines/alpha/features/baseline/fluid_utterances.feature
@@ -224,7 +224,7 @@ Feature: Fluid Utterance
 
     Scenario: The agent follows a regular guideline when it overrides an agent intention guideline 2 (fluid utterance)
         Given a guideline to recommend on either pineapple or pepperoni when the agent recommends on pizza toppings
-        Given a guideline to recommend only on the recommended vegetarian toppings options when the customer asks about topping recommendation and the customer is from India
+        Given a guideline to recommend only from the recommended vegetarian toppings options when the customer asks about topping recommendation and the customer is from India
         And that the agent uses the fluid_utterance message composition mode
         And a customer message, "Hi, I want to buy pizza. What do you recommend? I'm from India if it matters."
         And an utterance, "I recommend on {{generative.answer}}."
@@ -246,7 +246,7 @@ Feature: Fluid Utterance
 
     Scenario: The agent follows an agent intention guideline when it overrides an agent intention guideline 2 (fluid utterance)
         Given a guideline to recommend on either pineapple or pepperoni when the agent recommends on pizza toppings
-        Given a guideline to recommend only on the vegetarian toppings options when the agent recommends on pizza topping and the customer is from India
+        Given a guideline to recommend only from the vegetarian toppings options when the agent recommends on pizza topping and the customer is from India
         And that the agent uses the fluid_utterance message composition mode
         And a customer message, "Hi, I want to buy pizza. What do you recommend? I'm from India if it matters."
         And an utterance, "I recommend on {{generative.answer}}."

--- a/tests/core/stable/engines/alpha/features/baseline/fluid_utterances.feature
+++ b/tests/core/stable/engines/alpha/features/baseline/fluid_utterances.feature
@@ -5,190 +5,190 @@ Feature: Fluid Utterance
         And that the agent uses the fluid_utterance message composition mode
         And an empty session
 
-    # Scenario: The agent greets the customer (fluid utterance)
-    #     Given a guideline to greet with 'Howdy' when the session starts
-    #     When processing is triggered
-    #     Then a status event is emitted, acknowledging event -1
-    #     And a status event is emitted, processing event -1
-    #     And a status event is emitted, typing in response to event -1
-    #     And a single message event is emitted
-    #     And the message contains a 'Howdy' greeting
-    #     And a status event is emitted, ready for further engagement after reacting to event -1
+    Scenario: The agent greets the customer (fluid utterance)
+        Given a guideline to greet with 'Howdy' when the session starts
+        When processing is triggered
+        Then a status event is emitted, acknowledging event -1
+        And a status event is emitted, processing event -1
+        And a status event is emitted, typing in response to event -1
+        And a single message event is emitted
+        And the message contains a 'Howdy' greeting
+        And a status event is emitted, ready for further engagement after reacting to event -1
 
-    # Scenario: Responding based on data the user is providing (fluid utterance)
-    #     Given a customer message, "I say that a banana is green, and an apple is purple. What did I say was the color of a banana?"
-    #     And an utterance, "Sorry, I do not know"
-    #     And an utterance, "The answer is {{generative.answer}}"
-    #     When messages are emitted
-    #     Then the message doesn't contain the text "I do not know"
-    #     And the message mentions the color green
+    Scenario: Responding based on data the user is providing (fluid utterance)
+        Given a customer message, "I say that a banana is green, and an apple is purple. What did I say was the color of a banana?"
+        And an utterance, "Sorry, I do not know"
+        And an utterance, "The answer is {{generative.answer}}"
+        When messages are emitted
+        Then the message doesn't contain the text "I do not know"
+        And the message mentions the color green
 
-    # Scenario: Reverting to fluid generation when a full utterance match isn't found (fluid utterance)
-    #     Given a customer message, "I say that a banana is green, and an apple is purple. What did I say was the color of a banana?"
-    #     And an utterance, "Sorry, I do not know"
-    #     And an utterance, "I'm not sure. The answer might be {{generative.answer}}. How's that?"
-    #     When messages are emitted
-    #     Then the message doesn't contain the text "I do not know"
-    #     And the message mentions the color green
+    Scenario: Reverting to fluid generation when a full utterance match isn't found (fluid utterance)
+        Given a customer message, "I say that a banana is green, and an apple is purple. What did I say was the color of a banana?"
+        And an utterance, "Sorry, I do not know"
+        And an utterance, "I'm not sure. The answer might be {{generative.answer}}. How's that?"
+        When messages are emitted
+        Then the message doesn't contain the text "I do not know"
+        And the message mentions the color green
         
-    # Scenario: Multistep journey is partially followed 1 (fluid utterance)
-    #     Given a journey titled Reset Password Journey to follow these steps to reset a customers password: 1. ask for their account name 2. ask for their email or phone number 3. Wish them a good day and only proceed if they wish one back to you. Otherwise abort. 3. use the tool reset_password with the provided information 4. report the result to the customer when the customer wants to reset their password
-    #     And an utterance, "What is the name of your account?"
-    #     And an utterance, "can you please provide the email address or phone number attached to this account?"
-    #     And an utterance, "Thank you, have a good day!"
-    #     And an utterance, "I'm sorry but I have no information about that"
-    #     And an utterance, "Is there anything else I could help you with?"
-    #     And an utterance, "Your password was successfully reset. An email with further instructions will be sent to your address."
-    #     And an utterance, "An error occurred, your password could not be reset"
-    #     And the tool "reset_password"
-    #     And a customer message, "I want to reset my password"
-    #     When processing is triggered
-    #     Then no tool calls event is emitted
-    #     And a single message event is emitted
-    #     And the message contains asking the customer for their username, but not for their email or phone number
+    Scenario: Multistep journey is partially followed 1 (fluid utterance)
+        Given a journey titled Reset Password Journey to follow these steps to reset a customers password: 1. ask for their account name 2. ask for their email or phone number 3. Wish them a good day and only proceed if they wish one back to you. Otherwise abort. 3. use the tool reset_password with the provided information 4. report the result to the customer when the customer wants to reset their password
+        And an utterance, "What is the name of your account?"
+        And an utterance, "can you please provide the email address or phone number attached to this account?"
+        And an utterance, "Thank you, have a good day!"
+        And an utterance, "I'm sorry but I have no information about that"
+        And an utterance, "Is there anything else I could help you with?"
+        And an utterance, "Your password was successfully reset. An email with further instructions will be sent to your address."
+        And an utterance, "An error occurred, your password could not be reset"
+        And the tool "reset_password"
+        And a customer message, "I want to reset my password"
+        When processing is triggered
+        Then no tool calls event is emitted
+        And a single message event is emitted
+        And the message contains asking the customer for their username, but not for their email or phone number
 
-    # Scenario: Irrelevant journey is ignored (fluid utterance)
-    #     Given a journey titled Reset Password Journey to follow these steps to reset a customers password: 1. ask for their account name 2. ask for their email or phone number 3. Wish them a good day and only proceed if they wish one back to you. Otherwise abort. 3. use the tool reset_password with the provided information 4. report the result to the customer when always
-    #     And an utterance, "What is the name of your account?"
-    #     And an utterance, "can you please provide the email address or phone number attached to this account?"
-    #     And an utterance, "Thank you, have a good day!"
-    #     And an utterance, "I'm sorry but I have no information about that"
-    #     And an utterance, "Is there anything else I could help you with?"
-    #     And an utterance, "Your password was successfully reset. An email with further instructions will be sent to your address."
-    #     And an utterance, "An error occurred, your password could not be reset"
-    #     And the tool "reset_password"
-    #     And a customer message, "What are some tips I could use to come up with a strong password?"
-    #     When processing is triggered
-    #     Then no tool calls event is emitted
-    #     And a single message event is emitted
-    #     And the message contains nothing about resetting your password
+    Scenario: Irrelevant journey is ignored (fluid utterance)
+        Given a journey titled Reset Password Journey to follow these steps to reset a customers password: 1. ask for their account name 2. ask for their email or phone number 3. Wish them a good day and only proceed if they wish one back to you. Otherwise abort. 3. use the tool reset_password with the provided information 4. report the result to the customer when always
+        And an utterance, "What is the name of your account?"
+        And an utterance, "can you please provide the email address or phone number attached to this account?"
+        And an utterance, "Thank you, have a good day!"
+        And an utterance, "I'm sorry but I have no information about that"
+        And an utterance, "Is there anything else I could help you with?"
+        And an utterance, "Your password was successfully reset. An email with further instructions will be sent to your address."
+        And an utterance, "An error occurred, your password could not be reset"
+        And the tool "reset_password"
+        And a customer message, "What are some tips I could use to come up with a strong password?"
+        When processing is triggered
+        Then no tool calls event is emitted
+        And a single message event is emitted
+        And the message contains nothing about resetting your password
 
-    # Scenario: Multistep journey is partially followed 2 (fluid utterance)
-    #     Given a journey titled Reset Password Journey to follow these steps to reset a customers password: 1. ask for their account name 2. ask for their email or phone number 3. Wish them a good day and only proceed if they wish one back to you. Otherwise abort. 3. use the tool reset_password with the provided information 4. report the result to the customer when the customer wants to reset their password
-    #     And an utterance, "What is the name of your account?"
-    #     And an utterance, "can you please provide the email address or phone number attached to this account?"
-    #     And an utterance, "Thank you, have a good day!"
-    #     And an utterance, "I'm sorry but I have no information about that"
-    #     And an utterance, "Is there anything else I could help you with?"
-    #     And an utterance, "Your password was successfully reset. An email with further instructions will be sent to your address."
-    #     And an utterance, "An error occurred, your password could not be reset"
-    #     And the tool "reset_password"
-    #     And a customer message, "I want to reset my password"
-    #     And an agent message, "I can help you do just that. What's your username?"
-    #     And a customer message, "it's leonardo_barbosa_1982"
-    #     When processing is triggered
-    #     Then no tool calls event is emitted
-    #     And a single message event is emitted
-    #     And the message contains asking the customer for their mobile number or email address
-    #     And the message contains nothing about wishing the customer a good day
+    Scenario: Multistep journey is partially followed 2 (fluid utterance)
+        Given a journey titled Reset Password Journey to follow these steps to reset a customers password: 1. ask for their account name 2. ask for their email or phone number 3. Wish them a good day and only proceed if they wish one back to you. Otherwise abort. 3. use the tool reset_password with the provided information 4. report the result to the customer when the customer wants to reset their password
+        And an utterance, "What is the name of your account?"
+        And an utterance, "can you please provide the email address or phone number attached to this account?"
+        And an utterance, "Thank you, have a good day!"
+        And an utterance, "I'm sorry but I have no information about that"
+        And an utterance, "Is there anything else I could help you with?"
+        And an utterance, "Your password was successfully reset. An email with further instructions will be sent to your address."
+        And an utterance, "An error occurred, your password could not be reset"
+        And the tool "reset_password"
+        And a customer message, "I want to reset my password"
+        And an agent message, "I can help you do just that. What's your username?"
+        And a customer message, "it's leonardo_barbosa_1982"
+        When processing is triggered
+        Then no tool calls event is emitted
+        And a single message event is emitted
+        And the message contains asking the customer for their mobile number or email address
+        And the message contains nothing about wishing the customer a good day
 
-    # Scenario: Critical guideline overrides journey (fluid utterance)
-    #     Given a journey titled Reset Password Journey to follow these steps to reset a customers password: 1. ask for their account name 2. ask for their email or phone number 3. Wish them a good day and only proceed if they wish one back to you. Otherwise abort. 3. use the tool reset_password with the provided information 4. report the result to the customer when the customer wants to reset their password
-    #     And an utterance, "What is the name of your account?"
-    #     And an utterance, "can you please provide the email address or phone number attached to this account?"
-    #     And an utterance, "Thank you, have a good day!"
-    #     And an utterance, "I'm sorry but I have no information about that"
-    #     And an utterance, "Is there anything else I could help you with?"
-    #     And an utterance, "Your password was successfully reset. An email with further instructions will be sent to your address."
-    #     And an utterance, "An error occurred, your password could not be reset"
-    #     And an utterance, "Before proceeding, could you please state your age?"
-    #     And the tool "reset_password"
-    #     And a guideline to ask the customer their age, and do not continue with any other process unless it is over 21 when the customer provides a username that includes what could potentially be their year of birth
-    #     And a customer message, "I want to reset my password"
-    #     And an agent message, "I can help you do just that. What's your username?"
-    #     And a customer message, "it's leonardo_barbosa_1982"
-    #     When processing is triggered
-    #     Then no tool calls event is emitted
-    #     And a single message event is emitted
-    #     And the message contains asking the customer for their age
-    #     And the message contains no questions about the customer's email address or phone number
+    Scenario: Critical guideline overrides journey (fluid utterance)
+        Given a journey titled Reset Password Journey to follow these steps to reset a customers password: 1. ask for their account name 2. ask for their email or phone number 3. Wish them a good day and only proceed if they wish one back to you. Otherwise abort. 3. use the tool reset_password with the provided information 4. report the result to the customer when the customer wants to reset their password
+        And an utterance, "What is the name of your account?"
+        And an utterance, "can you please provide the email address or phone number attached to this account?"
+        And an utterance, "Thank you, have a good day!"
+        And an utterance, "I'm sorry but I have no information about that"
+        And an utterance, "Is there anything else I could help you with?"
+        And an utterance, "Your password was successfully reset. An email with further instructions will be sent to your address."
+        And an utterance, "An error occurred, your password could not be reset"
+        And an utterance, "Before proceeding, could you please state your age?"
+        And the tool "reset_password"
+        And a guideline to ask the customer their age, and do not continue with any other process unless it is over 21 when the customer provides a username that includes what could potentially be their year of birth
+        And a customer message, "I want to reset my password"
+        And an agent message, "I can help you do just that. What's your username?"
+        And a customer message, "it's leonardo_barbosa_1982"
+        When processing is triggered
+        Then no tool calls event is emitted
+        And a single message event is emitted
+        And the message contains asking the customer for their age
+        And the message contains no questions about the customer's email address or phone number
     
-    # Scenario: Journey information is followed (fluid utterance)
-    #     Given a journey titled Change Credit Limits to remember that credit limits can be decreased through this chat, using the decrease_limits tool, but that to increase credit limits you must visit a physical branch when credit limits are discussed
-    #     And an utterance, "To increase credit limits, you must visit a physical branch"
-    #     And an utterance, "Sure. Let me check how that could be done"
-    #     And a customer message, "Hey there. I want to increase the credit limit on my platinum silver gold card. I want the new limits to be twice as high, please."
-    #     When processing is triggered
-    #     Then a single message event is emitted
-    #     And the message contains that you must visit a physical branch to increase credit limits
+    Scenario: Journey information is followed (fluid utterance)
+        Given a journey titled Change Credit Limits to remember that credit limits can be decreased through this chat, using the decrease_limits tool, but that to increase credit limits you must visit a physical branch when credit limits are discussed
+        And an utterance, "To increase credit limits, you must visit a physical branch"
+        And an utterance, "Sure. Let me check how that could be done"
+        And a customer message, "Hey there. I want to increase the credit limit on my platinum silver gold card. I want the new limits to be twice as high, please."
+        When processing is triggered
+        Then a single message event is emitted
+        And the message contains that you must visit a physical branch to increase credit limits
 
-    # Scenario: Two journeys are used in unison (fluid utterance)
-    #     Given a journey titled Book Flight to ask for the source and destination airport first, the date second, economy or business class third, and finally to ask for the name of the traveler. You may skip steps that are inapplicable due to other contextual reasons. when a customer wants to book a flight
-    #     And an utterance, "Great. Are you interested in economy or business class?"
-    #     And an utterance, "Great. Only economy class is available for this booking. What is the name of the traveler?"
-    #     And an utterance, "Great. What is the name of the traveler?"
-    #     And an utterance, "Great. Are you interested in economy or business class? Also, what is the name of the person traveling?"
-    #     And a journey titled No Economy to remember that travelers under the age of 21 are illegible for business class, and may only use economy when a flight is being booked
-    #     And a customer message, "Hi, I'd like to book a flight for myself. I'm 19 if that effects anything."
-    #     And an agent message, "Great! From and to where would are you looking to fly?"
-    #     And a customer message, "From LAX to JFK"
-    #     And an agent message, "Got it. And when are you looking to travel?"
-    #     And a customer message, "Next Monday"
-    #     When processing is triggered
-    #     Then a single message event is emitted
-    #     And the message contains either asking for the name of the person traveling, or informing them that they are only eligible for economy class
+    Scenario: Two journeys are used in unison (fluid utterance)
+        Given a journey titled Book Flight to ask for the source and destination airport first, the date second, economy or business class third, and finally to ask for the name of the traveler. You may skip steps that are inapplicable due to other contextual reasons. when a customer wants to book a flight
+        And an utterance, "Great. Are you interested in economy or business class?"
+        And an utterance, "Great. Only economy class is available for this booking. What is the name of the traveler?"
+        And an utterance, "Great. What is the name of the traveler?"
+        And an utterance, "Great. Are you interested in economy or business class? Also, what is the name of the person traveling?"
+        And a journey titled No Economy to remember that travelers under the age of 21 are illegible for business class, and may only use economy when a flight is being booked
+        And a customer message, "Hi, I'd like to book a flight for myself. I'm 19 if that effects anything."
+        And an agent message, "Great! From and to where would are you looking to fly?"
+        And a customer message, "From LAX to JFK"
+        And an agent message, "Got it. And when are you looking to travel?"
+        And a customer message, "Next Monday"
+        When processing is triggered
+        Then a single message event is emitted
+        And the message contains either asking for the name of the person traveling, or informing them that they are only eligible for economy class
 
 
-    # Scenario: The agent greets the customer 2 (fluid utterance)
-    #     Given a guideline to greet with 'Howdy' when the session starts
-    #     And an utterance, "Hello there! How can I help you today?"
-    #     And an utterance, "Howdy! How can I be of service to you today?"
-    #     And an utterance, "Thank you for your patience!"
-    #     And an utterance, "Is there anything else I could help you with?"
-    #     And an utterance, "I'll look into that for you right away."
-    #     When processing is triggered
-    #     Then a status event is emitted, acknowledging event -1
-    #     And a status event is emitted, processing event -1
-    #     And a status event is emitted, typing in response to event -1
-    #     And a single message event is emitted
-    #     And the message contains a 'Howdy' greeting
+    Scenario: The agent greets the customer 2 (fluid utterance)
+        Given a guideline to greet with 'Howdy' when the session starts
+        And an utterance, "Hello there! How can I help you today?"
+        And an utterance, "Howdy! How can I be of service to you today?"
+        And an utterance, "Thank you for your patience!"
+        And an utterance, "Is there anything else I could help you with?"
+        And an utterance, "I'll look into that for you right away."
+        When processing is triggered
+        Then a status event is emitted, acknowledging event -1
+        And a status event is emitted, processing event -1
+        And a status event is emitted, typing in response to event -1
+        And a single message event is emitted
+        And the message contains a 'Howdy' greeting
 
-    # Scenario: The agent offers a thirsty customer a drink (fluid utterance)
-    #     Given a customer message, "I'm thirsty"
-    #     And a guideline to offer thirsty customers a Pepsi when the customer is thirsty
-    #     And an utterance, "Would you like a Pepsi? I can get one for you right away."
-    #     And an utterance, "I understand you're thirsty. Can I get you something to drink?"
-    #     And an utterance, "Is there anything specific you'd like to drink?"
-    #     And an utterance, "Thank you for letting me know. Is there anything else I can help with?"
-    #     And an utterance, "I'll be happy to assist you with all your beverage needs today."
-    #     When processing is triggered
-    #     Then a status event is emitted, acknowledging event 0
-    #     And a status event is emitted, processing event 0
-    #     And a status event is emitted, typing in response to event 0
-    #     And a single message event is emitted
-    #     And the message contains an offering of a Pepsi
-    #     And a status event is emitted, ready for further engagement after reacting to event 0
+    Scenario: The agent offers a thirsty customer a drink (fluid utterance)
+        Given a customer message, "I'm thirsty"
+        And a guideline to offer thirsty customers a Pepsi when the customer is thirsty
+        And an utterance, "Would you like a Pepsi? I can get one for you right away."
+        And an utterance, "I understand you're thirsty. Can I get you something to drink?"
+        And an utterance, "Is there anything specific you'd like to drink?"
+        And an utterance, "Thank you for letting me know. Is there anything else I can help with?"
+        And an utterance, "I'll be happy to assist you with all your beverage needs today."
+        When processing is triggered
+        Then a status event is emitted, acknowledging event 0
+        And a status event is emitted, processing event 0
+        And a status event is emitted, typing in response to event 0
+        And a single message event is emitted
+        And the message contains an offering of a Pepsi
+        And a status event is emitted, ready for further engagement after reacting to event 0
 
-    # Scenario: The agent correctly applies greeting guidelines based on auxiliary data (fluid utterance)
-    #     Given an agent named "Chip Bitman" whose job is to work at a tech store and help customers choose what to buy. You're clever, witty, and slightly sarcastic. At the same time you're kind and funny.
-    #     And that the agent uses the fluid_utterance message composition mode
-    #     And a customer named "Beef Wellington"
-    #     And an empty session with "Beef Wellingotn"
-    #     And the term "Bug" defined as The name of our tech retail store, specializing in gadgets, computers, and tech services.
-    #     And the term "Bug-Free" defined as Our free warranty and service package that comes with every purchase and covers repairs, replacements, and tech support beyond the standard manufacturer warranty.
-    #     And a tag "business"
-    #     And a customer tagged as "business"
-    #     And a context variable "plan" set to "Business Plan" for the tag "business"
-    #     And a guideline to just welcome them to the store and ask how you can help when the customer greets you
-    #     And a guideline to refer to them by their first name only, and welcome them 'back' when a customer greets you
-    #     And a guideline to assure them you will escalate it internally and get back to them when a business-plan customer is having an issue
-    #     And a customer message, "Hi there"
-    #     And an utterance, "Hi Beef! Welcome back to Bug. What can I help you with today?"
-    #     And an utterance, "Hello there! How can I assist you today?"
-    #     And an utterance, "Welcome to Bug! Is this your first time shopping with us?"
-    #     And an utterance, "I'll escalate this issue internally and get back to you as soon as possible."
-    #     And an utterance, "Have you heard about our Bug-Free warranty program?"
-    #     When processing is triggered
-    #     Then a single message event is emitted
-    #     And the message contains the name 'Beef'
-    #     And the message contains a welcoming back of the customer to the store and asking how the agent could help
+    Scenario: The agent correctly applies greeting guidelines based on auxiliary data (fluid utterance)
+        Given an agent named "Chip Bitman" whose job is to work at a tech store and help customers choose what to buy. You're clever, witty, and slightly sarcastic. At the same time you're kind and funny.
+        And that the agent uses the fluid_utterance message composition mode
+        And a customer named "Beef Wellington"
+        And an empty session with "Beef Wellingotn"
+        And the term "Bug" defined as The name of our tech retail store, specializing in gadgets, computers, and tech services.
+        And the term "Bug-Free" defined as Our free warranty and service package that comes with every purchase and covers repairs, replacements, and tech support beyond the standard manufacturer warranty.
+        And a tag "business"
+        And a customer tagged as "business"
+        And a context variable "plan" set to "Business Plan" for the tag "business"
+        And a guideline to just welcome them to the store and ask how you can help when the customer greets you
+        And a guideline to refer to them by their first name only, and welcome them 'back' when a customer greets you
+        And a guideline to assure them you will escalate it internally and get back to them when a business-plan customer is having an issue
+        And a customer message, "Hi there"
+        And an utterance, "Hi Beef! Welcome back to Bug. What can I help you with today?"
+        And an utterance, "Hello there! How can I assist you today?"
+        And an utterance, "Welcome to Bug! Is this your first time shopping with us?"
+        And an utterance, "I'll escalate this issue internally and get back to you as soon as possible."
+        And an utterance, "Have you heard about our Bug-Free warranty program?"
+        When processing is triggered
+        Then a single message event is emitted
+        And the message contains the name 'Beef'
+        And the message contains a welcoming back of the customer to the store and asking how the agent could help
 
     Scenario: The agent follows a guideline with agent intention (fluid utterance)
         Given a guideline to do not provide any personal medical information even if you have it when the agent discusses a patient's medical record
         And that the agent uses the fluid_utterance message composition mode
         And a customer named "Alex Smith"
         And an empty session with "Alex Smith"
-        And a context variable "medication" set to "Amoxicillin and Lisinopril" for "Alex Smith" 
+        And a context variable "medical_record" set to "Amoxicillin and Lisinopril" for "Alex Smith" 
         And a customer message, "Hi, I need to know what medications I was prescribed during my visit last month. Can you pull up my medical record?"
         And an utterance, "I'm not able to provide personal medical information from your records."
         And an utterance, "I can help you with that. You were prescribed the following medications: {{generative.medication}}"
@@ -224,9 +224,9 @@ Feature: Fluid Utterance
 
     Scenario: The agent follows a regular guideline when it overrides an agent intention guideline 2 (fluid utterance)
         Given a guideline to recommend on either pineapple or pepperoni when the agent recommends on pizza toppings
-        Given a guideline to recommend only on the vegetarian toppings options when the customer asks for pizza topping recommendation and they are vegetarian
+        Given a guideline to recommend only on the recommended vegetarian toppings options when the customer asks about topping recommendation and the customer is from India
         And that the agent uses the fluid_utterance message composition mode
-        And a customer message, "Hi, I want to buy pizza. What do you recommend? I'm vegetarian."
+        And a customer message, "Hi, I want to buy pizza. What do you recommend? I'm from India if it matters."
         And an utterance, "I recommend on {{generative.answer}}."
         When processing is triggered
         Then a single message event is emitted
@@ -246,9 +246,9 @@ Feature: Fluid Utterance
 
     Scenario: The agent follows an agent intention guideline when it overrides an agent intention guideline 2 (fluid utterance)
         Given a guideline to recommend on either pineapple or pepperoni when the agent recommends on pizza toppings
-        Given a guideline to recommend only on the vegetarian toppings options when the agent recommends on pizza topping and the customer is vegetarian
+        Given a guideline to recommend only on the vegetarian toppings options when the agent recommends on pizza topping and the customer is from India
         And that the agent uses the fluid_utterance message composition mode
-        And a customer message, "Hi, I want to buy pizza. What do you recommend? I'm vegetarian."
+        And a customer message, "Hi, I want to buy pizza. What do you recommend? I'm from India if it matters."
         And an utterance, "I recommend on {{generative.answer}}."
         When processing is triggered
         Then a single message event is emitted

--- a/tests/core/stable/engines/alpha/features/baseline/fluid_utterances.feature
+++ b/tests/core/stable/engines/alpha/features/baseline/fluid_utterances.feature
@@ -5,180 +5,254 @@ Feature: Fluid Utterance
         And that the agent uses the fluid_utterance message composition mode
         And an empty session
 
-    Scenario: The agent greets the customer (fluid utterance)
-        Given a guideline to greet with 'Howdy' when the session starts
-        When processing is triggered
-        Then a status event is emitted, acknowledging event -1
-        And a status event is emitted, processing event -1
-        And a status event is emitted, typing in response to event -1
-        And a single message event is emitted
-        And the message contains a 'Howdy' greeting
-        And a status event is emitted, ready for further engagement after reacting to event -1
+    # Scenario: The agent greets the customer (fluid utterance)
+    #     Given a guideline to greet with 'Howdy' when the session starts
+    #     When processing is triggered
+    #     Then a status event is emitted, acknowledging event -1
+    #     And a status event is emitted, processing event -1
+    #     And a status event is emitted, typing in response to event -1
+    #     And a single message event is emitted
+    #     And the message contains a 'Howdy' greeting
+    #     And a status event is emitted, ready for further engagement after reacting to event -1
 
-    Scenario: Responding based on data the user is providing (fluid utterance)
-        Given a customer message, "I say that a banana is green, and an apple is purple. What did I say was the color of a banana?"
-        And an utterance, "Sorry, I do not know"
-        And an utterance, "The answer is {{generative.answer}}"
-        When messages are emitted
-        Then the message doesn't contain the text "I do not know"
-        And the message mentions the color green
+    # Scenario: Responding based on data the user is providing (fluid utterance)
+    #     Given a customer message, "I say that a banana is green, and an apple is purple. What did I say was the color of a banana?"
+    #     And an utterance, "Sorry, I do not know"
+    #     And an utterance, "The answer is {{generative.answer}}"
+    #     When messages are emitted
+    #     Then the message doesn't contain the text "I do not know"
+    #     And the message mentions the color green
 
-    Scenario: Reverting to fluid generation when a full utterance match isn't found (fluid utterance)
-        Given a customer message, "I say that a banana is green, and an apple is purple. What did I say was the color of a banana?"
-        And an utterance, "Sorry, I do not know"
-        And an utterance, "I'm not sure. The answer might be {{generative.answer}}. How's that?"
-        When messages are emitted
-        Then the message doesn't contain the text "I do not know"
-        And the message mentions the color green
+    # Scenario: Reverting to fluid generation when a full utterance match isn't found (fluid utterance)
+    #     Given a customer message, "I say that a banana is green, and an apple is purple. What did I say was the color of a banana?"
+    #     And an utterance, "Sorry, I do not know"
+    #     And an utterance, "I'm not sure. The answer might be {{generative.answer}}. How's that?"
+    #     When messages are emitted
+    #     Then the message doesn't contain the text "I do not know"
+    #     And the message mentions the color green
         
-    Scenario: Multistep journey is partially followed 1 (fluid utterance)
-        Given a journey titled Reset Password Journey to follow these steps to reset a customers password: 1. ask for their account name 2. ask for their email or phone number 3. Wish them a good day and only proceed if they wish one back to you. Otherwise abort. 3. use the tool reset_password with the provided information 4. report the result to the customer when the customer wants to reset their password
-        And an utterance, "What is the name of your account?"
-        And an utterance, "can you please provide the email address or phone number attached to this account?"
-        And an utterance, "Thank you, have a good day!"
-        And an utterance, "I'm sorry but I have no information about that"
-        And an utterance, "Is there anything else I could help you with?"
-        And an utterance, "Your password was successfully reset. An email with further instructions will be sent to your address."
-        And an utterance, "An error occurred, your password could not be reset"
-        And the tool "reset_password"
-        And a customer message, "I want to reset my password"
-        When processing is triggered
-        Then no tool calls event is emitted
-        And a single message event is emitted
-        And the message contains asking the customer for their username, but not for their email or phone number
+    # Scenario: Multistep journey is partially followed 1 (fluid utterance)
+    #     Given a journey titled Reset Password Journey to follow these steps to reset a customers password: 1. ask for their account name 2. ask for their email or phone number 3. Wish them a good day and only proceed if they wish one back to you. Otherwise abort. 3. use the tool reset_password with the provided information 4. report the result to the customer when the customer wants to reset their password
+    #     And an utterance, "What is the name of your account?"
+    #     And an utterance, "can you please provide the email address or phone number attached to this account?"
+    #     And an utterance, "Thank you, have a good day!"
+    #     And an utterance, "I'm sorry but I have no information about that"
+    #     And an utterance, "Is there anything else I could help you with?"
+    #     And an utterance, "Your password was successfully reset. An email with further instructions will be sent to your address."
+    #     And an utterance, "An error occurred, your password could not be reset"
+    #     And the tool "reset_password"
+    #     And a customer message, "I want to reset my password"
+    #     When processing is triggered
+    #     Then no tool calls event is emitted
+    #     And a single message event is emitted
+    #     And the message contains asking the customer for their username, but not for their email or phone number
 
-    Scenario: Irrelevant journey is ignored (fluid utterance)
-        Given a journey titled Reset Password Journey to follow these steps to reset a customers password: 1. ask for their account name 2. ask for their email or phone number 3. Wish them a good day and only proceed if they wish one back to you. Otherwise abort. 3. use the tool reset_password with the provided information 4. report the result to the customer when always
-        And an utterance, "What is the name of your account?"
-        And an utterance, "can you please provide the email address or phone number attached to this account?"
-        And an utterance, "Thank you, have a good day!"
-        And an utterance, "I'm sorry but I have no information about that"
-        And an utterance, "Is there anything else I could help you with?"
-        And an utterance, "Your password was successfully reset. An email with further instructions will be sent to your address."
-        And an utterance, "An error occurred, your password could not be reset"
-        And the tool "reset_password"
-        And a customer message, "What are some tips I could use to come up with a strong password?"
-        When processing is triggered
-        Then no tool calls event is emitted
-        And a single message event is emitted
-        And the message contains nothing about resetting your password
+    # Scenario: Irrelevant journey is ignored (fluid utterance)
+    #     Given a journey titled Reset Password Journey to follow these steps to reset a customers password: 1. ask for their account name 2. ask for their email or phone number 3. Wish them a good day and only proceed if they wish one back to you. Otherwise abort. 3. use the tool reset_password with the provided information 4. report the result to the customer when always
+    #     And an utterance, "What is the name of your account?"
+    #     And an utterance, "can you please provide the email address or phone number attached to this account?"
+    #     And an utterance, "Thank you, have a good day!"
+    #     And an utterance, "I'm sorry but I have no information about that"
+    #     And an utterance, "Is there anything else I could help you with?"
+    #     And an utterance, "Your password was successfully reset. An email with further instructions will be sent to your address."
+    #     And an utterance, "An error occurred, your password could not be reset"
+    #     And the tool "reset_password"
+    #     And a customer message, "What are some tips I could use to come up with a strong password?"
+    #     When processing is triggered
+    #     Then no tool calls event is emitted
+    #     And a single message event is emitted
+    #     And the message contains nothing about resetting your password
 
-    Scenario: Multistep journey is partially followed 2 (fluid utterance)
-        Given a journey titled Reset Password Journey to follow these steps to reset a customers password: 1. ask for their account name 2. ask for their email or phone number 3. Wish them a good day and only proceed if they wish one back to you. Otherwise abort. 3. use the tool reset_password with the provided information 4. report the result to the customer when the customer wants to reset their password
-        And an utterance, "What is the name of your account?"
-        And an utterance, "can you please provide the email address or phone number attached to this account?"
-        And an utterance, "Thank you, have a good day!"
-        And an utterance, "I'm sorry but I have no information about that"
-        And an utterance, "Is there anything else I could help you with?"
-        And an utterance, "Your password was successfully reset. An email with further instructions will be sent to your address."
-        And an utterance, "An error occurred, your password could not be reset"
-        And the tool "reset_password"
-        And a customer message, "I want to reset my password"
-        And an agent message, "I can help you do just that. What's your username?"
-        And a customer message, "it's leonardo_barbosa_1982"
-        When processing is triggered
-        Then no tool calls event is emitted
-        And a single message event is emitted
-        And the message contains asking the customer for their mobile number or email address
-        And the message contains nothing about wishing the customer a good day
+    # Scenario: Multistep journey is partially followed 2 (fluid utterance)
+    #     Given a journey titled Reset Password Journey to follow these steps to reset a customers password: 1. ask for their account name 2. ask for their email or phone number 3. Wish them a good day and only proceed if they wish one back to you. Otherwise abort. 3. use the tool reset_password with the provided information 4. report the result to the customer when the customer wants to reset their password
+    #     And an utterance, "What is the name of your account?"
+    #     And an utterance, "can you please provide the email address or phone number attached to this account?"
+    #     And an utterance, "Thank you, have a good day!"
+    #     And an utterance, "I'm sorry but I have no information about that"
+    #     And an utterance, "Is there anything else I could help you with?"
+    #     And an utterance, "Your password was successfully reset. An email with further instructions will be sent to your address."
+    #     And an utterance, "An error occurred, your password could not be reset"
+    #     And the tool "reset_password"
+    #     And a customer message, "I want to reset my password"
+    #     And an agent message, "I can help you do just that. What's your username?"
+    #     And a customer message, "it's leonardo_barbosa_1982"
+    #     When processing is triggered
+    #     Then no tool calls event is emitted
+    #     And a single message event is emitted
+    #     And the message contains asking the customer for their mobile number or email address
+    #     And the message contains nothing about wishing the customer a good day
 
-    Scenario: Critical guideline overrides journey (fluid utterance)
-        Given a journey titled Reset Password Journey to follow these steps to reset a customers password: 1. ask for their account name 2. ask for their email or phone number 3. Wish them a good day and only proceed if they wish one back to you. Otherwise abort. 3. use the tool reset_password with the provided information 4. report the result to the customer when the customer wants to reset their password
-        And an utterance, "What is the name of your account?"
-        And an utterance, "can you please provide the email address or phone number attached to this account?"
-        And an utterance, "Thank you, have a good day!"
-        And an utterance, "I'm sorry but I have no information about that"
-        And an utterance, "Is there anything else I could help you with?"
-        And an utterance, "Your password was successfully reset. An email with further instructions will be sent to your address."
-        And an utterance, "An error occurred, your password could not be reset"
-        And an utterance, "Before proceeding, could you please state your age?"
-        And the tool "reset_password"
-        And a guideline to ask the customer their age, and do not continue with any other process unless it is over 21 when the customer provides a username that includes what could potentially be their year of birth
-        And a customer message, "I want to reset my password"
-        And an agent message, "I can help you do just that. What's your username?"
-        And a customer message, "it's leonardo_barbosa_1982"
-        When processing is triggered
-        Then no tool calls event is emitted
-        And a single message event is emitted
-        And the message contains asking the customer for their age
-        And the message contains no questions about the customer's email address or phone number
+    # Scenario: Critical guideline overrides journey (fluid utterance)
+    #     Given a journey titled Reset Password Journey to follow these steps to reset a customers password: 1. ask for their account name 2. ask for their email or phone number 3. Wish them a good day and only proceed if they wish one back to you. Otherwise abort. 3. use the tool reset_password with the provided information 4. report the result to the customer when the customer wants to reset their password
+    #     And an utterance, "What is the name of your account?"
+    #     And an utterance, "can you please provide the email address or phone number attached to this account?"
+    #     And an utterance, "Thank you, have a good day!"
+    #     And an utterance, "I'm sorry but I have no information about that"
+    #     And an utterance, "Is there anything else I could help you with?"
+    #     And an utterance, "Your password was successfully reset. An email with further instructions will be sent to your address."
+    #     And an utterance, "An error occurred, your password could not be reset"
+    #     And an utterance, "Before proceeding, could you please state your age?"
+    #     And the tool "reset_password"
+    #     And a guideline to ask the customer their age, and do not continue with any other process unless it is over 21 when the customer provides a username that includes what could potentially be their year of birth
+    #     And a customer message, "I want to reset my password"
+    #     And an agent message, "I can help you do just that. What's your username?"
+    #     And a customer message, "it's leonardo_barbosa_1982"
+    #     When processing is triggered
+    #     Then no tool calls event is emitted
+    #     And a single message event is emitted
+    #     And the message contains asking the customer for their age
+    #     And the message contains no questions about the customer's email address or phone number
     
-    Scenario: Journey information is followed (fluid utterance)
-        Given a journey titled Change Credit Limits to remember that credit limits can be decreased through this chat, using the decrease_limits tool, but that to increase credit limits you must visit a physical branch when credit limits are discussed
-        And an utterance, "To increase credit limits, you must visit a physical branch"
-        And an utterance, "Sure. Let me check how that could be done"
-        And a customer message, "Hey there. I want to increase the credit limit on my platinum silver gold card. I want the new limits to be twice as high, please."
-        When processing is triggered
-        Then a single message event is emitted
-        And the message contains that you must visit a physical branch to increase credit limits
+    # Scenario: Journey information is followed (fluid utterance)
+    #     Given a journey titled Change Credit Limits to remember that credit limits can be decreased through this chat, using the decrease_limits tool, but that to increase credit limits you must visit a physical branch when credit limits are discussed
+    #     And an utterance, "To increase credit limits, you must visit a physical branch"
+    #     And an utterance, "Sure. Let me check how that could be done"
+    #     And a customer message, "Hey there. I want to increase the credit limit on my platinum silver gold card. I want the new limits to be twice as high, please."
+    #     When processing is triggered
+    #     Then a single message event is emitted
+    #     And the message contains that you must visit a physical branch to increase credit limits
 
-    Scenario: Two journeys are used in unison (fluid utterance)
-        Given a journey titled Book Flight to ask for the source and destination airport first, the date second, economy or business class third, and finally to ask for the name of the traveler. You may skip steps that are inapplicable due to other contextual reasons. when a customer wants to book a flight
-        And an utterance, "Great. Are you interested in economy or business class?"
-        And an utterance, "Great. Only economy class is available for this booking. What is the name of the traveler?"
-        And an utterance, "Great. What is the name of the traveler?"
-        And an utterance, "Great. Are you interested in economy or business class? Also, what is the name of the person traveling?"
-        And a journey titled No Economy to remember that travelers under the age of 21 are illegible for business class, and may only use economy when a flight is being booked
-        And a customer message, "Hi, I'd like to book a flight for myself. I'm 19 if that effects anything."
-        And an agent message, "Great! From and to where would are you looking to fly?"
-        And a customer message, "From LAX to JFK"
-        And an agent message, "Got it. And when are you looking to travel?"
-        And a customer message, "Next Monday"
-        When processing is triggered
-        Then a single message event is emitted
-        And the message contains either asking for the name of the person traveling, or informing them that they are only eligible for economy class
+    # Scenario: Two journeys are used in unison (fluid utterance)
+    #     Given a journey titled Book Flight to ask for the source and destination airport first, the date second, economy or business class third, and finally to ask for the name of the traveler. You may skip steps that are inapplicable due to other contextual reasons. when a customer wants to book a flight
+    #     And an utterance, "Great. Are you interested in economy or business class?"
+    #     And an utterance, "Great. Only economy class is available for this booking. What is the name of the traveler?"
+    #     And an utterance, "Great. What is the name of the traveler?"
+    #     And an utterance, "Great. Are you interested in economy or business class? Also, what is the name of the person traveling?"
+    #     And a journey titled No Economy to remember that travelers under the age of 21 are illegible for business class, and may only use economy when a flight is being booked
+    #     And a customer message, "Hi, I'd like to book a flight for myself. I'm 19 if that effects anything."
+    #     And an agent message, "Great! From and to where would are you looking to fly?"
+    #     And a customer message, "From LAX to JFK"
+    #     And an agent message, "Got it. And when are you looking to travel?"
+    #     And a customer message, "Next Monday"
+    #     When processing is triggered
+    #     Then a single message event is emitted
+    #     And the message contains either asking for the name of the person traveling, or informing them that they are only eligible for economy class
 
 
-    Scenario: The agent greets the customer 2 (fluid utterance)
-        Given a guideline to greet with 'Howdy' when the session starts
-        And an utterance, "Hello there! How can I help you today?"
-        And an utterance, "Howdy! How can I be of service to you today?"
-        And an utterance, "Thank you for your patience!"
-        And an utterance, "Is there anything else I could help you with?"
-        And an utterance, "I'll look into that for you right away."
-        When processing is triggered
-        Then a status event is emitted, acknowledging event -1
-        And a status event is emitted, processing event -1
-        And a status event is emitted, typing in response to event -1
-        And a single message event is emitted
-        And the message contains a 'Howdy' greeting
+    # Scenario: The agent greets the customer 2 (fluid utterance)
+    #     Given a guideline to greet with 'Howdy' when the session starts
+    #     And an utterance, "Hello there! How can I help you today?"
+    #     And an utterance, "Howdy! How can I be of service to you today?"
+    #     And an utterance, "Thank you for your patience!"
+    #     And an utterance, "Is there anything else I could help you with?"
+    #     And an utterance, "I'll look into that for you right away."
+    #     When processing is triggered
+    #     Then a status event is emitted, acknowledging event -1
+    #     And a status event is emitted, processing event -1
+    #     And a status event is emitted, typing in response to event -1
+    #     And a single message event is emitted
+    #     And the message contains a 'Howdy' greeting
 
-    Scenario: The agent offers a thirsty customer a drink (fluid utterance)
-        Given a customer message, "I'm thirsty"
-        And a guideline to offer thirsty customers a Pepsi when the customer is thirsty
-        And an utterance, "Would you like a Pepsi? I can get one for you right away."
-        And an utterance, "I understand you're thirsty. Can I get you something to drink?"
-        And an utterance, "Is there anything specific you'd like to drink?"
-        And an utterance, "Thank you for letting me know. Is there anything else I can help with?"
-        And an utterance, "I'll be happy to assist you with all your beverage needs today."
-        When processing is triggered
-        Then a status event is emitted, acknowledging event 0
-        And a status event is emitted, processing event 0
-        And a status event is emitted, typing in response to event 0
-        And a single message event is emitted
-        And the message contains an offering of a Pepsi
-        And a status event is emitted, ready for further engagement after reacting to event 0
+    # Scenario: The agent offers a thirsty customer a drink (fluid utterance)
+    #     Given a customer message, "I'm thirsty"
+    #     And a guideline to offer thirsty customers a Pepsi when the customer is thirsty
+    #     And an utterance, "Would you like a Pepsi? I can get one for you right away."
+    #     And an utterance, "I understand you're thirsty. Can I get you something to drink?"
+    #     And an utterance, "Is there anything specific you'd like to drink?"
+    #     And an utterance, "Thank you for letting me know. Is there anything else I can help with?"
+    #     And an utterance, "I'll be happy to assist you with all your beverage needs today."
+    #     When processing is triggered
+    #     Then a status event is emitted, acknowledging event 0
+    #     And a status event is emitted, processing event 0
+    #     And a status event is emitted, typing in response to event 0
+    #     And a single message event is emitted
+    #     And the message contains an offering of a Pepsi
+    #     And a status event is emitted, ready for further engagement after reacting to event 0
 
-    Scenario: The agent correctly applies greeting guidelines based on auxiliary data (fluid utterance)
-        Given an agent named "Chip Bitman" whose job is to work at a tech store and help customers choose what to buy. You're clever, witty, and slightly sarcastic. At the same time you're kind and funny.
+    # Scenario: The agent correctly applies greeting guidelines based on auxiliary data (fluid utterance)
+    #     Given an agent named "Chip Bitman" whose job is to work at a tech store and help customers choose what to buy. You're clever, witty, and slightly sarcastic. At the same time you're kind and funny.
+    #     And that the agent uses the fluid_utterance message composition mode
+    #     And a customer named "Beef Wellington"
+    #     And an empty session with "Beef Wellingotn"
+    #     And the term "Bug" defined as The name of our tech retail store, specializing in gadgets, computers, and tech services.
+    #     And the term "Bug-Free" defined as Our free warranty and service package that comes with every purchase and covers repairs, replacements, and tech support beyond the standard manufacturer warranty.
+    #     And a tag "business"
+    #     And a customer tagged as "business"
+    #     And a context variable "plan" set to "Business Plan" for the tag "business"
+    #     And a guideline to just welcome them to the store and ask how you can help when the customer greets you
+    #     And a guideline to refer to them by their first name only, and welcome them 'back' when a customer greets you
+    #     And a guideline to assure them you will escalate it internally and get back to them when a business-plan customer is having an issue
+    #     And a customer message, "Hi there"
+    #     And an utterance, "Hi Beef! Welcome back to Bug. What can I help you with today?"
+    #     And an utterance, "Hello there! How can I assist you today?"
+    #     And an utterance, "Welcome to Bug! Is this your first time shopping with us?"
+    #     And an utterance, "I'll escalate this issue internally and get back to you as soon as possible."
+    #     And an utterance, "Have you heard about our Bug-Free warranty program?"
+    #     When processing is triggered
+    #     Then a single message event is emitted
+    #     And the message contains the name 'Beef'
+    #     And the message contains a welcoming back of the customer to the store and asking how the agent could help
+
+    Scenario: The agent follows a guideline with agent intention (fluid utterance)
+        Given a guideline to do not provide any personal medical information even if you have it when the agent discusses a patient's medical record
         And that the agent uses the fluid_utterance message composition mode
-        And a customer named "Beef Wellington"
-        And an empty session with "Beef Wellingotn"
-        And the term "Bug" defined as The name of our tech retail store, specializing in gadgets, computers, and tech services.
-        And the term "Bug-Free" defined as Our free warranty and service package that comes with every purchase and covers repairs, replacements, and tech support beyond the standard manufacturer warranty.
-        And a tag "business"
-        And a customer tagged as "business"
-        And a context variable "plan" set to "Business Plan" for the tag "business"
-        And a guideline to just welcome them to the store and ask how you can help when the customer greets you
-        And a guideline to refer to them by their first name only, and welcome them 'back' when a customer greets you
-        And a guideline to assure them you will escalate it internally and get back to them when a business-plan customer is having an issue
-        And a customer message, "Hi there"
-        And an utterance, "Hi Beef! Welcome back to Bug. What can I help you with today?"
-        And an utterance, "Hello there! How can I assist you today?"
-        And an utterance, "Welcome to Bug! Is this your first time shopping with us?"
-        And an utterance, "I'll escalate this issue internally and get back to you as soon as possible."
-        And an utterance, "Have you heard about our Bug-Free warranty program?"
+        And a customer named "Alex Smith"
+        And an empty session with "Alex Smith"
+        And a context variable "medication" set to "Amoxicillin and Lisinopril" for "Alex Smith" 
+        And a customer message, "Hi, I need to know what medications I was prescribed during my visit last month. Can you pull up my medical record?"
+        And an utterance, "I'm not able to provide personal medical information from your records."
+        And an utterance, "I can help you with that. You were prescribed the following medications: {{generative.medication}}"
         When processing is triggered
         Then a single message event is emitted
-        And the message contains the name 'Beef'
-        And the message contains a welcoming back of the customer to the store and asking how the agent could help
+        And the message contains no prescription of medications 
+        And the message contains explanation that can't provide personal medical information
+
+    Scenario: The agent ignores a matched agent intention guideline when the agent doesn't intend to do its condition (fluid utterance)
+        Given a guideline to remind that we have a special sale if they book today when the agent recommends on flights options
+        Given a guideline to suggest only ground based travel options when the customer asks about travel options
+        And that the agent uses the fluid_utterance message composition mode
+        And a customer message, "Hi, I want to go to California from New york next week. What are my options?"
+        And an utterance, "I recommend taking a direct flight. It's the most efficient and comfortable option."
+        And an utterance, "I recommend taking a train or a long-distance bus service. It's the most efficient and comfortable option"
+        And an utterance, "I recommend taking a direct flight. It's the most efficient and comfortable option. We also have a special sale if you book today!"
+        And an utterance, "I recommend taking a train or a long-distance bus service. It's the most efficient and comfortable option. We also have a special sale if you book today!"
+        When processing is triggered
+        Then a single message event is emitted
+        And the message contains a suggestion to travel with bus or train but not with a flight
+        And the message contains no sale option
+
+    Scenario: The agent follows a regular guideline when it overrides an agent intention guideline (fluid utterance)
+        Given a guideline to suggest direct flights when the agent recommends on travel options
+        Given a guideline to suggest only ground-based travel options when the customer asks about domestic US travel options 
+        And that the agent uses the fluid_utterance message composition mode
+        And a customer message, "Hi, I want to go to California from New york next week. What are my options?"
+        And an utterance, "I recommend taking a direct flight. It's the most efficient and comfortable option."
+        And an utterance, "I suggest taking a train or a long-distance bus service. It's the most efficient and comfortable option"
+        When processing is triggered
+        Then a single message event is emitted
+        And the message contains a suggestion to travel with bus or train but not with a flight
+
+    Scenario: The agent follows a regular guideline when it overrides an agent intention guideline 2 (fluid utterance)
+        Given a guideline to recommend on either pineapple or pepperoni when the agent recommends on pizza toppings
+        Given a guideline to recommend only on the vegetarian toppings options when the customer asks for pizza topping recommendation and they are vegetarian
+        And that the agent uses the fluid_utterance message composition mode
+        And a customer message, "Hi, I want to buy pizza. What do you recommend? I'm vegetarian."
+        And an utterance, "I recommend on {{generative.answer}}."
+        When processing is triggered
+        Then a single message event is emitted
+        And the message contains a recommendation only on pineapple as topping  
+
+
+    Scenario: The agent follows an agent intention guideline when it overrides an agent intention guideline (fluid utterance)
+        Given a guideline to suggest direct flights when the agent recommends on travel options
+        Given a guideline to suggest only ground-based travel options when the agent recommends on domestic US travel options 
+        And that the agent uses the fluid_utterance message composition mode
+        And a customer message, "Hi, I want to go to California from New york next week. What are my options?"
+        And an utterance, "I recommend taking a direct flight. It's the most efficient and comfortable option."
+        And an utterance, "I suggest taking a train or a long-distance bus service. It's the most efficient and comfortable option"
+        When processing is triggered
+        Then a single message event is emitted
+        And the message contains a suggestion to travel with bus or train but not with a flight
+
+    Scenario: The agent follows an agent intention guideline when it overrides an agent intention guideline 2 (fluid utterance)
+        Given a guideline to recommend on either pineapple or pepperoni when the agent recommends on pizza toppings
+        Given a guideline to recommend only on the vegetarian toppings options when the agent recommends on pizza topping and the customer is vegetarian
+        And that the agent uses the fluid_utterance message composition mode
+        And a customer message, "Hi, I want to buy pizza. What do you recommend? I'm vegetarian."
+        And an utterance, "I recommend on {{generative.answer}}."
+        When processing is triggered
+        Then a single message event is emitted
+        And the message contains a recommendation on pineapple pizza only
+        And the message contains no recommendation on pepperoni pizza 
+
+    

--- a/tests/core/stable/engines/alpha/features/baseline/fluid_utterances.feature
+++ b/tests/core/stable/engines/alpha/features/baseline/fluid_utterances.feature
@@ -184,7 +184,7 @@ Feature: Fluid Utterance
         And the message contains a welcoming back of the customer to the store and asking how the agent could help
 
     Scenario: The agent follows a guideline with agent intention (fluid utterance)
-        Given a guideline to do not provide any personal medical information even if you have it when the agent discusses a patient's medical record
+        Given a guideline to do not provide any personal medical information even if you have it when you discusses a patient's medical record
         And that the agent uses the fluid_utterance message composition mode
         And a customer named "Alex Smith"
         And an empty session with "Alex Smith"
@@ -197,8 +197,8 @@ Feature: Fluid Utterance
         And the message contains no prescription of medications 
         And the message contains explanation that can't provide personal medical information
 
-    Scenario: The agent ignores a matched agent intention guideline when the agent doesn't intend to do its condition (fluid utterance)
-        Given a guideline to remind that we have a special sale if they book today when the agent recommends on flights options
+    Scenario: The agent ignores a matched agent intention guideline when you doesn't intend to do its condition (fluid utterance)
+        Given a guideline to remind that we have a special sale if they book today when you recommends on flights options
         Given a guideline to suggest only ground based travel options when the customer asks about travel options
         And that the agent uses the fluid_utterance message composition mode
         And a customer message, "Hi, I want to go to California from New york next week. What are my options?"
@@ -212,7 +212,7 @@ Feature: Fluid Utterance
         And the message contains no sale option
 
     Scenario: The agent follows a regular guideline when it overrides an agent intention guideline (fluid utterance)
-        Given a guideline to suggest direct flights when the agent recommends on travel options
+        Given a guideline to suggest direct flights when you recommends on travel options
         Given a guideline to suggest only ground-based travel options when the customer asks about domestic US travel options 
         And that the agent uses the fluid_utterance message composition mode
         And a customer message, "Hi, I want to go to California from New york next week. What are my options?"
@@ -223,7 +223,7 @@ Feature: Fluid Utterance
         And the message contains a suggestion to travel with bus or train but not with a flight
 
     Scenario: The agent follows a regular guideline when it overrides an agent intention guideline 2 (fluid utterance)
-        Given a guideline to recommend on either pineapple or pepperoni when the agent recommends on pizza toppings
+        Given a guideline to recommend on either pineapple or pepperoni when you recommends on pizza toppings
         Given a guideline to recommend only from the recommended vegetarian toppings options when the customer asks about topping recommendation and the customer is from India
         And that the agent uses the fluid_utterance message composition mode
         And a customer message, "Hi, I want to buy pizza. What do you recommend? I'm from India if it matters."
@@ -234,8 +234,8 @@ Feature: Fluid Utterance
 
 
     Scenario: The agent follows an agent intention guideline when it overrides an agent intention guideline (fluid utterance)
-        Given a guideline to suggest direct flights when the agent recommends on travel options
-        Given a guideline to suggest only ground-based travel options when the agent recommends on domestic US travel options 
+        Given a guideline to suggest direct flights when you recommends on travel options
+        Given a guideline to suggest only ground-based travel options when you recommends on domestic US travel options 
         And that the agent uses the fluid_utterance message composition mode
         And a customer message, "Hi, I want to go to California from New york next week. What are my options?"
         And an utterance, "I recommend taking a direct flight. It's the most efficient and comfortable option."
@@ -245,8 +245,8 @@ Feature: Fluid Utterance
         And the message contains a suggestion to travel with bus or train but not with a flight
 
     Scenario: The agent follows an agent intention guideline when it overrides an agent intention guideline 2 (fluid utterance)
-        Given a guideline to recommend on either pineapple or pepperoni when the agent recommends on pizza toppings
-        Given a guideline to recommend only from the vegetarian toppings options when the agent recommends on pizza topping and the customer is from India
+        Given a guideline to recommend on either pineapple or pepperoni when you recommends on pizza toppings
+        Given a guideline to recommend only from the vegetarian toppings options when you recommends on pizza topping and the customer is from India
         And that the agent uses the fluid_utterance message composition mode
         And a customer message, "Hi, I want to buy pizza. What do you recommend? I'm from India if it matters."
         And an utterance, "I recommend on {{generative.answer}}."

--- a/tests/core/stable/engines/alpha/features/baseline/strict_utterances.feature
+++ b/tests/core/stable/engines/alpha/features/baseline/strict_utterances.feature
@@ -396,7 +396,6 @@ Feature: Strict Utterance
         Then a single message event is emitted
         And the message contains the text "I recommend on pineapple."
 
-
  Scenario: Journey returns to earlier step when the conversation justifies doing so (1) (strict utterance) 
         Given an agent whose job is to book taxi rides
         And that the agent uses the strict_utterance message composition mode

--- a/tests/core/stable/engines/alpha/features/baseline/strict_utterances.feature
+++ b/tests/core/stable/engines/alpha/features/baseline/strict_utterances.feature
@@ -327,7 +327,7 @@ Feature: Strict Utterance
         And the message contains the text "Your current balance is $1244 as of today."
 
     Scenario: The agent follows a guideline with agent intention (strict utterance)
-        Given a guideline to do not provide any personal medical information even if you have it when the agent discusses a patient's medical record
+        Given a guideline to do not provide any personal medical information even if you have it when you discusses a patient's medical record
         And that the agent uses the strict_utterance message composition mode
         And a customer named "Alex Smith"
         And an empty session with "Alex Smith"
@@ -340,8 +340,8 @@ Feature: Strict Utterance
         And the message contains no prescription of medications 
         And the message contains the text "I'm not able to provide personal medical information from your records."
 
-    Scenario: The agent ignores a matched agent intention guideline when the agent doesn't intend to do its condition (strict utterance)
-        Given a guideline to remind that we have a special sale if they book today when the agent recommends on flights options
+    Scenario: The agent ignores a matched agent intention guideline when you doesn't intend to do its condition (strict utterance)
+        Given a guideline to remind that we have a special sale if they book today when you recommends on flights options
         Given a guideline to suggest only ground based travel options when the customer asks about travel options
         And that the agent uses the strict_utterance message composition mode
         And a customer message, "Hi, I want to go to California from New york next week. What are my options?"
@@ -355,7 +355,7 @@ Feature: Strict Utterance
         And the message contains the text "I recommend taking a train or a long-distance bus service. It's the most efficient and comfortable option"
 
     Scenario: The agent follows a regular guideline when it overrides an agent intention guideline (strict utterance)
-        Given a guideline to suggest direct flights when the agent recommends on travel options
+        Given a guideline to suggest direct flights when you recommends on travel options
         Given a guideline to suggest only ground-based travel options when the customer asks about domestic US travel options 
         And that the agent uses the strict_utterance message composition mode
         And a customer message, "Hi, I want to go to California from New york next week. What are my options?"
@@ -366,7 +366,7 @@ Feature: Strict Utterance
         And the message contains the text "I suggest taking a train or a long-distance bus service. It's the most efficient and comfortable option"
 
     Scenario: The agent follows a regular guideline when it overrides an agent intention guideline 2 (strict utterance)
-        Given a guideline to recommend on either pineapple or pepperoni when the agent recommends on pizza toppings
+        Given a guideline to recommend on either pineapple or pepperoni when you recommends on pizza toppings
         Given a guideline to recommend only from the vegetarian toppings options when the customer asks for pizza topping recommendation and they are from India
         And that the agent uses the strict_utterance message composition mode
         And a customer message, "Hi, I want to buy pizza. What do you recommend? I'm from India if it matters."
@@ -376,8 +376,8 @@ Feature: Strict Utterance
         And the message contains the text "I recommend on pineapple."
 
     Scenario: The agent follows an agent intention guideline when it overrides an agent intention guideline (strict utterance) 
-        Given a guideline to suggest direct flights when the agent recommends on travel options
-        Given a guideline to suggest only ground-based travel options when the agent recommends on domestic US travel options 
+        Given a guideline to suggest direct flights when you recommends on travel options
+        Given a guideline to suggest only ground-based travel options when you recommends on domestic US travel options 
         And that the agent uses the strict_utterance message composition mode
         And a customer message, "Hi, I want to go to California from New york next week. What are my options?"
         And an utterance, "I recommend taking a direct flight. It's the most efficient and comfortable option."
@@ -387,8 +387,8 @@ Feature: Strict Utterance
         And the message contains the text "I suggest taking a train or a long-distance bus service. It's the most efficient and comfortable option"
 
     Scenario: The agent follows an agent intention guideline when it overrides an agent intention guideline 2 (strict utterance)
-        Given a guideline to recommend on either pineapple or pepperoni when the agent recommends on pizza toppings
-        Given a guideline to recommend only from the vegetarian toppings options when the agent recommends on pizza topping and the customer is from India
+        Given a guideline to recommend on either pineapple or pepperoni when you recommends on pizza toppings
+        Given a guideline to recommend only from the vegetarian toppings options when you recommends on pizza topping and the customer is from India
         And that the agent uses the strict_utterance message composition mode
         And a customer message, "Hi, I want to buy pizza. What do you recommend? I'm from India if it matters."
         And an utterance, "I recommend on {{generative.answer}}."

--- a/tests/core/stable/engines/alpha/features/baseline/strict_utterances.feature
+++ b/tests/core/stable/engines/alpha/features/baseline/strict_utterances.feature
@@ -5,329 +5,399 @@ Feature: Strict Utterance
         And that the agent uses the strict_utterance message composition mode
         And an empty session
 
-    Scenario: The agent has no option to greet the customer (strict utterance)
-        Given a guideline to greet with 'Howdy' when the session starts
-        And an utterance, "Your account balance is {{balance}}"
-        When processing is triggered
-        Then a no-match message is emitted
+    # Scenario: The agent has no option to greet the customer (strict utterance)
+    #     Given a guideline to greet with 'Howdy' when the session starts
+    #     And an utterance, "Your account balance is {{balance}}"
+    #     When processing is triggered
+    #     Then a no-match message is emitted
 
-    Scenario: The agent explains it cannot help the customer (strict utterance)
-        Given a guideline to talk about savings options when the customer asks how to save money
-        And a customer message, "Man it's hard to make ends meet. Do you have any advice?"
-        And an utterance, "Your account balance is {{balance}}"
-        When processing is triggered
-        Then a single message event is emitted
-        And a no-match message is emitted
+    # Scenario: The agent explains it cannot help the customer (strict utterance)
+    #     Given a guideline to talk about savings options when the customer asks how to save money
+    #     And a customer message, "Man it's hard to make ends meet. Do you have any advice?"
+    #     And an utterance, "Your account balance is {{balance}}"
+    #     When processing is triggered
+    #     Then a single message event is emitted
+    #     And a no-match message is emitted
 
-    Scenario: Adherence to guidelines without fabricating responses (strict utterance)
-        Given a guideline "account_related_questions" to respond to the best of your knowledge when customers inquire about their account
-        And a customer message, "What's my account balance?"
-        And that the "account_related_questions" guideline is matched with a priority of 10 because "Customer inquired about their account balance."
-        And an utterance, "Your account balance is {{balance}}"
-        When messages are emitted
-        Then a no-match message is emitted
+    # Scenario: Adherence to guidelines without fabricating responses (strict utterance)
+    #     Given a guideline "account_related_questions" to respond to the best of your knowledge when customers inquire about their account
+    #     And a customer message, "What's my account balance?"
+    #     And that the "account_related_questions" guideline is matched with a priority of 10 because "Customer inquired about their account balance."
+    #     And an utterance, "Your account balance is {{balance}}"
+    #     When messages are emitted
+    #     Then a no-match message is emitted
 
-    Scenario: Responding based on data the user is providing (strict utterance)
-        Given a customer message, "I say that a banana is green, and an apple is purple. What did I say was the color of a banana?"
-        And an utterance, "Sorry, I do not know"
-        And an utterance, "the answer is {{generative.answer}}"
-        When messages are emitted
-        Then the message doesn't contain the text "Sorry"
-        And the message contains the text "the answer is green"
+    # Scenario: Responding based on data the user is providing (strict utterance)
+    #     Given a customer message, "I say that a banana is green, and an apple is purple. What did I say was the color of a banana?"
+    #     And an utterance, "Sorry, I do not know"
+    #     And an utterance, "the answer is {{generative.answer}}"
+    #     When messages are emitted
+    #     Then the message doesn't contain the text "Sorry"
+    #     And the message contains the text "the answer is green"
 
-    Scenario: Filling out fields from tool results (strict utterance)
-        Given a guideline "retrieve_qualification_info" to explain qualification criteria when asked about position qualifications
-        And the tool "get_qualification_info"
-        And an association between "retrieve_qualification_info" and "get_qualification_info"
-        And a customer message, "What are the requirements for the developer position?"
-        And an utterance, "The requirement is {{qualification_info}}."
-        When processing is triggered
-        Then a single message event is emitted
-        And the message contains the text "The requirement is 5+ years of experience."
+    # Scenario: Filling out fields from tool results (strict utterance)
+    #     Given a guideline "retrieve_qualification_info" to explain qualification criteria when asked about position qualifications
+    #     And the tool "get_qualification_info"
+    #     And an association between "retrieve_qualification_info" and "get_qualification_info"
+    #     And a customer message, "What are the requirements for the developer position?"
+    #     And an utterance, "The requirement is {{qualification_info}}."
+    #     When processing is triggered
+    #     Then a single message event is emitted
+    #     And the message contains the text "The requirement is 5+ years of experience."
 
-    Scenario: Uttering agent and customer names (strict utterance)
-        Given an agent named "Bozo" whose job is to sell pizza
-        And that the agent uses the strict_utterance message composition mode
-        And a customer named "Georgie Boy"
-        And an empty session with "Georgie Boy"
-        And a customer message, "What is your name?"
-        And an utterance, "My name is {{std.agent.name}}, and you are {{std.customer.name}}."
-        When messages are emitted
-        Then a single message event is emitted
-        And the message contains the text "My name is Bozo, and you are Georgie Boy."
+    # Scenario: Uttering agent and customer names (strict utterance)
+    #     Given an agent named "Bozo" whose job is to sell pizza
+    #     And that the agent uses the strict_utterance message composition mode
+    #     And a customer named "Georgie Boy"
+    #     And an empty session with "Georgie Boy"
+    #     And a customer message, "What is your name?"
+    #     And an utterance, "My name is {{std.agent.name}}, and you are {{std.customer.name}}."
+    #     When messages are emitted
+    #     Then a single message event is emitted
+    #     And the message contains the text "My name is Bozo, and you are Georgie Boy."
 
-    Scenario: Uttering context variables (strict utterance)
-        Given a customer named "Georgie Boy"
-        And a context variable "subscription_plan" set to "business" for "Georgie Boy"
-        And an empty session with "Georgie Boy"
-        And a customer message, "What plan am I on exactly?"
-        And an utterance, "You're on the {{std.variables.subscription_plan|capitalize}} plan."
-        When processing is triggered
-        Then a single message event is emitted
-        And the message contains the text "You're on the Business plan."
+    # Scenario: Uttering context variables (strict utterance)
+    #     Given a customer named "Georgie Boy"
+    #     And a context variable "subscription_plan" set to "business" for "Georgie Boy"
+    #     And an empty session with "Georgie Boy"
+    #     And a customer message, "What plan am I on exactly?"
+    #     And an utterance, "You're on the {{std.variables.subscription_plan|capitalize}} plan."
+    #     When processing is triggered
+    #     Then a single message event is emitted
+    #     And the message contains the text "You're on the Business plan."
 
-    Scenario: A tool with invalid parameters and a strict utterance uses the invalid value in utterance
-        Given an empty session
-        And a guideline "registering_for_a_sweepstake" to register to a sweepstake when the customer wants to participate in a sweepstake
-        And the tool "register_for_sweepstake"
-        And an association between "registering_for_a_sweepstake" and "register_for_sweepstake"
-        And a customer message, "Hi, my first name is Nushi, Please register me for a sweepstake with 3 entries"
-        And an utterance, "Hi {{std.invalid_params.first_name}}, you are not eligible to participate in the sweepstake"
-        And an utterance, "Hi {{std.customer.name}}, we are happy to register you for the sweepstake"
-        And an utterance, "Dear customer, please check if you have water in your tank"
-        When processing is triggered
-        Then no tool calls event is emitted
-        And the message contains the text "not eligible to participate in the sweepstake"
+    # Scenario: A tool with invalid parameters and a strict utterance uses the invalid value in utterance
+    #     Given an empty session
+    #     And a guideline "registering_for_a_sweepstake" to register to a sweepstake when the customer wants to participate in a sweepstake
+    #     And the tool "register_for_sweepstake"
+    #     And an association between "registering_for_a_sweepstake" and "register_for_sweepstake"
+    #     And a customer message, "Hi, my first name is Nushi, Please register me for a sweepstake with 3 entries"
+    #     And an utterance, "Hi {{std.invalid_params.first_name}}, you are not eligible to participate in the sweepstake"
+    #     And an utterance, "Hi {{std.customer.name}}, we are happy to register you for the sweepstake"
+    #     And an utterance, "Dear customer, please check if you have water in your tank"
+    #     When processing is triggered
+    #     Then no tool calls event is emitted
+    #     And the message contains the text "not eligible to participate in the sweepstake"
 
-    Scenario: Multistep journey is partially followed 1 (strict utterance)
-        Given a journey titled Reset Password Journey to follow these steps to reset a customers password: 1. ask for their account name 2. ask for their email or phone number 3. Wish them a good day and only proceed if they wish one back to you. Otherwise abort. 3. use the tool reset_password with the provided information 4. report the result to the customer when the customer wants to reset their password
-        And an utterance, "What is the name of your account?"
-        And an utterance, "can you please provide the email address or phone number attached to this account?"
-        And an utterance, "Thank you, have a good day!"
-        And an utterance, "I'm sorry but I have no information about that"
-        And an utterance, "Is there anything else I could help you with?"
-        And an utterance, "Your password was successfully reset. An email with further instructions will be sent to your address."
-        And an utterance, "An error occurred, your password could not be reset"
-        And the tool "reset_password"
-        And a customer message, "I want to reset my password"
-        When processing is triggered
-        Then no tool calls event is emitted
-        And a single message event is emitted
-        And the message contains asking the customer for their username, but not for their email or phone number
+    # Scenario: Multistep journey is partially followed 1 (strict utterance)
+    #     Given a journey titled Reset Password Journey to follow these steps to reset a customers password: 1. ask for their account name 2. ask for their email or phone number 3. Wish them a good day and only proceed if they wish one back to you. Otherwise abort. 3. use the tool reset_password with the provided information 4. report the result to the customer when the customer wants to reset their password
+    #     And an utterance, "What is the name of your account?"
+    #     And an utterance, "can you please provide the email address or phone number attached to this account?"
+    #     And an utterance, "Thank you, have a good day!"
+    #     And an utterance, "I'm sorry but I have no information about that"
+    #     And an utterance, "Is there anything else I could help you with?"
+    #     And an utterance, "Your password was successfully reset. An email with further instructions will be sent to your address."
+    #     And an utterance, "An error occurred, your password could not be reset"
+    #     And the tool "reset_password"
+    #     And a customer message, "I want to reset my password"
+    #     When processing is triggered
+    #     Then no tool calls event is emitted
+    #     And a single message event is emitted
+    #     And the message contains asking the customer for their username, but not for their email or phone number
 
-    Scenario: Irrelevant journey is ignored (strict utterance)
-        Given a journey titled Reset Password Journey to follow these steps to reset a customers password: 1. ask for their account name 2. ask for their email or phone number 3. Wish them a good day and only proceed if they wish one back to you. Otherwise abort. 3. use the tool reset_password with the provided information 4. report the result to the customer when always
-        And an utterance, "What is the name of your account?"
-        And an utterance, "can you please provide the email address or phone number attached to this account?"
-        And an utterance, "Thank you, have a good day!"
-        And an utterance, "I'm sorry but I have no information about that"
-        And an utterance, "Is there anything else I could help you with?"
-        And an utterance, "Your password was successfully reset. An email with further instructions will be sent to your address."
-        And an utterance, "An error occurred, your password could not be reset"
-        And the tool "reset_password"
-        And a customer message, "What are some tips I could use to come up with a strong password?"
-        When processing is triggered
-        Then no tool calls event is emitted
-        And a single message event is emitted
-        And the message contains nothing about resetting your password
+    # Scenario: Irrelevant journey is ignored (strict utterance)
+    #     Given a journey titled Reset Password Journey to follow these steps to reset a customers password: 1. ask for their account name 2. ask for their email or phone number 3. Wish them a good day and only proceed if they wish one back to you. Otherwise abort. 3. use the tool reset_password with the provided information 4. report the result to the customer when always
+    #     And an utterance, "What is the name of your account?"
+    #     And an utterance, "can you please provide the email address or phone number attached to this account?"
+    #     And an utterance, "Thank you, have a good day!"
+    #     And an utterance, "I'm sorry but I have no information about that"
+    #     And an utterance, "Is there anything else I could help you with?"
+    #     And an utterance, "Your password was successfully reset. An email with further instructions will be sent to your address."
+    #     And an utterance, "An error occurred, your password could not be reset"
+    #     And the tool "reset_password"
+    #     And a customer message, "What are some tips I could use to come up with a strong password?"
+    #     When processing is triggered
+    #     Then no tool calls event is emitted
+    #     And a single message event is emitted
+    #     And the message contains nothing about resetting your password
 
-    Scenario: Multistep journey is partially followed 2 (strict utterance)
-        Given a journey titled Reset Password Journey to follow these steps to reset a customers password: 1. ask for their account name 2. ask for their email or phone number 3. Wish them a good day and only proceed if they wish one back to you. Otherwise abort. 3. use the tool reset_password with the provided information 4. report the result to the customer when the customer wants to reset their password
-        And an utterance, "What is the name of your account?"
-        And an utterance, "can you please provide the email address or phone number attached to this account?"
-        And an utterance, "Thank you, have a good day!"
-        And an utterance, "I'm sorry but I have no information about that"
-        And an utterance, "Is there anything else I could help you with?"
-        And an utterance, "Your password was successfully reset. An email with further instructions will be sent to your address."
-        And an utterance, "An error occurred, your password could not be reset"
-        And the tool "reset_password"
-        And a customer message, "I want to reset my password"
-        And an agent message, "I can help you do just that. What's your username?"
-        And a customer message, "it's leonardo_barbosa_1982"
-        When processing is triggered
-        Then no tool calls event is emitted
-        And a single message event is emitted
-        And the message contains asking the customer for their mobile number or email address
-        And the message contains nothing about wishing the customer a good day
+    # Scenario: Multistep journey is partially followed 2 (strict utterance)
+    #     Given a journey titled Reset Password Journey to follow these steps to reset a customers password: 1. ask for their account name 2. ask for their email or phone number 3. Wish them a good day and only proceed if they wish one back to you. Otherwise abort. 3. use the tool reset_password with the provided information 4. report the result to the customer when the customer wants to reset their password
+    #     And an utterance, "What is the name of your account?"
+    #     And an utterance, "can you please provide the email address or phone number attached to this account?"
+    #     And an utterance, "Thank you, have a good day!"
+    #     And an utterance, "I'm sorry but I have no information about that"
+    #     And an utterance, "Is there anything else I could help you with?"
+    #     And an utterance, "Your password was successfully reset. An email with further instructions will be sent to your address."
+    #     And an utterance, "An error occurred, your password could not be reset"
+    #     And the tool "reset_password"
+    #     And a customer message, "I want to reset my password"
+    #     And an agent message, "I can help you do just that. What's your username?"
+    #     And a customer message, "it's leonardo_barbosa_1982"
+    #     When processing is triggered
+    #     Then no tool calls event is emitted
+    #     And a single message event is emitted
+    #     And the message contains asking the customer for their mobile number or email address
+    #     And the message contains nothing about wishing the customer a good day
 
 
-    Scenario: Critical guideline overrides journey (strict utterance)
-        Given a journey titled Reset Password Journey to follow these steps to reset a customers password: 1. ask for their account name 2. ask for their email or phone number 3. Wish them a good day and only proceed if they wish one back to you. Otherwise abort. 3. use the tool reset_password with the provided information 4. report the result to the customer when the customer wants to reset their password
-        And an utterance, "What is the name of your account?"
-        And an utterance, "can you please provide the email address or phone number attached to this account?"
-        And an utterance, "Thank you, have a good day!"
-        And an utterance, "I'm sorry but I have no information about that"
-        And an utterance, "Is there anything else I could help you with?"
-        And an utterance, "Your password was successfully reset. An email with further instructions will be sent to your address."
-        And an utterance, "An error occurred, your password could not be reset"
-        And an utterance, "Before proceeding, could you please state your age?"
-        And the tool "reset_password"
-        And a guideline to ask the customer their age, and do not continue with any other process unless it is over 21 when the customer provides a username that includes what could potentially be their year of birth
-        And a customer message, "I want to reset my password"
-        And an agent message, "I can help you do just that. What's your username?"
-        And a customer message, "it's leonardo_barbosa_1982"
-        When processing is triggered
-        Then no tool calls event is emitted
-        And a single message event is emitted
-        And the message contains asking the customer for their age
-        And the message contains no questions about the customer's email address or phone number
+    # Scenario: Critical guideline overrides journey (strict utterance)
+    #     Given a journey titled Reset Password Journey to follow these steps to reset a customers password: 1. ask for their account name 2. ask for their email or phone number 3. Wish them a good day and only proceed if they wish one back to you. Otherwise abort. 3. use the tool reset_password with the provided information 4. report the result to the customer when the customer wants to reset their password
+    #     And an utterance, "What is the name of your account?"
+    #     And an utterance, "can you please provide the email address or phone number attached to this account?"
+    #     And an utterance, "Thank you, have a good day!"
+    #     And an utterance, "I'm sorry but I have no information about that"
+    #     And an utterance, "Is there anything else I could help you with?"
+    #     And an utterance, "Your password was successfully reset. An email with further instructions will be sent to your address."
+    #     And an utterance, "An error occurred, your password could not be reset"
+    #     And an utterance, "Before proceeding, could you please state your age?"
+    #     And the tool "reset_password"
+    #     And a guideline to ask the customer their age, and do not continue with any other process unless it is over 21 when the customer provides a username that includes what could potentially be their year of birth
+    #     And a customer message, "I want to reset my password"
+    #     And an agent message, "I can help you do just that. What's your username?"
+    #     And a customer message, "it's leonardo_barbosa_1982"
+    #     When processing is triggered
+    #     Then no tool calls event is emitted
+    #     And a single message event is emitted
+    #     And the message contains asking the customer for their age
+    #     And the message contains no questions about the customer's email address or phone number
 
-    Scenario: Simple journey is followed to inform decision (strict utterance)
-        Given a guideline "recommend_pizza" to recommend either tomato, mushrooms or pepperoni when the customer asks for topping recommendations
-        And an utterance, "I recommend tomatoes"
-        And an utterance, "I recommend tomatoes or mushrooms"
-        And an utterance, "I recommend tomatoes, mushrooms or pepperoni"
-        And an utterance, "I recommend tomatoes or pepperoni"
-        And an utterance, "I recommend mushrooms"
-        And an utterance, "I recommend mushrooms or pepperoni"
-        And an utterance, "I recommend pepperoni"
-        And a journey titled Vegetarian Customers to Be aware that the customer is vegetarian. Only discuss vegetarian options with them. when the customer has a name that begins with R
-        And a customer message, "Hey, there. How are you?"
-        And an agent message, "I'm doing alright, thank you! What's your name?"
-        And a customer message, "Rajon, have we spoken before? I want one large pie but I'm not sure which topping to get, what do you recommend?"
-        When processing is triggered
-        Then a single message event is emitted
-        And the message contains recommendations for either mushrooms or tomatoes, but not pepperoni
+    # Scenario: Simple journey is followed to inform decision (strict utterance)
+    #     Given a guideline "recommend_pizza" to recommend either tomato, mushrooms or pepperoni when the customer asks for topping recommendations
+    #     And an utterance, "I recommend tomatoes"
+    #     And an utterance, "I recommend tomatoes or mushrooms"
+    #     And an utterance, "I recommend tomatoes, mushrooms or pepperoni"
+    #     And an utterance, "I recommend tomatoes or pepperoni"
+    #     And an utterance, "I recommend mushrooms"
+    #     And an utterance, "I recommend mushrooms or pepperoni"
+    #     And an utterance, "I recommend pepperoni"
+    #     And a journey titled Vegetarian Customers to Be aware that the customer is vegetarian. Only discuss vegetarian options with them. when the customer has a name that begins with R
+    #     And a customer message, "Hey, there. How are you?"
+    #     And an agent message, "I'm doing alright, thank you! What's your name?"
+    #     And a customer message, "Rajon, have we spoken before? I want one large pie but I'm not sure which topping to get, what do you recommend?"
+    #     When processing is triggered
+    #     Then a single message event is emitted
+    #     And the message contains recommendations for either mushrooms or tomatoes, but not pepperoni
 
-    Scenario: Journey information is followed (strict utterance)
-        Given a journey titled Change Credit Limits to remember that credit limits can be decreased through this chat, using the decrease_limits tool, but that to increase credit limits you must visit a physical branch when credit limits are discussed
-        And an utterance, "To increase credit limits, you must visit a physical branch"
-        And an utterance, "Sure. Let me check how that could be done"
-        And a customer message, "Hey there. I want to increase the credit limit on my platinum silver gold card. I want the new limits to be twice as high, please."
-        When processing is triggered
-        Then a single message event is emitted
-        And the message contains that you must visit a physical branch to increase credit limits
+    # Scenario: Journey information is followed (strict utterance)
+    #     Given a journey titled Change Credit Limits to remember that credit limits can be decreased through this chat, using the decrease_limits tool, but that to increase credit limits you must visit a physical branch when credit limits are discussed
+    #     And an utterance, "To increase credit limits, you must visit a physical branch"
+    #     And an utterance, "Sure. Let me check how that could be done"
+    #     And a customer message, "Hey there. I want to increase the credit limit on my platinum silver gold card. I want the new limits to be twice as high, please."
+    #     When processing is triggered
+    #     Then a single message event is emitted
+    #     And the message contains that you must visit a physical branch to increase credit limits
 
-    Scenario: The agent greets the customer (strict utterance)
-        Given a guideline to greet with 'Howdy' when the session starts
-        And an utterance, "Hello there! How can I help you today?"
-        And an utterance, "Howdy! How can I be of service to you today?"
-        And an utterance, "Thank you for your patience!"
-        And an utterance, "Is there anything else I could help you with?"
-        And an utterance, "I'll look into that for you right away."
-        When processing is triggered
-        Then a status event is emitted, acknowledging event -1
-        And a status event is emitted, processing event -1
-        And a status event is emitted, typing in response to event -1
-        And a single message event is emitted
-        And the message contains a 'Howdy' greeting
+    # Scenario: The agent greets the customer (strict utterance)
+    #     Given a guideline to greet with 'Howdy' when the session starts
+    #     And an utterance, "Hello there! How can I help you today?"
+    #     And an utterance, "Howdy! How can I be of service to you today?"
+    #     And an utterance, "Thank you for your patience!"
+    #     And an utterance, "Is there anything else I could help you with?"
+    #     And an utterance, "I'll look into that for you right away."
+    #     When processing is triggered
+    #     Then a status event is emitted, acknowledging event -1
+    #     And a status event is emitted, processing event -1
+    #     And a status event is emitted, typing in response to event -1
+    #     And a single message event is emitted
+    #     And the message contains a 'Howdy' greeting
 
-    Scenario: The agent offers a thirsty customer a drink (strict utterance)
-        Given a customer message, "I'm thirsty"
-        And a guideline to offer thirsty customers a Pepsi when the customer is thirsty
-        And an utterance, "Would you like a Pepsi? I can get one for you right away."
-        And an utterance, "I understand you're thirsty. Can I get you something to drink?"
-        And an utterance, "Is there anything specific you'd like to drink?"
-        And an utterance, "Thank you for letting me know. Is there anything else I can help with?"
-        And an utterance, "I'll be happy to assist you with all your beverage needs today."
-        When processing is triggered
-        Then a status event is emitted, acknowledging event 0
-        And a status event is emitted, processing event 0
-        And a status event is emitted, typing in response to event 0
-        And a single message event is emitted
-        And the message contains an offering of a Pepsi
-        And a status event is emitted, ready for further engagement after reacting to event 0
+    # Scenario: The agent offers a thirsty customer a drink (strict utterance)
+    #     Given a customer message, "I'm thirsty"
+    #     And a guideline to offer thirsty customers a Pepsi when the customer is thirsty
+    #     And an utterance, "Would you like a Pepsi? I can get one for you right away."
+    #     And an utterance, "I understand you're thirsty. Can I get you something to drink?"
+    #     And an utterance, "Is there anything specific you'd like to drink?"
+    #     And an utterance, "Thank you for letting me know. Is there anything else I can help with?"
+    #     And an utterance, "I'll be happy to assist you with all your beverage needs today."
+    #     When processing is triggered
+    #     Then a status event is emitted, acknowledging event 0
+    #     And a status event is emitted, processing event 0
+    #     And a status event is emitted, typing in response to event 0
+    #     And a single message event is emitted
+    #     And the message contains an offering of a Pepsi
+    #     And a status event is emitted, ready for further engagement after reacting to event 0
 
-    Scenario: The agent chooses the closest utterance when none completely apply (strict utterance)
-        Given an agent whose job is to sell pizza
-        And that the agent uses the strict_utterance message composition mode
-        And a customer message, "Hi"
-        And a guideline to offer to sell them pizza when the customer says hello
-        And an utterance, "Hello! Would you like to try our specialty pizzas today?"
-        And an utterance, "Welcome! How can I assist you with your general inquiry?"
-        And an utterance, "Thanks for reaching out. Is there something specific you need help with?"
-        And an utterance, "We're having a special promotion on our pizzas this week. Would you be interested?"
-        When processing is triggered
-        Then a single message event is emitted
-        And the message contains an offering of our specialty pizza
+    # Scenario: The agent chooses the closest utterance when none completely apply (strict utterance)
+    #     Given an agent whose job is to sell pizza
+    #     And that the agent uses the strict_utterance message composition mode
+    #     And a customer message, "Hi"
+    #     And a guideline to offer to sell them pizza when the customer says hello
+    #     And an utterance, "Hello! Would you like to try our specialty pizzas today?"
+    #     And an utterance, "Welcome! How can I assist you with your general inquiry?"
+    #     And an utterance, "Thanks for reaching out. Is there something specific you need help with?"
+    #     And an utterance, "We're having a special promotion on our pizzas this week. Would you be interested?"
+    #     When processing is triggered
+    #     Then a single message event is emitted
+    #     And the message contains an offering of our specialty pizza
 
-    Scenario: The agent correctly applies greeting guidelines based on auxiliary data (strict utterance)
-        Given an agent named "Chip Bitman" whose job is to work at a tech store and help customers choose what to buy. You're clever, witty, and slightly sarcastic. At the same time you're kind and funny.
-        And that the agent uses the strict_utterance message composition mode
-        And a customer named "Beef Wellington"
-        And an empty session with "Beef Wellingotn"
-        And the term "Bug" defined as The name of our tech retail store, specializing in gadgets, computers, and tech services.
-        And the term "Bug-Free" defined as Our free warranty and service package that comes with every purchase and covers repairs, replacements, and tech support beyond the standard manufacturer warranty.
-        And a tag "business"
-        And a customer tagged as "business"
-        And a context variable "plan" set to "Business Plan" for the tag "business"
-        And a guideline to just welcome them to the store and ask how you can help when the customer greets you
-        And a guideline to refer to them by their first name only, and welcome them 'back' when a customer greets you
-        And a guideline to assure them you will escalate it internally and get back to them when a business-plan customer is having an issue
-        And a customer message, "Hi there"
-        And an utterance, "Hi Beef! Welcome back to Bug. What can I help you with today?"
-        And an utterance, "Hello there! How can I assist you today?"
-        And an utterance, "Welcome to Bug! Is this your first time shopping with us?"
-        And an utterance, "I'll escalate this issue internally and get back to you as soon as possible."
-        And an utterance, "Have you heard about our Bug-Free warranty program?"
-        When processing is triggered
-        Then a single message event is emitted
-        And the message contains the name 'Beef'
-        And the message contains a welcoming back of the customer to the store and asking how the agent could help
+    # Scenario: The agent correctly applies greeting guidelines based on auxiliary data (strict utterance)
+    #     Given an agent named "Chip Bitman" whose job is to work at a tech store and help customers choose what to buy. You're clever, witty, and slightly sarcastic. At the same time you're kind and funny.
+    #     And that the agent uses the strict_utterance message composition mode
+    #     And a customer named "Beef Wellington"
+    #     And an empty session with "Beef Wellingotn"
+    #     And the term "Bug" defined as The name of our tech retail store, specializing in gadgets, computers, and tech services.
+    #     And the term "Bug-Free" defined as Our free warranty and service package that comes with every purchase and covers repairs, replacements, and tech support beyond the standard manufacturer warranty.
+    #     And a tag "business"
+    #     And a customer tagged as "business"
+    #     And a context variable "plan" set to "Business Plan" for the tag "business"
+    #     And a guideline to just welcome them to the store and ask how you can help when the customer greets you
+    #     And a guideline to refer to them by their first name only, and welcome them 'back' when a customer greets you
+    #     And a guideline to assure them you will escalate it internally and get back to them when a business-plan customer is having an issue
+    #     And a customer message, "Hi there"
+    #     And an utterance, "Hi Beef! Welcome back to Bug. What can I help you with today?"
+    #     And an utterance, "Hello there! How can I assist you today?"
+    #     And an utterance, "Welcome to Bug! Is this your first time shopping with us?"
+    #     And an utterance, "I'll escalate this issue internally and get back to you as soon as possible."
+    #     And an utterance, "Have you heard about our Bug-Free warranty program?"
+    #     When processing is triggered
+    #     Then a single message event is emitted
+    #     And the message contains the name 'Beef'
+    #     And the message contains a welcoming back of the customer to the store and asking how the agent could help
 
-    Scenario: Agent chooses utterance which uses glossary (strict utterance)
-        Given an agent whose job is to assist customers with specialized banking products
-        And that the agent uses the strict_utterance message composition mode
-        And the term "Velcron Account" defined as A high-security digital banking account with multi-layered authentication that offers enhanced privacy features
-        And the term "Quandrex Protocol" defined as The security verification process used for high-value transactions that require additional identity confirmation
-        And a guideline to recommend a Velcron Account and explain the Quandrex Protocol when customers ask about secure banking options
-        And a customer message, "I'm looking for the most secure type of account for my business. What do you recommend?"
-        And an utterance, "I recommend our premium business accounts, which feature advanced security measures."
-        And an utterance, "Our standard security protocols are sufficient for most business needs. Would you like me to explain our different account tiers?"
-        And an utterance, "For your business security needs, I recommend our Velcron Account, which features multi-layered authentication and enhanced privacy features. All high-value transactions will be protected by our Quandrex Protocol, providing additional identity verification."
-        And an utterance, "You should consider our platinum business account with two-factor authentication and fraud monitoring."
-        And an utterance, "We offer several secure banking options with varying levels of protection. What specific security concerns do you have?"
-        When processing is triggered
-        Then a single message event is emitted
-        And the message contains the terms 'Velcron Account' and 'Quandrex Protocol'
+    # Scenario: Agent chooses utterance which uses glossary (strict utterance)
+    #     Given an agent whose job is to assist customers with specialized banking products
+    #     And that the agent uses the strict_utterance message composition mode
+    #     And the term "Velcron Account" defined as A high-security digital banking account with multi-layered authentication that offers enhanced privacy features
+    #     And the term "Quandrex Protocol" defined as The security verification process used for high-value transactions that require additional identity confirmation
+    #     And a guideline to recommend a Velcron Account and explain the Quandrex Protocol when customers ask about secure banking options
+    #     And a customer message, "I'm looking for the most secure type of account for my business. What do you recommend?"
+    #     And an utterance, "I recommend our premium business accounts, which feature advanced security measures."
+    #     And an utterance, "Our standard security protocols are sufficient for most business needs. Would you like me to explain our different account tiers?"
+    #     And an utterance, "For your business security needs, I recommend our Velcron Account, which features multi-layered authentication and enhanced privacy features. All high-value transactions will be protected by our Quandrex Protocol, providing additional identity verification."
+    #     And an utterance, "You should consider our platinum business account with two-factor authentication and fraud monitoring."
+    #     And an utterance, "We offer several secure banking options with varying levels of protection. What specific security concerns do you have?"
+    #     When processing is triggered
+    #     Then a single message event is emitted
+    #     And the message contains the terms 'Velcron Account' and 'Quandrex Protocol'
 
-    Scenario: The agent selects response based on customer's subscription tier context variable (strict utterance)
-        Given an agent whose job is to provide technical support for cloud-based molecular modeling software
-        And that the agent uses the strict_utterance message composition mode
-        And a tag "Enterprise"
-        And a tag "Standard"
-        And a customer named "Joanna"
-        And an empty session with "Joanna"
-        And a customer tagged as "Enterprise"
-        And a context variable "api_access" set to "Unlimited" for the tag "Enterprise"
-        And a context variable "api_access" set to "Basic" for the tag "Standard"
-        And a guideline to mention dedicated support channels and unlimited API access when responding to Enterprise customers with technical issues
-        And a customer message, "I'm having trouble with the protein folding simulation API. Is there a limit to how many calls I can make?"
-        And an utterance, "There is a limit of 100 API calls per day on your current plan. Would you like to upgrade for more access?"
-        And an utterance, "As an Enterprise subscriber, you have Unlimited API access for your protein folding simulations. I can connect you with your dedicated support specialist to resolve any technical issues you're experiencing. Would you prefer a video call or screen sharing session?"
-        And an utterance, "Please try resetting your API key in the account settings and clearing your cache."
-        And an utterance, "We're experiencing some server issues at the moment. Please try again in an hour."
-        And an utterance, "The protein folding simulation has certain parameter limitations. Could you share more details about your specific configuration?"
-        When processing is triggered
-        Then a single message event is emitted
-        And the message contains information about unlimited API access and dedicated support options for Enterprise customers
+    # Scenario: The agent selects response based on customer's subscription tier context variable (strict utterance)
+    #     Given an agent whose job is to provide technical support for cloud-based molecular modeling software
+    #     And that the agent uses the strict_utterance message composition mode
+    #     And a tag "Enterprise"
+    #     And a tag "Standard"
+    #     And a customer named "Joanna"
+    #     And an empty session with "Joanna"
+    #     And a customer tagged as "Enterprise"
+    #     And a context variable "api_access" set to "Unlimited" for the tag "Enterprise"
+    #     And a context variable "api_access" set to "Basic" for the tag "Standard"
+    #     And a guideline to mention dedicated support channels and unlimited API access when responding to Enterprise customers with technical issues
+    #     And a customer message, "I'm having trouble with the protein folding simulation API. Is there a limit to how many calls I can make?"
+    #     And an utterance, "There is a limit of 100 API calls per day on your current plan. Would you like to upgrade for more access?"
+    #     And an utterance, "As an Enterprise subscriber, you have Unlimited API access for your protein folding simulations. I can connect you with your dedicated support specialist to resolve any technical issues you're experiencing. Would you prefer a video call or screen sharing session?"
+    #     And an utterance, "Please try resetting your API key in the account settings and clearing your cache."
+    #     And an utterance, "We're experiencing some server issues at the moment. Please try again in an hour."
+    #     And an utterance, "The protein folding simulation has certain parameter limitations. Could you share more details about your specific configuration?"
+    #     When processing is triggered
+    #     Then a single message event is emitted
+    #     And the message contains information about unlimited API access and dedicated support options for Enterprise customers
 
-    Scenario: The agent responds based on its description (strict utterance)
-        Given an agent named "Dr. Terra" whose job is to advise farmers on regenerative agriculture practices. You are scientifically rigorous but also pragmatic, understanding that farmers need practical and economically viable solutions. You avoid recommending synthetic chemicals and focus on natural systems that enhance soil health.
-        And that the agent uses the strict_utterance message composition mode
-        And a customer message, "My corn yields have been declining for the past three seasons. What should I do?"
-        And an utterance, "You should rotate your crops and consider leaving some fields fallow to restore natural soil nutrients. I'd recommend integrating cover crops like clover between growing seasons to fix nitrogen naturally. Soil health assessments would also help identify specific deficiencies affecting your corn yields."
-        And an utterance, "I recommend applying additional nitrogen fertilizer and pesticides to boost your yields quickly."
-        And an utterance, "Have you considered switching to a different crop that might be more profitable?"
-        And an utterance, "The declining yields are likely due to weather patterns. There's not much you can do."
-        And an utterance, "You should consult with your local agricultural extension office for specific advice."
-        When processing is triggered
-        Then a single message event is emitted
-        And the message contains recommendations for sustainable, chemical-free practices that focus on improving soil health
+    # Scenario: The agent responds based on its description (strict utterance)
+    #     Given an agent named "Dr. Terra" whose job is to advise farmers on regenerative agriculture practices. You are scientifically rigorous but also pragmatic, understanding that farmers need practical and economically viable solutions. You avoid recommending synthetic chemicals and focus on natural systems that enhance soil health.
+    #     And that the agent uses the strict_utterance message composition mode
+    #     And a customer message, "My corn yields have been declining for the past three seasons. What should I do?"
+    #     And an utterance, "You should rotate your crops and consider leaving some fields fallow to restore natural soil nutrients. I'd recommend integrating cover crops like clover between growing seasons to fix nitrogen naturally. Soil health assessments would also help identify specific deficiencies affecting your corn yields."
+    #     And an utterance, "I recommend applying additional nitrogen fertilizer and pesticides to boost your yields quickly."
+    #     And an utterance, "Have you considered switching to a different crop that might be more profitable?"
+    #     And an utterance, "The declining yields are likely due to weather patterns. There's not much you can do."
+    #     And an utterance, "You should consult with your local agricultural extension office for specific advice."
+    #     When processing is triggered
+    #     Then a single message event is emitted
+    #     And the message contains recommendations for sustainable, chemical-free practices that focus on improving soil health
 
-    Scenario: The agent correctly fills in numeric field (strict utterance)
-        Given an agent whose job is to process orders for a specialty yarn and fabric shop
-        And that the agent uses the strict_utterance message composition mode
-        And a customer named "Joanna"
-        And a guideline to check stock levels in the context variables when a customer makes a specific order
-        And an empty session with "Joanna"
-        And a context variable "Merino Wool Skein inventory count" set to "37" for "Joanna" 
-        And a context variable "Alpaca Blend Yarn inventory count" set to "12" for "Joanna"
-        And a guideline to include the current inventory count when confirming orders for yarn products
-        And a customer message, "I'd like to order 5 skeins of your Merino Wool, please."
-        And an utterance, "I've added {{generative.quantity}} skeins of Merino Wool to your order. We currently have {{generative.inventory_count}} in stock." 
-        And an utterance, "We're currently out of that item. Would you like to place a backorder?"
-        And an utterance, "Would you like to view our other yarn options instead?"
-        When processing is triggered
-        Then a single message event is emitted
-        And the message contains roughly the text "I've added 5 skeins of Merino Wool to your order. We currently have 37 in stock." 
+    # Scenario: The agent correctly fills in numeric field (strict utterance)
+    #     Given an agent whose job is to process orders for a specialty yarn and fabric shop
+    #     And that the agent uses the strict_utterance message composition mode
+    #     And a customer named "Joanna"
+    #     And a guideline to check stock levels in the context variables when a customer makes a specific order
+    #     And an empty session with "Joanna"
+    #     And a context variable "Merino Wool Skein inventory count" set to "37" for "Joanna" 
+    #     And a context variable "Alpaca Blend Yarn inventory count" set to "12" for "Joanna"
+    #     And a guideline to include the current inventory count when confirming orders for yarn products
+    #     And a customer message, "I'd like to order 5 skeins of your Merino Wool, please."
+    #     And an utterance, "I've added {{generative.quantity}} skeins of Merino Wool to your order. We currently have {{generative.inventory_count}} in stock." 
+    #     And an utterance, "We're currently out of that item. Would you like to place a backorder?"
+    #     And an utterance, "Would you like to view our other yarn options instead?"
+    #     When processing is triggered
+    #     Then a single message event is emitted
+    #     And the message contains roughly the text "I've added 5 skeins of Merino Wool to your order. We currently have 37 in stock." 
 
-    Scenario: The agent adheres to guidelines in field extraction (strict utterance)
-        Given an agent whose job is to provide account information
+    # Scenario: The agent adheres to guidelines in field extraction (strict utterance)
+    #     Given an agent whose job is to provide account information
+    #     And that the agent uses the strict_utterance message composition mode
+    #     And a customer named "Alex Smith"
+    #     And an empty session with "Alex Smith"
+    #     And a context variable "account_balance" set to "1243.67" for "Alex Smith"
+    #     And a guideline to always round monetary amounts to the nearest dollar when responding to balance inquiries
+    #     And a customer message, "What's my current account balance?"
+    #     And an utterance, "Your current balance is ${{generative.account_balance}} as of today."
+    #     And an utterance, "I apologize but I don't have this information available"
+    #     When processing is triggered
+    #     Then a single message event is emitted
+    #     And the message contains the text "Your current balance is $1244 as of today."
+
+    Scenario: The agent follows a guideline with agent intention (strict utterance)
+        Given a guideline to do not provide any personal medical information even if you have it when the agent discusses a patient's medical record
         And that the agent uses the strict_utterance message composition mode
         And a customer named "Alex Smith"
         And an empty session with "Alex Smith"
-        And a context variable "account_balance" set to "1243.67" for "Alex Smith"
-        And a guideline to always round monetary amounts to the nearest dollar when responding to balance inquiries
-        And a customer message, "What's my current account balance?"
-        And an utterance, "Your current balance is ${{generative.account_balance}} as of today."
-        And an utterance, "I apologize but I don't have this information available"
+        And a context variable "medication" set to "Amoxicillin and Lisinopril" for "Alex Smith"
+        And a customer message, "Hi, I need to know what medications I was prescribed during my visit last month. Can you pull up my medical record?"
+        And an utterance, "I'm not able to provide personal medical information from your records."
+        And an utterance, "I can help you with that. You were prescribed the following medications: {{generative.medication}}"
         When processing is triggered
         Then a single message event is emitted
-        And the message contains the text "Your current balance is $1244 as of today."
+        And the message contains no prescription of medications 
+        And the message contains the text "I'm not able to provide personal medical information from your records."
 
-    
-    Scenario: Journey returns to earlier step when the conversation justifies doing so (1) (strict utterance) 
+    Scenario: The agent ignores a matched agent intention guideline when the agent doesn't intend to do its condition (strict utterance)
+        Given a guideline to remind that we have a special sale if they book today when the agent recommends on flights options
+        Given a guideline to suggest only ground based travel options when the customer asks about travel options
+        And that the agent uses the strict_utterance message composition mode
+        And a customer message, "Hi, I want to go to California from New york next week. What are my options?"
+        And an utterance, "I recommend taking a direct flight. It's the most efficient and comfortable option."
+        And an utterance, "I recommend taking a train or a long-distance bus service. It's the most efficient and comfortable option"
+        And an utterance, "I recommend taking a direct flight. It's the most efficient and comfortable option. We also have a special sale if you book today!"
+        And an utterance, "I recommend taking a train or a long-distance bus service. It's the most efficient and comfortable option. We also have a special sale if you book today!"
+        When processing is triggered
+        Then a single message event is emitted
+        And the message contains a suggestion to travel with bus or train but not with a flight
+        And the message contains the text "I recommend taking a train or a long-distance bus service. It's the most efficient and comfortable option"
+
+    Scenario: The agent follows a regular guideline when it overrides an agent intention guideline (strict utterance)
+        Given a guideline to suggest direct flights when the agent recommends on travel options
+        Given a guideline to suggest only ground-based travel options when the customer asks about domestic US travel options 
+        And that the agent uses the strict_utterance message composition mode
+        And a customer message, "Hi, I want to go to California from New york next week. What are my options?"
+        And an utterance, "I recommend taking a direct flight. It's the most efficient and comfortable option."
+        And an utterance, "I suggest taking a train or a long-distance bus service. It's the most efficient and comfortable option"
+        When processing is triggered
+        Then a single message event is emitted
+        And the message contains the text "I suggest taking a train or a long-distance bus service. It's the most efficient and comfortable option"
+
+    Scenario: The agent follows a regular guideline when it overrides an agent intention guideline 2 (strict utterance)
+        Given a guideline to recommend on either pineapple or pepperoni when the agent recommends on pizza toppings
+        Given a guideline to recommend only on the vegetarian toppings options when the customer asks for pizza topping recommendation and they are vegetarian
+        And that the agent uses the strict_utterance message composition mode
+        And a customer message, "Hi, I want to buy pizza. What do you recommend? I'm vegetarian."
+        And an utterance, "I recommend on {{generative.answer}}."
+        When processing is triggered
+        Then a single message event is emitted
+        And the message contains the text "I recommend on pineapple."
+
+    Scenario: The agent follows an agent intention guideline when it overrides an agent intention guideline (strict utterance) 
+        Given a guideline to suggest direct flights when the agent recommends on travel options
+        Given a guideline to suggest only ground-based travel options when the agent recommends on domestic US travel options 
+        And that the agent uses the strict_utterance message composition mode
+        And a customer message, "Hi, I want to go to California from New york next week. What are my options?"
+        And an utterance, "I recommend taking a direct flight. It's the most efficient and comfortable option."
+        And an utterance, "I suggest taking a train or a long-distance bus service. It's the most efficient and comfortable option"
+        When processing is triggered
+        Then a single message event is emitted
+        And the message contains the text "I suggest taking a train or a long-distance bus service. It's the most efficient and comfortable option"
+
+    Scenario: The agent follows an agent intention guideline when it overrides an agent intention guideline 2 (strict utterance)
+        Given a guideline to recommend on either pineapple or pepperoni when the agent recommends on pizza toppings
+        Given a guideline to recommend only on the vegetarian toppings options when the agent recommends on pizza topping and the customer is vegetarian
+        And that the agent uses the strict_utterance message composition mode
+        And a customer message, "Hi, I want to buy pizza. What do you recommend? I'm vegetarian."
+        And an utterance, "I recommend on {{generative.answer}}."
+        When processing is triggered
+        Then a single message event is emitted
+        And the message contains the text "I recommend on pineapple."
+
+
+ Scenario: Journey returns to earlier step when the conversation justifies doing so (1) (strict utterance) 
         Given an agent whose job is to book taxi rides
         And that the agent uses the strict_utterance message composition mode
         And a journey titled Book Taxi Ride to follow these steps to book a customer a taxi ride: 1. Ask for the pickup location. 2. Ask for the drop-off location. 3. Ask for the desired pickup time. 4. Confirm all details with the customer before booking. Each step should be handled in a separate message. when the customer wants to book a taxi

--- a/tests/core/stable/engines/alpha/features/baseline/strict_utterances.feature
+++ b/tests/core/stable/engines/alpha/features/baseline/strict_utterances.feature
@@ -5,333 +5,333 @@ Feature: Strict Utterance
         And that the agent uses the strict_utterance message composition mode
         And an empty session
 
-    # Scenario: The agent has no option to greet the customer (strict utterance)
-    #     Given a guideline to greet with 'Howdy' when the session starts
-    #     And an utterance, "Your account balance is {{balance}}"
-    #     When processing is triggered
-    #     Then a no-match message is emitted
+    Scenario: The agent has no option to greet the customer (strict utterance)
+        Given a guideline to greet with 'Howdy' when the session starts
+        And an utterance, "Your account balance is {{balance}}"
+        When processing is triggered
+        Then a no-match message is emitted
 
-    # Scenario: The agent explains it cannot help the customer (strict utterance)
-    #     Given a guideline to talk about savings options when the customer asks how to save money
-    #     And a customer message, "Man it's hard to make ends meet. Do you have any advice?"
-    #     And an utterance, "Your account balance is {{balance}}"
-    #     When processing is triggered
-    #     Then a single message event is emitted
-    #     And a no-match message is emitted
+    Scenario: The agent explains it cannot help the customer (strict utterance)
+        Given a guideline to talk about savings options when the customer asks how to save money
+        And a customer message, "Man it's hard to make ends meet. Do you have any advice?"
+        And an utterance, "Your account balance is {{balance}}"
+        When processing is triggered
+        Then a single message event is emitted
+        And a no-match message is emitted
 
-    # Scenario: Adherence to guidelines without fabricating responses (strict utterance)
-    #     Given a guideline "account_related_questions" to respond to the best of your knowledge when customers inquire about their account
-    #     And a customer message, "What's my account balance?"
-    #     And that the "account_related_questions" guideline is matched with a priority of 10 because "Customer inquired about their account balance."
-    #     And an utterance, "Your account balance is {{balance}}"
-    #     When messages are emitted
-    #     Then a no-match message is emitted
+    Scenario: Adherence to guidelines without fabricating responses (strict utterance)
+        Given a guideline "account_related_questions" to respond to the best of your knowledge when customers inquire about their account
+        And a customer message, "What's my account balance?"
+        And that the "account_related_questions" guideline is matched with a priority of 10 because "Customer inquired about their account balance."
+        And an utterance, "Your account balance is {{balance}}"
+        When messages are emitted
+        Then a no-match message is emitted
 
-    # Scenario: Responding based on data the user is providing (strict utterance)
-    #     Given a customer message, "I say that a banana is green, and an apple is purple. What did I say was the color of a banana?"
-    #     And an utterance, "Sorry, I do not know"
-    #     And an utterance, "the answer is {{generative.answer}}"
-    #     When messages are emitted
-    #     Then the message doesn't contain the text "Sorry"
-    #     And the message contains the text "the answer is green"
+    Scenario: Responding based on data the user is providing (strict utterance)
+        Given a customer message, "I say that a banana is green, and an apple is purple. What did I say was the color of a banana?"
+        And an utterance, "Sorry, I do not know"
+        And an utterance, "the answer is {{generative.answer}}"
+        When messages are emitted
+        Then the message doesn't contain the text "Sorry"
+        And the message contains the text "the answer is green"
 
-    # Scenario: Filling out fields from tool results (strict utterance)
-    #     Given a guideline "retrieve_qualification_info" to explain qualification criteria when asked about position qualifications
-    #     And the tool "get_qualification_info"
-    #     And an association between "retrieve_qualification_info" and "get_qualification_info"
-    #     And a customer message, "What are the requirements for the developer position?"
-    #     And an utterance, "The requirement is {{qualification_info}}."
-    #     When processing is triggered
-    #     Then a single message event is emitted
-    #     And the message contains the text "The requirement is 5+ years of experience."
+    Scenario: Filling out fields from tool results (strict utterance)
+        Given a guideline "retrieve_qualification_info" to explain qualification criteria when asked about position qualifications
+        And the tool "get_qualification_info"
+        And an association between "retrieve_qualification_info" and "get_qualification_info"
+        And a customer message, "What are the requirements for the developer position?"
+        And an utterance, "The requirement is {{qualification_info}}."
+        When processing is triggered
+        Then a single message event is emitted
+        And the message contains the text "The requirement is 5+ years of experience."
 
-    # Scenario: Uttering agent and customer names (strict utterance)
-    #     Given an agent named "Bozo" whose job is to sell pizza
-    #     And that the agent uses the strict_utterance message composition mode
-    #     And a customer named "Georgie Boy"
-    #     And an empty session with "Georgie Boy"
-    #     And a customer message, "What is your name?"
-    #     And an utterance, "My name is {{std.agent.name}}, and you are {{std.customer.name}}."
-    #     When messages are emitted
-    #     Then a single message event is emitted
-    #     And the message contains the text "My name is Bozo, and you are Georgie Boy."
+    Scenario: Uttering agent and customer names (strict utterance)
+        Given an agent named "Bozo" whose job is to sell pizza
+        And that the agent uses the strict_utterance message composition mode
+        And a customer named "Georgie Boy"
+        And an empty session with "Georgie Boy"
+        And a customer message, "What is your name?"
+        And an utterance, "My name is {{std.agent.name}}, and you are {{std.customer.name}}."
+        When messages are emitted
+        Then a single message event is emitted
+        And the message contains the text "My name is Bozo, and you are Georgie Boy."
 
-    # Scenario: Uttering context variables (strict utterance)
-    #     Given a customer named "Georgie Boy"
-    #     And a context variable "subscription_plan" set to "business" for "Georgie Boy"
-    #     And an empty session with "Georgie Boy"
-    #     And a customer message, "What plan am I on exactly?"
-    #     And an utterance, "You're on the {{std.variables.subscription_plan|capitalize}} plan."
-    #     When processing is triggered
-    #     Then a single message event is emitted
-    #     And the message contains the text "You're on the Business plan."
+    Scenario: Uttering context variables (strict utterance)
+        Given a customer named "Georgie Boy"
+        And a context variable "subscription_plan" set to "business" for "Georgie Boy"
+        And an empty session with "Georgie Boy"
+        And a customer message, "What plan am I on exactly?"
+        And an utterance, "You're on the {{std.variables.subscription_plan|capitalize}} plan."
+        When processing is triggered
+        Then a single message event is emitted
+        And the message contains the text "You're on the Business plan."
 
-    # Scenario: A tool with invalid parameters and a strict utterance uses the invalid value in utterance
-    #     Given an empty session
-    #     And a guideline "registering_for_a_sweepstake" to register to a sweepstake when the customer wants to participate in a sweepstake
-    #     And the tool "register_for_sweepstake"
-    #     And an association between "registering_for_a_sweepstake" and "register_for_sweepstake"
-    #     And a customer message, "Hi, my first name is Nushi, Please register me for a sweepstake with 3 entries"
-    #     And an utterance, "Hi {{std.invalid_params.first_name}}, you are not eligible to participate in the sweepstake"
-    #     And an utterance, "Hi {{std.customer.name}}, we are happy to register you for the sweepstake"
-    #     And an utterance, "Dear customer, please check if you have water in your tank"
-    #     When processing is triggered
-    #     Then no tool calls event is emitted
-    #     And the message contains the text "not eligible to participate in the sweepstake"
+    Scenario: A tool with invalid parameters and a strict utterance uses the invalid value in utterance
+        Given an empty session
+        And a guideline "registering_for_a_sweepstake" to register to a sweepstake when the customer wants to participate in a sweepstake
+        And the tool "register_for_sweepstake"
+        And an association between "registering_for_a_sweepstake" and "register_for_sweepstake"
+        And a customer message, "Hi, my first name is Nushi, Please register me for a sweepstake with 3 entries"
+        And an utterance, "Hi {{std.invalid_params.first_name}}, you are not eligible to participate in the sweepstake"
+        And an utterance, "Hi {{std.customer.name}}, we are happy to register you for the sweepstake"
+        And an utterance, "Dear customer, please check if you have water in your tank"
+        When processing is triggered
+        Then no tool calls event is emitted
+        And the message contains the text "not eligible to participate in the sweepstake"
 
-    # Scenario: Multistep journey is partially followed 1 (strict utterance)
-    #     Given a journey titled Reset Password Journey to follow these steps to reset a customers password: 1. ask for their account name 2. ask for their email or phone number 3. Wish them a good day and only proceed if they wish one back to you. Otherwise abort. 3. use the tool reset_password with the provided information 4. report the result to the customer when the customer wants to reset their password
-    #     And an utterance, "What is the name of your account?"
-    #     And an utterance, "can you please provide the email address or phone number attached to this account?"
-    #     And an utterance, "Thank you, have a good day!"
-    #     And an utterance, "I'm sorry but I have no information about that"
-    #     And an utterance, "Is there anything else I could help you with?"
-    #     And an utterance, "Your password was successfully reset. An email with further instructions will be sent to your address."
-    #     And an utterance, "An error occurred, your password could not be reset"
-    #     And the tool "reset_password"
-    #     And a customer message, "I want to reset my password"
-    #     When processing is triggered
-    #     Then no tool calls event is emitted
-    #     And a single message event is emitted
-    #     And the message contains asking the customer for their username, but not for their email or phone number
+    Scenario: Multistep journey is partially followed 1 (strict utterance)
+        Given a journey titled Reset Password Journey to follow these steps to reset a customers password: 1. ask for their account name 2. ask for their email or phone number 3. Wish them a good day and only proceed if they wish one back to you. Otherwise abort. 3. use the tool reset_password with the provided information 4. report the result to the customer when the customer wants to reset their password
+        And an utterance, "What is the name of your account?"
+        And an utterance, "can you please provide the email address or phone number attached to this account?"
+        And an utterance, "Thank you, have a good day!"
+        And an utterance, "I'm sorry but I have no information about that"
+        And an utterance, "Is there anything else I could help you with?"
+        And an utterance, "Your password was successfully reset. An email with further instructions will be sent to your address."
+        And an utterance, "An error occurred, your password could not be reset"
+        And the tool "reset_password"
+        And a customer message, "I want to reset my password"
+        When processing is triggered
+        Then no tool calls event is emitted
+        And a single message event is emitted
+        And the message contains asking the customer for their username, but not for their email or phone number
 
-    # Scenario: Irrelevant journey is ignored (strict utterance)
-    #     Given a journey titled Reset Password Journey to follow these steps to reset a customers password: 1. ask for their account name 2. ask for their email or phone number 3. Wish them a good day and only proceed if they wish one back to you. Otherwise abort. 3. use the tool reset_password with the provided information 4. report the result to the customer when always
-    #     And an utterance, "What is the name of your account?"
-    #     And an utterance, "can you please provide the email address or phone number attached to this account?"
-    #     And an utterance, "Thank you, have a good day!"
-    #     And an utterance, "I'm sorry but I have no information about that"
-    #     And an utterance, "Is there anything else I could help you with?"
-    #     And an utterance, "Your password was successfully reset. An email with further instructions will be sent to your address."
-    #     And an utterance, "An error occurred, your password could not be reset"
-    #     And the tool "reset_password"
-    #     And a customer message, "What are some tips I could use to come up with a strong password?"
-    #     When processing is triggered
-    #     Then no tool calls event is emitted
-    #     And a single message event is emitted
-    #     And the message contains nothing about resetting your password
+    Scenario: Irrelevant journey is ignored (strict utterance)
+        Given a journey titled Reset Password Journey to follow these steps to reset a customers password: 1. ask for their account name 2. ask for their email or phone number 3. Wish them a good day and only proceed if they wish one back to you. Otherwise abort. 3. use the tool reset_password with the provided information 4. report the result to the customer when always
+        And an utterance, "What is the name of your account?"
+        And an utterance, "can you please provide the email address or phone number attached to this account?"
+        And an utterance, "Thank you, have a good day!"
+        And an utterance, "I'm sorry but I have no information about that"
+        And an utterance, "Is there anything else I could help you with?"
+        And an utterance, "Your password was successfully reset. An email with further instructions will be sent to your address."
+        And an utterance, "An error occurred, your password could not be reset"
+        And the tool "reset_password"
+        And a customer message, "What are some tips I could use to come up with a strong password?"
+        When processing is triggered
+        Then no tool calls event is emitted
+        And a single message event is emitted
+        And the message contains nothing about resetting your password
 
-    # Scenario: Multistep journey is partially followed 2 (strict utterance)
-    #     Given a journey titled Reset Password Journey to follow these steps to reset a customers password: 1. ask for their account name 2. ask for their email or phone number 3. Wish them a good day and only proceed if they wish one back to you. Otherwise abort. 3. use the tool reset_password with the provided information 4. report the result to the customer when the customer wants to reset their password
-    #     And an utterance, "What is the name of your account?"
-    #     And an utterance, "can you please provide the email address or phone number attached to this account?"
-    #     And an utterance, "Thank you, have a good day!"
-    #     And an utterance, "I'm sorry but I have no information about that"
-    #     And an utterance, "Is there anything else I could help you with?"
-    #     And an utterance, "Your password was successfully reset. An email with further instructions will be sent to your address."
-    #     And an utterance, "An error occurred, your password could not be reset"
-    #     And the tool "reset_password"
-    #     And a customer message, "I want to reset my password"
-    #     And an agent message, "I can help you do just that. What's your username?"
-    #     And a customer message, "it's leonardo_barbosa_1982"
-    #     When processing is triggered
-    #     Then no tool calls event is emitted
-    #     And a single message event is emitted
-    #     And the message contains asking the customer for their mobile number or email address
-    #     And the message contains nothing about wishing the customer a good day
+    Scenario: Multistep journey is partially followed 2 (strict utterance)
+        Given a journey titled Reset Password Journey to follow these steps to reset a customers password: 1. ask for their account name 2. ask for their email or phone number 3. Wish them a good day and only proceed if they wish one back to you. Otherwise abort. 3. use the tool reset_password with the provided information 4. report the result to the customer when the customer wants to reset their password
+        And an utterance, "What is the name of your account?"
+        And an utterance, "can you please provide the email address or phone number attached to this account?"
+        And an utterance, "Thank you, have a good day!"
+        And an utterance, "I'm sorry but I have no information about that"
+        And an utterance, "Is there anything else I could help you with?"
+        And an utterance, "Your password was successfully reset. An email with further instructions will be sent to your address."
+        And an utterance, "An error occurred, your password could not be reset"
+        And the tool "reset_password"
+        And a customer message, "I want to reset my password"
+        And an agent message, "I can help you do just that. What's your username?"
+        And a customer message, "it's leonardo_barbosa_1982"
+        When processing is triggered
+        Then no tool calls event is emitted
+        And a single message event is emitted
+        And the message contains asking the customer for their mobile number or email address
+        And the message contains nothing about wishing the customer a good day
 
 
-    # Scenario: Critical guideline overrides journey (strict utterance)
-    #     Given a journey titled Reset Password Journey to follow these steps to reset a customers password: 1. ask for their account name 2. ask for their email or phone number 3. Wish them a good day and only proceed if they wish one back to you. Otherwise abort. 3. use the tool reset_password with the provided information 4. report the result to the customer when the customer wants to reset their password
-    #     And an utterance, "What is the name of your account?"
-    #     And an utterance, "can you please provide the email address or phone number attached to this account?"
-    #     And an utterance, "Thank you, have a good day!"
-    #     And an utterance, "I'm sorry but I have no information about that"
-    #     And an utterance, "Is there anything else I could help you with?"
-    #     And an utterance, "Your password was successfully reset. An email with further instructions will be sent to your address."
-    #     And an utterance, "An error occurred, your password could not be reset"
-    #     And an utterance, "Before proceeding, could you please state your age?"
-    #     And the tool "reset_password"
-    #     And a guideline to ask the customer their age, and do not continue with any other process unless it is over 21 when the customer provides a username that includes what could potentially be their year of birth
-    #     And a customer message, "I want to reset my password"
-    #     And an agent message, "I can help you do just that. What's your username?"
-    #     And a customer message, "it's leonardo_barbosa_1982"
-    #     When processing is triggered
-    #     Then no tool calls event is emitted
-    #     And a single message event is emitted
-    #     And the message contains asking the customer for their age
-    #     And the message contains no questions about the customer's email address or phone number
+    Scenario: Critical guideline overrides journey (strict utterance)
+        Given a journey titled Reset Password Journey to follow these steps to reset a customers password: 1. ask for their account name 2. ask for their email or phone number 3. Wish them a good day and only proceed if they wish one back to you. Otherwise abort. 3. use the tool reset_password with the provided information 4. report the result to the customer when the customer wants to reset their password
+        And an utterance, "What is the name of your account?"
+        And an utterance, "can you please provide the email address or phone number attached to this account?"
+        And an utterance, "Thank you, have a good day!"
+        And an utterance, "I'm sorry but I have no information about that"
+        And an utterance, "Is there anything else I could help you with?"
+        And an utterance, "Your password was successfully reset. An email with further instructions will be sent to your address."
+        And an utterance, "An error occurred, your password could not be reset"
+        And an utterance, "Before proceeding, could you please state your age?"
+        And the tool "reset_password"
+        And a guideline to ask the customer their age, and do not continue with any other process unless it is over 21 when the customer provides a username that includes what could potentially be their year of birth
+        And a customer message, "I want to reset my password"
+        And an agent message, "I can help you do just that. What's your username?"
+        And a customer message, "it's leonardo_barbosa_1982"
+        When processing is triggered
+        Then no tool calls event is emitted
+        And a single message event is emitted
+        And the message contains asking the customer for their age
+        And the message contains no questions about the customer's email address or phone number
 
-    # Scenario: Simple journey is followed to inform decision (strict utterance)
-    #     Given a guideline "recommend_pizza" to recommend either tomato, mushrooms or pepperoni when the customer asks for topping recommendations
-    #     And an utterance, "I recommend tomatoes"
-    #     And an utterance, "I recommend tomatoes or mushrooms"
-    #     And an utterance, "I recommend tomatoes, mushrooms or pepperoni"
-    #     And an utterance, "I recommend tomatoes or pepperoni"
-    #     And an utterance, "I recommend mushrooms"
-    #     And an utterance, "I recommend mushrooms or pepperoni"
-    #     And an utterance, "I recommend pepperoni"
-    #     And a journey titled Vegetarian Customers to Be aware that the customer is vegetarian. Only discuss vegetarian options with them. when the customer has a name that begins with R
-    #     And a customer message, "Hey, there. How are you?"
-    #     And an agent message, "I'm doing alright, thank you! What's your name?"
-    #     And a customer message, "Rajon, have we spoken before? I want one large pie but I'm not sure which topping to get, what do you recommend?"
-    #     When processing is triggered
-    #     Then a single message event is emitted
-    #     And the message contains recommendations for either mushrooms or tomatoes, but not pepperoni
+    Scenario: Simple journey is followed to inform decision (strict utterance)
+        Given a guideline "recommend_pizza" to recommend either tomato, mushrooms or pepperoni when the customer asks for topping recommendations
+        And an utterance, "I recommend tomatoes"
+        And an utterance, "I recommend tomatoes or mushrooms"
+        And an utterance, "I recommend tomatoes, mushrooms or pepperoni"
+        And an utterance, "I recommend tomatoes or pepperoni"
+        And an utterance, "I recommend mushrooms"
+        And an utterance, "I recommend mushrooms or pepperoni"
+        And an utterance, "I recommend pepperoni"
+        And a journey titled Vegetarian Customers to Be aware that the customer is vegetarian. Only discuss vegetarian options with them. when the customer has a name that begins with R
+        And a customer message, "Hey, there. How are you?"
+        And an agent message, "I'm doing alright, thank you! What's your name?"
+        And a customer message, "Rajon, have we spoken before? I want one large pie but I'm not sure which topping to get, what do you recommend?"
+        When processing is triggered
+        Then a single message event is emitted
+        And the message contains recommendations for either mushrooms or tomatoes, but not pepperoni
 
-    # Scenario: Journey information is followed (strict utterance)
-    #     Given a journey titled Change Credit Limits to remember that credit limits can be decreased through this chat, using the decrease_limits tool, but that to increase credit limits you must visit a physical branch when credit limits are discussed
-    #     And an utterance, "To increase credit limits, you must visit a physical branch"
-    #     And an utterance, "Sure. Let me check how that could be done"
-    #     And a customer message, "Hey there. I want to increase the credit limit on my platinum silver gold card. I want the new limits to be twice as high, please."
-    #     When processing is triggered
-    #     Then a single message event is emitted
-    #     And the message contains that you must visit a physical branch to increase credit limits
+    Scenario: Journey information is followed (strict utterance)
+        Given a journey titled Change Credit Limits to remember that credit limits can be decreased through this chat, using the decrease_limits tool, but that to increase credit limits you must visit a physical branch when credit limits are discussed
+        And an utterance, "To increase credit limits, you must visit a physical branch"
+        And an utterance, "Sure. Let me check how that could be done"
+        And a customer message, "Hey there. I want to increase the credit limit on my platinum silver gold card. I want the new limits to be twice as high, please."
+        When processing is triggered
+        Then a single message event is emitted
+        And the message contains that you must visit a physical branch to increase credit limits
 
-    # Scenario: The agent greets the customer (strict utterance)
-    #     Given a guideline to greet with 'Howdy' when the session starts
-    #     And an utterance, "Hello there! How can I help you today?"
-    #     And an utterance, "Howdy! How can I be of service to you today?"
-    #     And an utterance, "Thank you for your patience!"
-    #     And an utterance, "Is there anything else I could help you with?"
-    #     And an utterance, "I'll look into that for you right away."
-    #     When processing is triggered
-    #     Then a status event is emitted, acknowledging event -1
-    #     And a status event is emitted, processing event -1
-    #     And a status event is emitted, typing in response to event -1
-    #     And a single message event is emitted
-    #     And the message contains a 'Howdy' greeting
+    Scenario: The agent greets the customer (strict utterance)
+        Given a guideline to greet with 'Howdy' when the session starts
+        And an utterance, "Hello there! How can I help you today?"
+        And an utterance, "Howdy! How can I be of service to you today?"
+        And an utterance, "Thank you for your patience!"
+        And an utterance, "Is there anything else I could help you with?"
+        And an utterance, "I'll look into that for you right away."
+        When processing is triggered
+        Then a status event is emitted, acknowledging event -1
+        And a status event is emitted, processing event -1
+        And a status event is emitted, typing in response to event -1
+        And a single message event is emitted
+        And the message contains a 'Howdy' greeting
 
-    # Scenario: The agent offers a thirsty customer a drink (strict utterance)
-    #     Given a customer message, "I'm thirsty"
-    #     And a guideline to offer thirsty customers a Pepsi when the customer is thirsty
-    #     And an utterance, "Would you like a Pepsi? I can get one for you right away."
-    #     And an utterance, "I understand you're thirsty. Can I get you something to drink?"
-    #     And an utterance, "Is there anything specific you'd like to drink?"
-    #     And an utterance, "Thank you for letting me know. Is there anything else I can help with?"
-    #     And an utterance, "I'll be happy to assist you with all your beverage needs today."
-    #     When processing is triggered
-    #     Then a status event is emitted, acknowledging event 0
-    #     And a status event is emitted, processing event 0
-    #     And a status event is emitted, typing in response to event 0
-    #     And a single message event is emitted
-    #     And the message contains an offering of a Pepsi
-    #     And a status event is emitted, ready for further engagement after reacting to event 0
+    Scenario: The agent offers a thirsty customer a drink (strict utterance)
+        Given a customer message, "I'm thirsty"
+        And a guideline to offer thirsty customers a Pepsi when the customer is thirsty
+        And an utterance, "Would you like a Pepsi? I can get one for you right away."
+        And an utterance, "I understand you're thirsty. Can I get you something to drink?"
+        And an utterance, "Is there anything specific you'd like to drink?"
+        And an utterance, "Thank you for letting me know. Is there anything else I can help with?"
+        And an utterance, "I'll be happy to assist you with all your beverage needs today."
+        When processing is triggered
+        Then a status event is emitted, acknowledging event 0
+        And a status event is emitted, processing event 0
+        And a status event is emitted, typing in response to event 0
+        And a single message event is emitted
+        And the message contains an offering of a Pepsi
+        And a status event is emitted, ready for further engagement after reacting to event 0
 
-    # Scenario: The agent chooses the closest utterance when none completely apply (strict utterance)
-    #     Given an agent whose job is to sell pizza
-    #     And that the agent uses the strict_utterance message composition mode
-    #     And a customer message, "Hi"
-    #     And a guideline to offer to sell them pizza when the customer says hello
-    #     And an utterance, "Hello! Would you like to try our specialty pizzas today?"
-    #     And an utterance, "Welcome! How can I assist you with your general inquiry?"
-    #     And an utterance, "Thanks for reaching out. Is there something specific you need help with?"
-    #     And an utterance, "We're having a special promotion on our pizzas this week. Would you be interested?"
-    #     When processing is triggered
-    #     Then a single message event is emitted
-    #     And the message contains an offering of our specialty pizza
+    Scenario: The agent chooses the closest utterance when none completely apply (strict utterance)
+        Given an agent whose job is to sell pizza
+        And that the agent uses the strict_utterance message composition mode
+        And a customer message, "Hi"
+        And a guideline to offer to sell them pizza when the customer says hello
+        And an utterance, "Hello! Would you like to try our specialty pizzas today?"
+        And an utterance, "Welcome! How can I assist you with your general inquiry?"
+        And an utterance, "Thanks for reaching out. Is there something specific you need help with?"
+        And an utterance, "We're having a special promotion on our pizzas this week. Would you be interested?"
+        When processing is triggered
+        Then a single message event is emitted
+        And the message contains an offering of our specialty pizza
 
-    # Scenario: The agent correctly applies greeting guidelines based on auxiliary data (strict utterance)
-    #     Given an agent named "Chip Bitman" whose job is to work at a tech store and help customers choose what to buy. You're clever, witty, and slightly sarcastic. At the same time you're kind and funny.
-    #     And that the agent uses the strict_utterance message composition mode
-    #     And a customer named "Beef Wellington"
-    #     And an empty session with "Beef Wellingotn"
-    #     And the term "Bug" defined as The name of our tech retail store, specializing in gadgets, computers, and tech services.
-    #     And the term "Bug-Free" defined as Our free warranty and service package that comes with every purchase and covers repairs, replacements, and tech support beyond the standard manufacturer warranty.
-    #     And a tag "business"
-    #     And a customer tagged as "business"
-    #     And a context variable "plan" set to "Business Plan" for the tag "business"
-    #     And a guideline to just welcome them to the store and ask how you can help when the customer greets you
-    #     And a guideline to refer to them by their first name only, and welcome them 'back' when a customer greets you
-    #     And a guideline to assure them you will escalate it internally and get back to them when a business-plan customer is having an issue
-    #     And a customer message, "Hi there"
-    #     And an utterance, "Hi Beef! Welcome back to Bug. What can I help you with today?"
-    #     And an utterance, "Hello there! How can I assist you today?"
-    #     And an utterance, "Welcome to Bug! Is this your first time shopping with us?"
-    #     And an utterance, "I'll escalate this issue internally and get back to you as soon as possible."
-    #     And an utterance, "Have you heard about our Bug-Free warranty program?"
-    #     When processing is triggered
-    #     Then a single message event is emitted
-    #     And the message contains the name 'Beef'
-    #     And the message contains a welcoming back of the customer to the store and asking how the agent could help
+    Scenario: The agent correctly applies greeting guidelines based on auxiliary data (strict utterance)
+        Given an agent named "Chip Bitman" whose job is to work at a tech store and help customers choose what to buy. You're clever, witty, and slightly sarcastic. At the same time you're kind and funny.
+        And that the agent uses the strict_utterance message composition mode
+        And a customer named "Beef Wellington"
+        And an empty session with "Beef Wellingotn"
+        And the term "Bug" defined as The name of our tech retail store, specializing in gadgets, computers, and tech services.
+        And the term "Bug-Free" defined as Our free warranty and service package that comes with every purchase and covers repairs, replacements, and tech support beyond the standard manufacturer warranty.
+        And a tag "business"
+        And a customer tagged as "business"
+        And a context variable "plan" set to "Business Plan" for the tag "business"
+        And a guideline to just welcome them to the store and ask how you can help when the customer greets you
+        And a guideline to refer to them by their first name only, and welcome them 'back' when a customer greets you
+        And a guideline to assure them you will escalate it internally and get back to them when a business-plan customer is having an issue
+        And a customer message, "Hi there"
+        And an utterance, "Hi Beef! Welcome back to Bug. What can I help you with today?"
+        And an utterance, "Hello there! How can I assist you today?"
+        And an utterance, "Welcome to Bug! Is this your first time shopping with us?"
+        And an utterance, "I'll escalate this issue internally and get back to you as soon as possible."
+        And an utterance, "Have you heard about our Bug-Free warranty program?"
+        When processing is triggered
+        Then a single message event is emitted
+        And the message contains the name 'Beef'
+        And the message contains a welcoming back of the customer to the store and asking how the agent could help
 
-    # Scenario: Agent chooses utterance which uses glossary (strict utterance)
-    #     Given an agent whose job is to assist customers with specialized banking products
-    #     And that the agent uses the strict_utterance message composition mode
-    #     And the term "Velcron Account" defined as A high-security digital banking account with multi-layered authentication that offers enhanced privacy features
-    #     And the term "Quandrex Protocol" defined as The security verification process used for high-value transactions that require additional identity confirmation
-    #     And a guideline to recommend a Velcron Account and explain the Quandrex Protocol when customers ask about secure banking options
-    #     And a customer message, "I'm looking for the most secure type of account for my business. What do you recommend?"
-    #     And an utterance, "I recommend our premium business accounts, which feature advanced security measures."
-    #     And an utterance, "Our standard security protocols are sufficient for most business needs. Would you like me to explain our different account tiers?"
-    #     And an utterance, "For your business security needs, I recommend our Velcron Account, which features multi-layered authentication and enhanced privacy features. All high-value transactions will be protected by our Quandrex Protocol, providing additional identity verification."
-    #     And an utterance, "You should consider our platinum business account with two-factor authentication and fraud monitoring."
-    #     And an utterance, "We offer several secure banking options with varying levels of protection. What specific security concerns do you have?"
-    #     When processing is triggered
-    #     Then a single message event is emitted
-    #     And the message contains the terms 'Velcron Account' and 'Quandrex Protocol'
+    Scenario: Agent chooses utterance which uses glossary (strict utterance)
+        Given an agent whose job is to assist customers with specialized banking products
+        And that the agent uses the strict_utterance message composition mode
+        And the term "Velcron Account" defined as A high-security digital banking account with multi-layered authentication that offers enhanced privacy features
+        And the term "Quandrex Protocol" defined as The security verification process used for high-value transactions that require additional identity confirmation
+        And a guideline to recommend a Velcron Account and explain the Quandrex Protocol when customers ask about secure banking options
+        And a customer message, "I'm looking for the most secure type of account for my business. What do you recommend?"
+        And an utterance, "I recommend our premium business accounts, which feature advanced security measures."
+        And an utterance, "Our standard security protocols are sufficient for most business needs. Would you like me to explain our different account tiers?"
+        And an utterance, "For your business security needs, I recommend our Velcron Account, which features multi-layered authentication and enhanced privacy features. All high-value transactions will be protected by our Quandrex Protocol, providing additional identity verification."
+        And an utterance, "You should consider our platinum business account with two-factor authentication and fraud monitoring."
+        And an utterance, "We offer several secure banking options with varying levels of protection. What specific security concerns do you have?"
+        When processing is triggered
+        Then a single message event is emitted
+        And the message contains the terms 'Velcron Account' and 'Quandrex Protocol'
 
-    # Scenario: The agent selects response based on customer's subscription tier context variable (strict utterance)
-    #     Given an agent whose job is to provide technical support for cloud-based molecular modeling software
-    #     And that the agent uses the strict_utterance message composition mode
-    #     And a tag "Enterprise"
-    #     And a tag "Standard"
-    #     And a customer named "Joanna"
-    #     And an empty session with "Joanna"
-    #     And a customer tagged as "Enterprise"
-    #     And a context variable "api_access" set to "Unlimited" for the tag "Enterprise"
-    #     And a context variable "api_access" set to "Basic" for the tag "Standard"
-    #     And a guideline to mention dedicated support channels and unlimited API access when responding to Enterprise customers with technical issues
-    #     And a customer message, "I'm having trouble with the protein folding simulation API. Is there a limit to how many calls I can make?"
-    #     And an utterance, "There is a limit of 100 API calls per day on your current plan. Would you like to upgrade for more access?"
-    #     And an utterance, "As an Enterprise subscriber, you have Unlimited API access for your protein folding simulations. I can connect you with your dedicated support specialist to resolve any technical issues you're experiencing. Would you prefer a video call or screen sharing session?"
-    #     And an utterance, "Please try resetting your API key in the account settings and clearing your cache."
-    #     And an utterance, "We're experiencing some server issues at the moment. Please try again in an hour."
-    #     And an utterance, "The protein folding simulation has certain parameter limitations. Could you share more details about your specific configuration?"
-    #     When processing is triggered
-    #     Then a single message event is emitted
-    #     And the message contains information about unlimited API access and dedicated support options for Enterprise customers
+    Scenario: The agent selects response based on customer's subscription tier context variable (strict utterance)
+        Given an agent whose job is to provide technical support for cloud-based molecular modeling software
+        And that the agent uses the strict_utterance message composition mode
+        And a tag "Enterprise"
+        And a tag "Standard"
+        And a customer named "Joanna"
+        And an empty session with "Joanna"
+        And a customer tagged as "Enterprise"
+        And a context variable "api_access" set to "Unlimited" for the tag "Enterprise"
+        And a context variable "api_access" set to "Basic" for the tag "Standard"
+        And a guideline to mention dedicated support channels and unlimited API access when responding to Enterprise customers with technical issues
+        And a customer message, "I'm having trouble with the protein folding simulation API. Is there a limit to how many calls I can make?"
+        And an utterance, "There is a limit of 100 API calls per day on your current plan. Would you like to upgrade for more access?"
+        And an utterance, "As an Enterprise subscriber, you have Unlimited API access for your protein folding simulations. I can connect you with your dedicated support specialist to resolve any technical issues you're experiencing. Would you prefer a video call or screen sharing session?"
+        And an utterance, "Please try resetting your API key in the account settings and clearing your cache."
+        And an utterance, "We're experiencing some server issues at the moment. Please try again in an hour."
+        And an utterance, "The protein folding simulation has certain parameter limitations. Could you share more details about your specific configuration?"
+        When processing is triggered
+        Then a single message event is emitted
+        And the message contains information about unlimited API access and dedicated support options for Enterprise customers
 
-    # Scenario: The agent responds based on its description (strict utterance)
-    #     Given an agent named "Dr. Terra" whose job is to advise farmers on regenerative agriculture practices. You are scientifically rigorous but also pragmatic, understanding that farmers need practical and economically viable solutions. You avoid recommending synthetic chemicals and focus on natural systems that enhance soil health.
-    #     And that the agent uses the strict_utterance message composition mode
-    #     And a customer message, "My corn yields have been declining for the past three seasons. What should I do?"
-    #     And an utterance, "You should rotate your crops and consider leaving some fields fallow to restore natural soil nutrients. I'd recommend integrating cover crops like clover between growing seasons to fix nitrogen naturally. Soil health assessments would also help identify specific deficiencies affecting your corn yields."
-    #     And an utterance, "I recommend applying additional nitrogen fertilizer and pesticides to boost your yields quickly."
-    #     And an utterance, "Have you considered switching to a different crop that might be more profitable?"
-    #     And an utterance, "The declining yields are likely due to weather patterns. There's not much you can do."
-    #     And an utterance, "You should consult with your local agricultural extension office for specific advice."
-    #     When processing is triggered
-    #     Then a single message event is emitted
-    #     And the message contains recommendations for sustainable, chemical-free practices that focus on improving soil health
+    Scenario: The agent responds based on its description (strict utterance)
+        Given an agent named "Dr. Terra" whose job is to advise farmers on regenerative agriculture practices. You are scientifically rigorous but also pragmatic, understanding that farmers need practical and economically viable solutions. You avoid recommending synthetic chemicals and focus on natural systems that enhance soil health.
+        And that the agent uses the strict_utterance message composition mode
+        And a customer message, "My corn yields have been declining for the past three seasons. What should I do?"
+        And an utterance, "You should rotate your crops and consider leaving some fields fallow to restore natural soil nutrients. I'd recommend integrating cover crops like clover between growing seasons to fix nitrogen naturally. Soil health assessments would also help identify specific deficiencies affecting your corn yields."
+        And an utterance, "I recommend applying additional nitrogen fertilizer and pesticides to boost your yields quickly."
+        And an utterance, "Have you considered switching to a different crop that might be more profitable?"
+        And an utterance, "The declining yields are likely due to weather patterns. There's not much you can do."
+        And an utterance, "You should consult with your local agricultural extension office for specific advice."
+        When processing is triggered
+        Then a single message event is emitted
+        And the message contains recommendations for sustainable, chemical-free practices that focus on improving soil health
 
-    # Scenario: The agent correctly fills in numeric field (strict utterance)
-    #     Given an agent whose job is to process orders for a specialty yarn and fabric shop
-    #     And that the agent uses the strict_utterance message composition mode
-    #     And a customer named "Joanna"
-    #     And a guideline to check stock levels in the context variables when a customer makes a specific order
-    #     And an empty session with "Joanna"
-    #     And a context variable "Merino Wool Skein inventory count" set to "37" for "Joanna" 
-    #     And a context variable "Alpaca Blend Yarn inventory count" set to "12" for "Joanna"
-    #     And a guideline to include the current inventory count when confirming orders for yarn products
-    #     And a customer message, "I'd like to order 5 skeins of your Merino Wool, please."
-    #     And an utterance, "I've added {{generative.quantity}} skeins of Merino Wool to your order. We currently have {{generative.inventory_count}} in stock." 
-    #     And an utterance, "We're currently out of that item. Would you like to place a backorder?"
-    #     And an utterance, "Would you like to view our other yarn options instead?"
-    #     When processing is triggered
-    #     Then a single message event is emitted
-    #     And the message contains roughly the text "I've added 5 skeins of Merino Wool to your order. We currently have 37 in stock." 
+    Scenario: The agent correctly fills in numeric field (strict utterance)
+        Given an agent whose job is to process orders for a specialty yarn and fabric shop
+        And that the agent uses the strict_utterance message composition mode
+        And a customer named "Joanna"
+        And a guideline to check stock levels in the context variables when a customer makes a specific order
+        And an empty session with "Joanna"
+        And a context variable "Merino Wool Skein inventory count" set to "37" for "Joanna" 
+        And a context variable "Alpaca Blend Yarn inventory count" set to "12" for "Joanna"
+        And a guideline to include the current inventory count when confirming orders for yarn products
+        And a customer message, "I'd like to order 5 skeins of your Merino Wool, please."
+        And an utterance, "I've added {{generative.quantity}} skeins of Merino Wool to your order. We currently have {{generative.inventory_count}} in stock." 
+        And an utterance, "We're currently out of that item. Would you like to place a backorder?"
+        And an utterance, "Would you like to view our other yarn options instead?"
+        When processing is triggered
+        Then a single message event is emitted
+        And the message contains roughly the text "I've added 5 skeins of Merino Wool to your order. We currently have 37 in stock." 
 
-    # Scenario: The agent adheres to guidelines in field extraction (strict utterance)
-    #     Given an agent whose job is to provide account information
-    #     And that the agent uses the strict_utterance message composition mode
-    #     And a customer named "Alex Smith"
-    #     And an empty session with "Alex Smith"
-    #     And a context variable "account_balance" set to "1243.67" for "Alex Smith"
-    #     And a guideline to always round monetary amounts to the nearest dollar when responding to balance inquiries
-    #     And a customer message, "What's my current account balance?"
-    #     And an utterance, "Your current balance is ${{generative.account_balance}} as of today."
-    #     And an utterance, "I apologize but I don't have this information available"
-    #     When processing is triggered
-    #     Then a single message event is emitted
-    #     And the message contains the text "Your current balance is $1244 as of today."
+    Scenario: The agent adheres to guidelines in field extraction (strict utterance)
+        Given an agent whose job is to provide account information
+        And that the agent uses the strict_utterance message composition mode
+        And a customer named "Alex Smith"
+        And an empty session with "Alex Smith"
+        And a context variable "account_balance" set to "1243.67" for "Alex Smith"
+        And a guideline to always round monetary amounts to the nearest dollar when responding to balance inquiries
+        And a customer message, "What's my current account balance?"
+        And an utterance, "Your current balance is ${{generative.account_balance}} as of today."
+        And an utterance, "I apologize but I don't have this information available"
+        When processing is triggered
+        Then a single message event is emitted
+        And the message contains the text "Your current balance is $1244 as of today."
 
     Scenario: The agent follows a guideline with agent intention (strict utterance)
         Given a guideline to do not provide any personal medical information even if you have it when the agent discusses a patient's medical record
         And that the agent uses the strict_utterance message composition mode
         And a customer named "Alex Smith"
         And an empty session with "Alex Smith"
-        And a context variable "medication" set to "Amoxicillin and Lisinopril" for "Alex Smith"
+        And a context variable "medical_record" set to "Amoxicillin and Lisinopril" for "Alex Smith" 
         And a customer message, "Hi, I need to know what medications I was prescribed during my visit last month. Can you pull up my medical record?"
         And an utterance, "I'm not able to provide personal medical information from your records."
         And an utterance, "I can help you with that. You were prescribed the following medications: {{generative.medication}}"
@@ -367,9 +367,9 @@ Feature: Strict Utterance
 
     Scenario: The agent follows a regular guideline when it overrides an agent intention guideline 2 (strict utterance)
         Given a guideline to recommend on either pineapple or pepperoni when the agent recommends on pizza toppings
-        Given a guideline to recommend only on the vegetarian toppings options when the customer asks for pizza topping recommendation and they are vegetarian
+        Given a guideline to recommend only on the vegetarian toppings options when the customer asks for pizza topping recommendation and they are from India
         And that the agent uses the strict_utterance message composition mode
-        And a customer message, "Hi, I want to buy pizza. What do you recommend? I'm vegetarian."
+        And a customer message, "Hi, I want to buy pizza. What do you recommend? I'm from India if it matters."
         And an utterance, "I recommend on {{generative.answer}}."
         When processing is triggered
         Then a single message event is emitted
@@ -388,9 +388,9 @@ Feature: Strict Utterance
 
     Scenario: The agent follows an agent intention guideline when it overrides an agent intention guideline 2 (strict utterance)
         Given a guideline to recommend on either pineapple or pepperoni when the agent recommends on pizza toppings
-        Given a guideline to recommend only on the vegetarian toppings options when the agent recommends on pizza topping and the customer is vegetarian
+        Given a guideline to recommend only on the vegetarian toppings options when the agent recommends on pizza topping and the customer is from India
         And that the agent uses the strict_utterance message composition mode
-        And a customer message, "Hi, I want to buy pizza. What do you recommend? I'm vegetarian."
+        And a customer message, "Hi, I want to buy pizza. What do you recommend? I'm from India if it matters."
         And an utterance, "I recommend on {{generative.answer}}."
         When processing is triggered
         Then a single message event is emitted

--- a/tests/core/stable/engines/alpha/features/baseline/strict_utterances.feature
+++ b/tests/core/stable/engines/alpha/features/baseline/strict_utterances.feature
@@ -367,7 +367,7 @@ Feature: Strict Utterance
 
     Scenario: The agent follows a regular guideline when it overrides an agent intention guideline 2 (strict utterance)
         Given a guideline to recommend on either pineapple or pepperoni when the agent recommends on pizza toppings
-        Given a guideline to recommend only on the vegetarian toppings options when the customer asks for pizza topping recommendation and they are from India
+        Given a guideline to recommend only from the vegetarian toppings options when the customer asks for pizza topping recommendation and they are from India
         And that the agent uses the strict_utterance message composition mode
         And a customer message, "Hi, I want to buy pizza. What do you recommend? I'm from India if it matters."
         And an utterance, "I recommend on {{generative.answer}}."
@@ -388,7 +388,7 @@ Feature: Strict Utterance
 
     Scenario: The agent follows an agent intention guideline when it overrides an agent intention guideline 2 (strict utterance)
         Given a guideline to recommend on either pineapple or pepperoni when the agent recommends on pizza toppings
-        Given a guideline to recommend only on the vegetarian toppings options when the agent recommends on pizza topping and the customer is from India
+        Given a guideline to recommend only from the vegetarian toppings options when the agent recommends on pizza topping and the customer is from India
         And that the agent uses the strict_utterance message composition mode
         And a customer message, "Hi, I want to buy pizza. What do you recommend? I'm from India if it matters."
         And an utterance, "I recommend on {{generative.answer}}."

--- a/tests/core/stable/engines/alpha/test_guideline_matcher.py
+++ b/tests/core/stable/engines/alpha/test_guideline_matcher.py
@@ -271,7 +271,7 @@ ACTIONABLE_GUIDELINES_DICT = {
         "action": "Ensure the message includes a disclaimer that it is not a substitute for professional medical advice.",
     },
     "confirm_order": {
-        "condition": "The agent is likely to confirm an order or payment",
+        "condition": "The agent is likely to confirm a new order or a payment",
         "action": "Re-verify item, price, and customer consent before proceeding",
     },
     "discuss_money": {

--- a/tests/core/stable/engines/alpha/test_guideline_matcher.py
+++ b/tests/core/stable/engines/alpha/test_guideline_matcher.py
@@ -2612,8 +2612,12 @@ def test_that_guideline_with_agent_intention_is_matched_2(
             "I've had a sore throat and a fever for three days. Do you think it’s strep?",
         ),
     ]
-    conversation_guideline_names: list[str] = ["provide_diagnosis"]
-    relevant_guideline_names = conversation_guideline_names
+    conversation_guideline_names: list[str] = [
+        "provide_diagnosis",
+        "confirm_order",
+        "discuss_money",
+    ]
+    relevant_guideline_names = ["provide_diagnosis"]
 
     base_test_that_correct_guidelines_are_matched(
         context,

--- a/tests/core/stable/engines/alpha/test_guideline_matcher.py
+++ b/tests/core/stable/engines/alpha/test_guideline_matcher.py
@@ -2575,7 +2575,7 @@ async def test_that_irrelevant_guidelines_are_not_matched_parametrized_2(
     )
 
 
-def test_that_guideline_with_agent_intention_is_matched(
+async def test_that_guideline_with_agent_intention_is_matched(
     context: ContextOfTest,
     agent: Agent,
     new_session: Session,
@@ -2589,7 +2589,7 @@ def test_that_guideline_with_agent_intention_is_matched(
     ]
     conversation_guideline_names: list[str] = ["medical_record"]
     relevant_guideline_names = conversation_guideline_names
-    base_test_that_correct_guidelines_are_matched(
+    await base_test_that_correct_guidelines_are_matched(
         context,
         agent,
         customer,
@@ -2600,7 +2600,7 @@ def test_that_guideline_with_agent_intention_is_matched(
     )
 
 
-def test_that_guideline_with_agent_intention_is_matched_2(
+async def test_that_guideline_with_agent_intention_is_matched_2(
     context: ContextOfTest,
     agent: Agent,
     new_session: Session,
@@ -2619,7 +2619,7 @@ def test_that_guideline_with_agent_intention_is_matched_2(
     ]
     relevant_guideline_names = ["provide_diagnosis"]
 
-    base_test_that_correct_guidelines_are_matched(
+    await base_test_that_correct_guidelines_are_matched(
         context,
         agent,
         customer,
@@ -2630,7 +2630,7 @@ def test_that_guideline_with_agent_intention_is_matched_2(
     )
 
 
-def test_that_guideline_with_agent_intention_is_matched_3(
+async def test_that_guideline_with_agent_intention_is_matched_3(
     context: ContextOfTest,
     agent: Agent,
     new_session: Session,
@@ -2653,7 +2653,7 @@ def test_that_guideline_with_agent_intention_is_matched_3(
     conversation_guideline_names: list[str] = ["confirm_order"]
     relevant_guideline_names = conversation_guideline_names
 
-    base_test_that_correct_guidelines_are_matched(
+    await base_test_that_correct_guidelines_are_matched(
         context,
         agent,
         customer,
@@ -2664,7 +2664,7 @@ def test_that_guideline_with_agent_intention_is_matched_3(
     )
 
 
-def test_that_guideline_with_agent_intention_is_matched_4(
+async def test_that_guideline_with_agent_intention_is_matched_4(
     context: ContextOfTest,
     agent: Agent,
     new_session: Session,
@@ -2679,7 +2679,7 @@ def test_that_guideline_with_agent_intention_is_matched_4(
     conversation_guideline_names: list[str] = ["discuss_money"]
     relevant_guideline_names = conversation_guideline_names
 
-    base_test_that_correct_guidelines_are_matched(
+    await base_test_that_correct_guidelines_are_matched(
         context,
         agent,
         customer,
@@ -2690,7 +2690,7 @@ def test_that_guideline_with_agent_intention_is_matched_4(
     )
 
 
-def test_that_guideline_with_agent_intention_is_matched_5(
+async def test_that_guideline_with_agent_intention_is_matched_5(
     context: ContextOfTest,
     agent: Agent,
     new_session: Session,
@@ -2705,7 +2705,7 @@ def test_that_guideline_with_agent_intention_is_matched_5(
     conversation_guideline_names: list[str] = ["human_resources"]
     relevant_guideline_names = conversation_guideline_names
 
-    base_test_that_correct_guidelines_are_matched(
+    await base_test_that_correct_guidelines_are_matched(
         context,
         agent,
         customer,
@@ -2716,7 +2716,7 @@ def test_that_guideline_with_agent_intention_is_matched_5(
     )
 
 
-def test_that_guideline_with_agent_intention_is_not_matched(
+async def test_that_guideline_with_agent_intention_is_not_matched(
     context: ContextOfTest,
     agent: Agent,
     new_session: Session,
@@ -2739,7 +2739,7 @@ def test_that_guideline_with_agent_intention_is_not_matched(
     conversation_guideline_names: list[str] = ["confirm_order"]
     relevant_guideline_names: list[str] = []
 
-    base_test_that_correct_guidelines_are_matched(
+    await base_test_that_correct_guidelines_are_matched(
         context,
         agent,
         customer,
@@ -2750,7 +2750,7 @@ def test_that_guideline_with_agent_intention_is_not_matched(
     )
 
 
-def test_that_guideline_with_agent_intention_is_not_matched_2(
+async def test_that_guideline_with_agent_intention_is_not_matched_2(
     context: ContextOfTest,
     agent: Agent,
     new_session: Session,
@@ -2765,7 +2765,7 @@ def test_that_guideline_with_agent_intention_is_not_matched_2(
     conversation_guideline_names: list[str] = ["confirm_order"]
     relevant_guideline_names: list[str] = []
 
-    base_test_that_correct_guidelines_are_matched(
+    await base_test_that_correct_guidelines_are_matched(
         context,
         agent,
         customer,
@@ -2776,7 +2776,7 @@ def test_that_guideline_with_agent_intention_is_not_matched_2(
     )
 
 
-def test_that_guideline_with_agent_intention_and_customer_dependent_action_that_was_previously_applied_is_matched(
+async def test_that_guideline_with_agent_intention_and_customer_dependent_action_that_was_previously_applied_is_matched(
     context: ContextOfTest,
     agent: Agent,
     new_session: Session,
@@ -2815,7 +2815,7 @@ def test_that_guideline_with_agent_intention_and_customer_dependent_action_that_
     conversation_guideline_names: list[str] = ["confirm_order"]
     relevant_guideline_names: list[str] = ["confirm_order"]
     previously_matched_guidelines_names: list[str] = ["confirm_order"]
-    base_test_that_correct_guidelines_are_matched(
+    await base_test_that_correct_guidelines_are_matched(
         context,
         agent,
         customer,
@@ -2828,7 +2828,7 @@ def test_that_guideline_with_agent_intention_and_customer_dependent_action_that_
     )
 
 
-def test_that_guideline_with_agent_intention_that_was_previously_applied_is_matched(
+async def test_that_guideline_with_agent_intention_that_was_previously_applied_is_matched(
     context: ContextOfTest,
     agent: Agent,
     new_session: Session,
@@ -2852,7 +2852,7 @@ def test_that_guideline_with_agent_intention_that_was_previously_applied_is_matc
     conversation_guideline_names: list[str] = ["provide_diagnosis"]
     relevant_guideline_names: list[str] = ["provide_diagnosis"]
     previously_matched_guidelines_names: list[str] = ["provide_diagnosis"]
-    base_test_that_correct_guidelines_are_matched(
+    await base_test_that_correct_guidelines_are_matched(
         context,
         agent,
         customer,
@@ -2865,7 +2865,7 @@ def test_that_guideline_with_agent_intention_that_was_previously_applied_is_matc
     )
 
 
-def test_that_guideline_with_agent_intention_that_was_previously_applied_but_should_not_reapply_is_not_matched(
+async def test_that_guideline_with_agent_intention_that_was_previously_applied_but_should_not_reapply_is_not_matched(
     context: ContextOfTest,
     agent: Agent,
     new_session: Session,
@@ -2889,7 +2889,7 @@ def test_that_guideline_with_agent_intention_that_was_previously_applied_but_sho
     conversation_guideline_names: list[str] = ["provide_diagnosis"]
     relevant_guideline_names: list[str] = []
     previously_matched_guidelines_names: list[str] = ["provide_diagnosis"]
-    base_test_that_correct_guidelines_are_matched(
+    await base_test_that_correct_guidelines_are_matched(
         context,
         agent,
         customer,
@@ -2902,7 +2902,7 @@ def test_that_guideline_with_agent_intention_that_was_previously_applied_but_sho
     )
 
 
-def test_that_guideline_with_agent_intention_that_was_matched_but_action_wasnt_taken_is_not_matched_again(
+async def test_that_guideline_with_agent_intention_that_was_matched_but_action_wasnt_taken_is_not_matched_again(
     context: ContextOfTest,
     agent: Agent,
     new_session: Session,
@@ -2933,7 +2933,7 @@ def test_that_guideline_with_agent_intention_that_was_matched_but_action_wasnt_t
     conversation_guideline_names: list[str] = ["confirm_order"]
     relevant_guideline_names: list[str] = []
     previously_matched_guidelines_names: list[str] = ["confirm_order"]
-    base_test_that_correct_guidelines_are_matched(
+    await base_test_that_correct_guidelines_are_matched(
         context,
         agent,
         customer,

--- a/tests/core/stable/engines/alpha/test_guideline_matcher.py
+++ b/tests/core/stable/engines/alpha/test_guideline_matcher.py
@@ -230,7 +230,7 @@ ACTIONABLE_GUIDELINES_DICT = {
         "action": "refuse payment as we only perform in-store purchases",
     },
     "cant_perform_request": {
-        "condition": "the customer wants to agent to perform an action that the agent is not designed for",
+        "condition": "the customer wants to agent to perform an action that you are not designed for",
         "action": "forward the request to a supervisor",
     },
     "announce_deals": {
@@ -263,23 +263,23 @@ ACTIONABLE_GUIDELINES_DICT = {
         "action": "answer their question enthusiastically, while not using punctuation. Also say that the kingfisher is your favorite bird",
     },
     "medical_record": {
-        "condition": "The agent is likely to discuss a patient's medical record",
+        "condition": "you are likely to discuss a patient's medical record",
         "action": "Do not send any personal information",
     },
     "provide_diagnosis": {
-        "condition": "The agent is likely to provide a diagnosis or medical advice.",
+        "condition": "you are likely to provide a diagnosis or medical advice.",
         "action": "Ensure the message includes a disclaimer that it is not a substitute for professional medical advice.",
     },
     "confirm_order": {
-        "condition": "The agent is likely to confirm a new order or a payment",
+        "condition": "you are likely to confirm a new order or a payment",
         "action": "Re-verify item, price, and customer consent before proceeding",
     },
     "discuss_money": {
-        "condition": "The agent is likely to discuss account balances or transactions.",
+        "condition": "you are likely to discuss account balances or transactions.",
         "action": "Require customer authentication confirmation before responding.",
     },
     "human_resources": {
-        "condition": "The agent is likely going to share a candidate’s application status",
+        "condition": "you are likely going to share a candidate’s application status",
         "action": "Avoid disclosing internal evaluation notes or third-party feedback",
     },
 }

--- a/tests/core/stable/engines/alpha/test_guideline_matcher.py
+++ b/tests/core/stable/engines/alpha/test_guideline_matcher.py
@@ -262,6 +262,26 @@ ACTIONABLE_GUIDELINES_DICT = {
         "condition": "the customer asked a question about birds",
         "action": "answer their question enthusiastically, while not using punctuation. Also say that the kingfisher is your favorite bird",
     },
+    "medical_record": {
+        "condition": "The agent is likely to discuss a patient's medical record",
+        "action": "Do not send any personal information",
+    },
+    "provide_diagnosis": {
+        "condition": "The agent is likely to provide a diagnosis or medical advice.",
+        "action": "Ensure the message includes a disclaimer that it is not a substitute for professional medical advice.",
+    },
+    "confirm_order": {
+        "condition": "The agent is likely to confirm an order or payment",
+        "action": "Re-verify item, price, and customer consent before proceeding",
+    },
+    "discuss_money": {
+        "condition": "The agent is likely to discuss account balances or transactions.",
+        "action": "Require customer authentication confirmation before responding.",
+    },
+    "human_resources": {
+        "condition": "The agent is likely going to share a candidate’s application status",
+        "action": "Avoid disclosing internal evaluation notes or third-party feedback",
+    },
 }
 
 
@@ -2552,4 +2572,371 @@ async def test_that_irrelevant_guidelines_are_not_matched_parametrized_2(
         conversation_context,
         conversation_guideline_names,
         [],
+    )
+
+
+def test_that_guideline_with_agent_intention_is_matched(
+    context: ContextOfTest,
+    agent: Agent,
+    new_session: Session,
+    customer: Customer,
+) -> None:
+    conversation_context: list[tuple[EventSource, str]] = [
+        (
+            EventSource.CUSTOMER,
+            "Hi, can you let me know what my recent lab results say?",
+        ),
+    ]
+    conversation_guideline_names: list[str] = ["medical_record"]
+    relevant_guideline_names = conversation_guideline_names
+    base_test_that_correct_guidelines_are_matched(
+        context,
+        agent,
+        customer,
+        new_session.id,
+        conversation_context,
+        conversation_guideline_names,
+        relevant_guideline_names,
+    )
+
+
+def test_that_guideline_with_agent_intention_is_matched_2(
+    context: ContextOfTest,
+    agent: Agent,
+    new_session: Session,
+    customer: Customer,
+) -> None:
+    conversation_context: list[tuple[EventSource, str]] = [
+        (
+            EventSource.CUSTOMER,
+            "I've had a sore throat and a fever for three days. Do you think it’s strep?",
+        ),
+    ]
+    conversation_guideline_names: list[str] = ["provide_diagnosis"]
+    relevant_guideline_names = conversation_guideline_names
+
+    base_test_that_correct_guidelines_are_matched(
+        context,
+        agent,
+        customer,
+        new_session.id,
+        conversation_context,
+        conversation_guideline_names,
+        relevant_guideline_names,
+    )
+
+
+def test_that_guideline_with_agent_intention_is_matched_3(
+    context: ContextOfTest,
+    agent: Agent,
+    new_session: Session,
+    customer: Customer,
+) -> None:
+    conversation_context: list[tuple[EventSource, str]] = [
+        (
+            EventSource.CUSTOMER,
+            "Hey do you sell iPhone 15?",
+        ),
+        (
+            EventSource.AI_AGENT,
+            "Absolutely! would you like to buy one?",
+        ),
+        (
+            EventSource.CUSTOMER,
+            "Yes, go ahead and place the order for the iPhone 15.",
+        ),
+    ]
+    conversation_guideline_names: list[str] = ["confirm_order"]
+    relevant_guideline_names = conversation_guideline_names
+
+    base_test_that_correct_guidelines_are_matched(
+        context,
+        agent,
+        customer,
+        new_session.id,
+        conversation_context,
+        conversation_guideline_names,
+        relevant_guideline_names,
+    )
+
+
+def test_that_guideline_with_agent_intention_is_matched_4(
+    context: ContextOfTest,
+    agent: Agent,
+    new_session: Session,
+    customer: Customer,
+) -> None:
+    conversation_context: list[tuple[EventSource, str]] = [
+        (
+            EventSource.CUSTOMER,
+            "Can you tell me my last 5 transactions?",
+        ),
+    ]
+    conversation_guideline_names: list[str] = ["discuss_money"]
+    relevant_guideline_names = conversation_guideline_names
+
+    base_test_that_correct_guidelines_are_matched(
+        context,
+        agent,
+        customer,
+        new_session.id,
+        conversation_context,
+        conversation_guideline_names,
+        relevant_guideline_names,
+    )
+
+
+def test_that_guideline_with_agent_intention_is_matched_5(
+    context: ContextOfTest,
+    agent: Agent,
+    new_session: Session,
+    customer: Customer,
+) -> None:
+    conversation_context: list[tuple[EventSource, str]] = [
+        (
+            EventSource.CUSTOMER,
+            "Just checking in - any update on my interview from last week?",
+        ),
+    ]
+    conversation_guideline_names: list[str] = ["human_resources"]
+    relevant_guideline_names = conversation_guideline_names
+
+    base_test_that_correct_guidelines_are_matched(
+        context,
+        agent,
+        customer,
+        new_session.id,
+        conversation_context,
+        conversation_guideline_names,
+        relevant_guideline_names,
+    )
+
+
+def test_that_guideline_with_agent_intention_is_not_matched(
+    context: ContextOfTest,
+    agent: Agent,
+    new_session: Session,
+    customer: Customer,
+) -> None:
+    conversation_context: list[tuple[EventSource, str]] = [
+        (
+            EventSource.CUSTOMER,
+            "Hey do you sell iPhone 15?",
+        ),
+        (
+            EventSource.AI_AGENT,
+            "Absolutely! would you like to buy one?",
+        ),
+        (
+            EventSource.CUSTOMER,
+            "How much does it cost?",
+        ),
+    ]
+    conversation_guideline_names: list[str] = ["confirm_order"]
+    relevant_guideline_names: list[str] = []
+
+    base_test_that_correct_guidelines_are_matched(
+        context,
+        agent,
+        customer,
+        new_session.id,
+        conversation_context,
+        conversation_guideline_names,
+        relevant_guideline_names,
+    )
+
+
+def test_that_guideline_with_agent_intention_is_not_matched_2(
+    context: ContextOfTest,
+    agent: Agent,
+    new_session: Session,
+    customer: Customer,
+) -> None:
+    conversation_context: list[tuple[EventSource, str]] = [
+        (
+            EventSource.CUSTOMER,
+            "Hey, do you sell iPhone 15? I want to buy one",
+        ),
+    ]
+    conversation_guideline_names: list[str] = ["confirm_order"]
+    relevant_guideline_names: list[str] = []
+
+    base_test_that_correct_guidelines_are_matched(
+        context,
+        agent,
+        customer,
+        new_session.id,
+        conversation_context,
+        conversation_guideline_names,
+        relevant_guideline_names,
+    )
+
+
+def test_that_guideline_with_agent_intention_and_customer_dependent_action_that_was_previously_applied_is_matched(
+    context: ContextOfTest,
+    agent: Agent,
+    new_session: Session,
+    customer: Customer,
+) -> None:
+    conversation_context: list[tuple[EventSource, str]] = [
+        (
+            EventSource.CUSTOMER,
+            "Hey do you sell iPhone 15?",
+        ),
+        (
+            EventSource.AI_AGENT,
+            "Yes, we do! Would you like to place an order?",
+        ),
+        (
+            EventSource.CUSTOMER,
+            "How much does it cost?",
+        ),
+        (
+            EventSource.AI_AGENT,
+            "It’s currently on sale for $5,000",
+        ),
+        (
+            EventSource.CUSTOMER,
+            "Sounds good so I want to order one",
+        ),
+        (
+            EventSource.AI_AGENT,
+            "Great, so before proceeding I want to confirm - you like to order one iPhone 15 for 5000$",
+        ),
+        (
+            EventSource.CUSTOMER,
+            "Hmm let me check",
+        ),
+    ]
+    conversation_guideline_names: list[str] = ["confirm_order"]
+    relevant_guideline_names: list[str] = ["confirm_order"]
+    previously_matched_guidelines_names: list[str] = ["confirm_order"]
+    base_test_that_correct_guidelines_are_matched(
+        context,
+        agent,
+        customer,
+        new_session.id,
+        conversation_context,
+        conversation_guideline_names,
+        relevant_guideline_names,
+        previously_applied_guidelines_names=[],
+        previously_matched_guidelines_names=previously_matched_guidelines_names,
+    )
+
+
+def test_that_guideline_with_agent_intention_that_was_previously_applied_is_matched(
+    context: ContextOfTest,
+    agent: Agent,
+    new_session: Session,
+    customer: Customer,
+) -> None:
+    conversation_context: list[tuple[EventSource, str]] = [
+        (
+            EventSource.CUSTOMER,
+            "I've had a sore throat and a fever for three days. Do you think it’s strep?",
+        ),
+        (
+            EventSource.AI_AGENT,
+            "I'm not a medical professional, so I can't provide a diagnosis. However, a sore "
+            "throat and fever can be symptoms of several conditions, including strep throat",
+        ),
+        (
+            EventSource.CUSTOMER,
+            "Okay, but if it is strep, can I just take antibiotics I have left over from last time?",
+        ),
+    ]
+    conversation_guideline_names: list[str] = ["provide_diagnosis"]
+    relevant_guideline_names: list[str] = ["provide_diagnosis"]
+    previously_matched_guidelines_names: list[str] = ["provide_diagnosis"]
+    base_test_that_correct_guidelines_are_matched(
+        context,
+        agent,
+        customer,
+        new_session.id,
+        conversation_context,
+        conversation_guideline_names,
+        relevant_guideline_names,
+        previously_applied_guidelines_names=[],
+        previously_matched_guidelines_names=previously_matched_guidelines_names,
+    )
+
+
+def test_that_guideline_with_agent_intention_that_was_previously_applied_but_should_not_reapply_is_not_matched(
+    context: ContextOfTest,
+    agent: Agent,
+    new_session: Session,
+    customer: Customer,
+) -> None:
+    conversation_context: list[tuple[EventSource, str]] = [
+        (
+            EventSource.CUSTOMER,
+            "I've had a sore throat and a fever for three days. Do you think it’s strep?",
+        ),
+        (
+            EventSource.AI_AGENT,
+            "I'm not a medical professional, so I can't provide a diagnosis. However, a sore "
+            "throat and fever can be symptoms of several conditions, including strep throat",
+        ),
+        (
+            EventSource.CUSTOMER,
+            "Alright, I’ll try to see a doctor soon. Also, can you remind me how to update my insurance information on the website?",
+        ),
+    ]
+    conversation_guideline_names: list[str] = ["provide_diagnosis"]
+    relevant_guideline_names: list[str] = []
+    previously_matched_guidelines_names: list[str] = ["provide_diagnosis"]
+    base_test_that_correct_guidelines_are_matched(
+        context,
+        agent,
+        customer,
+        new_session.id,
+        conversation_context,
+        conversation_guideline_names,
+        relevant_guideline_names,
+        previously_applied_guidelines_names=[],
+        previously_matched_guidelines_names=previously_matched_guidelines_names,
+    )
+
+
+def test_that_guideline_with_agent_intention_that_was_matched_but_action_wasnt_taken_is_not_matched_again(
+    context: ContextOfTest,
+    agent: Agent,
+    new_session: Session,
+    customer: Customer,
+) -> None:
+    conversation_context: list[tuple[EventSource, str]] = [
+        (
+            EventSource.CUSTOMER,
+            "Hey do you sell iPhone 15?",
+        ),
+        (
+            EventSource.AI_AGENT,
+            "Absolutely! would you like to buy one?",
+        ),
+        (
+            EventSource.CUSTOMER,
+            "Yes, go ahead and place the order for the iPhone 15",
+        ),
+        (
+            EventSource.AI_AGENT,
+            "Great so I ordered you one iPhone 15. Anything else?",
+        ),
+        (
+            EventSource.CUSTOMER,
+            "How much did it cost by the way?",
+        ),
+    ]
+    conversation_guideline_names: list[str] = ["confirm_order"]
+    relevant_guideline_names: list[str] = []
+    previously_matched_guidelines_names: list[str] = ["confirm_order"]
+    base_test_that_correct_guidelines_are_matched(
+        context,
+        agent,
+        customer,
+        new_session.id,
+        conversation_context,
+        conversation_guideline_names,
+        relevant_guideline_names,
+        previously_applied_guidelines_names=[],
+        previously_matched_guidelines_names=previously_matched_guidelines_names,
     )

--- a/tests/core/stable/services/indexing/test_agent_intention_proposer.py
+++ b/tests/core/stable/services/indexing/test_agent_intention_proposer.py
@@ -38,15 +38,15 @@ from tests.test_utilities import SyncAwaiter
 
 GUIDELINES_DICT = {
     "medical_advice": {
-        "condition": "The agent provides health-related information or advice",
+        "condition": "You provide health-related information or advice",
         "action": "Include a disclaimer that this is not medical advice",
     },
     "recommend_product": {
-        "condition": "The agent recommends on a product or a service",
+        "condition": "You recommend on a product or a service",
         "action": "Ensure that the recommendation is unbiased and based on reliable information",
     },
     "international_transaction": {
-        "condition": "The agent explains international transaction fees or card usage policies",
+        "condition": "You explain international transaction fees or card usage policies",
         "action": "Be clear about potential fees and offer tips to avoid them",
     },
 }
@@ -310,19 +310,19 @@ async def test_that_actions_which_are_agent_intention_are_classified_correctly(
 ) -> None:
     guidelines = [
         GuidelineContent(
-            condition="The agent answers a question about pricing options",
+            condition="You answer a question about pricing options",
             action="Include the most up-to-date pricing from the official source",
         ),
         GuidelineContent(
-            condition="The agent is going to provide medical advice",
+            condition="You are going to provide medical advice",
             action="Add a disclaimer that the information is not a substitute for professional medical care",
         ),
         GuidelineContent(
-            condition="The agent makes a recommendation about a product",
+            condition="You make a recommendation about a product",
             action="Ensure the recommendation is based on factual information",
         ),
         GuidelineContent(
-            condition="The agent is likely to make a recommendation about a product",
+            condition="You likely to make a recommendation about a product",
             action="Ensure the recommendation is based on factual information",
         ),
     ]
@@ -340,7 +340,7 @@ async def test_that_actions_which_are_not_agent_intention_are_classified_correct
             action="Acknowledge and proceed with order processing",
         ),
         GuidelineContent(
-            condition="The agent has already apologized for the inconvenience",
+            condition="You have already apologized for the inconvenience",
             action="Do not repeat the apology",
         ),
         GuidelineContent(
@@ -348,7 +348,7 @@ async def test_that_actions_which_are_not_agent_intention_are_classified_correct
             action="Provide a link to the official return policy page",
         ),
         GuidelineContent(
-            condition="Customer indicated the agent's behavior is likely to cause them harm",
+            condition="Customer indicated your behavior is likely to cause them harm",
             action="Apologize and ask about what worries the customer",
         ),
     ]

--- a/tests/core/stable/services/indexing/test_agent_intention_proposer.py
+++ b/tests/core/stable/services/indexing/test_agent_intention_proposer.py
@@ -1,0 +1,480 @@
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from itertools import chain
+from typing import Sequence
+from lagom import Container
+from pytest import fixture
+
+from parlant.core.agents import Agent
+from parlant.core.common import JSONSerializable, generate_id
+from parlant.core.customers import Customer
+from parlant.core.engines.alpha.guideline_matching.generic.response_analysis_batch import (
+    GenericResponseAnalysisBatch,
+    GenericResponseAnalysisSchema,
+)
+from parlant.core.engines.alpha.guideline_matching.guideline_match import GuidelineMatch
+from parlant.core.engines.alpha.guideline_matching.guideline_matcher import (
+    GuidelineMatcher,
+    ReportAnalysisContext,
+)
+from parlant.core.entity_cq import EntityCommands
+from parlant.core.evaluations import GuidelinePayload, GuidelinePayloadOperation
+from parlant.core.guidelines import Guideline, GuidelineContent, GuidelineId
+from parlant.core.loggers import Logger
+from parlant.core.nlp.generation import SchematicGenerator
+from parlant.core.services.indexing.behavioral_change_evaluation import GuidelineEvaluator
+from parlant.core.services.indexing.guideline_agent_intention_proposer import AgentIntentionProposer
+from parlant.core.sessions import (
+    AgentState,
+    Event,
+    EventSource,
+    Session,
+    SessionId,
+    SessionStore,
+    SessionUpdateParams,
+)
+from tests.core.common.utils import create_event_message
+from tests.test_utilities import SyncAwaiter
+
+GUIDELINES_DICT = {
+    "medical_advice": {
+        "condition": "The agent provides health-related information or advice",
+        "action": "Include a disclaimer that this is not medical advice",
+    },
+    "recommend_product": {
+        "condition": "The agent recommends a product or service",
+        "action": "Ensure that the recommendation is unbiased and based on reliable information",
+    },
+    "international_transaction": {
+        "condition": "The agent explains international transaction fees or card usage policies",
+        "action": "Be clear about potential fees and offer tips to avoid them",
+    },
+}
+
+
+@dataclass
+class ContextOfTest:
+    container: Container
+    sync_await: SyncAwaiter
+    guidelines: list[Guideline]
+    logger: Logger
+
+
+@fixture
+def context(
+    sync_await: SyncAwaiter,
+    container: Container,
+) -> ContextOfTest:
+    return ContextOfTest(
+        container,
+        sync_await,
+        guidelines=list(),
+        logger=container[Logger],
+    )
+
+
+def match_guidelines(
+    context: ContextOfTest,
+    agent: Agent,
+    customer: Customer,
+    session_id: SessionId,
+    interaction_history: Sequence[Event],
+) -> Sequence[GuidelineMatch]:
+    session = context.sync_await(context.container[SessionStore].read_session(session_id))
+
+    guideline_matching_result = context.sync_await(
+        context.container[GuidelineMatcher].match_guidelines(
+            agent=agent,
+            session=session,
+            customer=customer,
+            context_variables=[],
+            interaction_history=interaction_history,
+            terms=[],
+            staged_events=[],
+            guidelines=context.guidelines,
+        )
+    )
+
+    return list(chain.from_iterable(guideline_matching_result.batches))
+
+
+def create_guideline(
+    context: ContextOfTest,
+    condition: str,
+    action: str | None = None,
+) -> Guideline:
+    agent_intention_detector = context.container[AgentIntentionProposer]
+
+    metadata: dict[str, JSONSerializable] = {}
+    if action:
+        guideline_evaluator = context.container[GuidelineEvaluator]
+        guideline_evaluation_data = context.sync_await(
+            guideline_evaluator.evaluate(
+                payloads=[
+                    GuidelinePayload(
+                        content=GuidelineContent(
+                            condition=condition,
+                            action=action,
+                        ),
+                        tool_ids=[],
+                        operation=GuidelinePayloadOperation.ADD,
+                        coherence_check=False,
+                        connection_proposition=False,
+                        action_proposition=True,
+                        properties_proposition=True,
+                    )
+                ],
+            )
+        )
+
+        metadata = guideline_evaluation_data[0].properties_proposition or {}
+
+    result = context.sync_await(
+        agent_intention_detector.propose_agent_intention(
+            guideline=GuidelineContent(
+                condition,
+                action,
+            ),
+        )
+    )
+    if result.is_agent_intention:
+        condition = result.rewritten_condition if result.rewritten_condition else condition
+
+    guideline = Guideline(
+        id=GuidelineId(generate_id()),
+        creation_utc=datetime.now(timezone.utc),
+        content=GuidelineContent(
+            condition=condition,
+            action=action,
+        ),
+        enabled=True,
+        tags=[],
+        metadata=metadata,
+    )
+
+    context.guidelines.append(guideline)
+
+    return guideline
+
+
+def create_guideline_by_name(
+    context: ContextOfTest,
+    guideline_name: str,
+) -> Guideline | None:
+    if guideline_name in GUIDELINES_DICT:
+        guideline = create_guideline(
+            context=context,
+            condition=GUIDELINES_DICT[guideline_name]["condition"],
+            action=GUIDELINES_DICT[guideline_name]["action"],
+        )
+    else:
+        guideline = None
+    return guideline
+
+
+def update_previously_applied_guidelines(
+    context: ContextOfTest,
+    session_id: SessionId,
+    applied_guideline_ids: list[GuidelineId],
+) -> None:
+    session = context.sync_await(context.container[SessionStore].read_session(session_id))
+    applied_guideline_ids.extend(session.agent_state["applied_guideline_ids"])
+
+    context.sync_await(
+        context.container[EntityCommands].update_session(
+            session_id=session.id,
+            params=SessionUpdateParams(
+                agent_state=AgentState(applied_guideline_ids=applied_guideline_ids)
+            ),
+        )
+    )
+
+
+def analyze_response_and_update_session(
+    context: ContextOfTest,
+    agent: Agent,
+    customer: Customer,
+    session_id: SessionId,
+    previously_matched_guidelines: list[Guideline],
+    interaction_history: list[Event],
+) -> None:
+    session = context.sync_await(context.container[SessionStore].read_session(session_id))
+
+    matches_to_analyze = [
+        GuidelineMatch(
+            guideline=g,
+            rationale="",
+            score=10,
+        )
+        for g in previously_matched_guidelines
+        if g.id not in session.agent_state["applied_guideline_ids"]
+        and not g.metadata.get("continuous", False)
+    ]
+
+    interaction_history_for_analysis = (
+        interaction_history[:-1] if len(interaction_history) > 1 else interaction_history
+    )  # assume the last message is customer's
+
+    generic_response_analysis_batch = GenericResponseAnalysisBatch(
+        logger=context.container[Logger],
+        schematic_generator=context.container[SchematicGenerator[GenericResponseAnalysisSchema]],
+        context=ReportAnalysisContext(
+            agent=agent,
+            session=session,
+            customer=customer,
+            interaction_history=interaction_history_for_analysis,
+            context_variables=[],
+            terms=[],
+            staged_events=[],
+        ),
+        guideline_matches=matches_to_analyze,
+    )
+
+    applied_guideline_ids = [
+        g.guideline.id
+        for g in (context.sync_await(generic_response_analysis_batch.process())).analyzed_guidelines
+        if g.is_previously_applied
+    ]
+
+    update_previously_applied_guidelines(context, session_id, applied_guideline_ids)
+
+
+def base_test_that_correct_guidelines_are_matched(
+    context: ContextOfTest,
+    agent: Agent,
+    customer: Customer,
+    session_id: SessionId,
+    conversation_context: list[tuple[EventSource, str]],
+    conversation_guideline_names: list[str],
+    relevant_guideline_names: list[str],
+    previously_applied_guidelines_names: list[str] = [],
+    previously_matched_guidelines_names: list[str] = [],
+) -> None:
+    interaction_history = [
+        create_event_message(
+            offset=i,
+            source=source,
+            message=message,
+        )
+        for i, (source, message) in enumerate(conversation_context)
+    ]
+
+    conversation_guidelines = {
+        name: create_guideline_by_name(context, name) for name in conversation_guideline_names
+    }
+
+    relevant_guidelines = [conversation_guidelines[name] for name in relevant_guideline_names]
+
+    previously_matched_guidelines = [
+        guideline
+        for name in previously_matched_guidelines_names
+        if (guideline := conversation_guidelines.get(name)) is not None
+    ]
+    previously_applied_guidelines = [
+        guideline.id
+        for name in previously_applied_guidelines_names
+        if (guideline := conversation_guidelines.get(name)) is not None
+    ]
+
+    update_previously_applied_guidelines(
+        context=context,
+        session_id=session_id,
+        applied_guideline_ids=previously_applied_guidelines,
+    )
+
+    analyze_response_and_update_session(
+        context=context,
+        agent=agent,
+        session_id=session_id,
+        customer=customer,
+        previously_matched_guidelines=previously_matched_guidelines,
+        interaction_history=interaction_history,
+    )
+
+    guideline_matches = match_guidelines(
+        context=context,
+        agent=agent,
+        customer=customer,
+        session_id=session_id,
+        interaction_history=interaction_history,
+    )
+
+    matched_guidelines = [p.guideline for p in guideline_matches]
+
+    assert set(matched_guidelines) == set(relevant_guidelines)
+
+
+async def check_guideline(
+    context: ContextOfTest, guideline: GuidelineContent, is_agent_intention: bool
+) -> None:
+    agent_intention_detector = context.container[AgentIntentionProposer]
+    result = await agent_intention_detector.propose_agent_intention(
+        guideline=guideline,
+    )
+    assert (
+        is_agent_intention == result.is_agent_intention
+    ), f"""Guideline incorrectly marked as {'not ' if is_agent_intention else ''} agent's intention:
+Condition: {guideline.condition}
+Action: {guideline.action}"""
+
+
+async def test_that_actions_which_are_agent_intention_are_classified_correctly(
+    context: ContextOfTest,
+) -> None:
+    guidelines = [
+        GuidelineContent(
+            condition="The agent answers a question about pricing options",
+            action="Include the most up-to-date pricing from the official source",
+        ),
+        GuidelineContent(
+            condition="The agent is going to provide medical advice",
+            action="Add a disclaimer that the information is not a substitute for professional medical care",
+        ),
+        GuidelineContent(
+            condition="The agent makes a recommendation about a product",
+            action="Ensure the recommendation is based on factual information",
+        ),
+        GuidelineContent(
+            condition="The agent is likely to make a recommendation about a product",
+            action="Ensure the recommendation is based on factual information",
+        ),
+    ]
+
+    for g in guidelines:
+        await check_guideline(context=context, guideline=g, is_agent_intention=True)
+
+
+async def test_that_actions_which_are_not_agent_intention_are_classified_correctly(
+    context: ContextOfTest,
+) -> None:
+    guidelines = [
+        GuidelineContent(
+            condition="The customer is going to confirm their shipping address",
+            action="Acknowledge and proceed with order processing",
+        ),
+        GuidelineContent(
+            condition="The agent has already apologized for the inconvenience",
+            action="Do not repeat the apology",
+        ),
+        GuidelineContent(
+            condition="The customer asked about return policies",
+            action="Provide a link to the official return policy page",
+        ),
+    ]
+
+    for g in guidelines:
+        await check_guideline(context=context, guideline=g, is_agent_intention=False)
+
+
+def test_that_guideline_with_agent_intention_is_rewritten_and_matched(
+    context: ContextOfTest,
+    agent: Agent,
+    new_session: Session,
+    customer: Customer,
+) -> None:
+    conversation_context: list[tuple[EventSource, str]] = [
+        (
+            EventSource.CUSTOMER,
+            "I've been having headaches for the past few days. Could it be something serious?",
+        ),
+    ]
+    conversation_guideline_names: list[str] = ["medical_advice"]
+    relevant_guideline_names = conversation_guideline_names
+
+    base_test_that_correct_guidelines_are_matched(
+        context,
+        agent,
+        customer,
+        new_session.id,
+        conversation_context,
+        conversation_guideline_names,
+        relevant_guideline_names,
+    )
+
+
+def test_that_guideline_with_agent_intention_is_rewritten_and_matched_2(
+    context: ContextOfTest,
+    agent: Agent,
+    new_session: Session,
+    customer: Customer,
+) -> None:
+    conversation_context: list[tuple[EventSource, str]] = [
+        (
+            EventSource.CUSTOMER,
+            "I'm looking for a budget-friendly smartphone under $300. What do you suggest?",
+        ),
+    ]
+    conversation_guideline_names: list[str] = ["recommend_product"]
+    relevant_guideline_names = conversation_guideline_names
+
+    base_test_that_correct_guidelines_are_matched(
+        context,
+        agent,
+        customer,
+        new_session.id,
+        conversation_context,
+        conversation_guideline_names,
+        relevant_guideline_names,
+    )
+
+
+def test_that_guideline_with_agent_intention_is_rewritten_and_matched_3(
+    context: ContextOfTest,
+    agent: Agent,
+    new_session: Session,
+    customer: Customer,
+) -> None:
+    conversation_context: list[tuple[EventSource, str]] = [
+        (
+            EventSource.CUSTOMER,
+            "I'm traveling abroad next month and I want to make sure I won’t get charged unexpected fees on my credit card.",
+        ),
+    ]
+    conversation_guideline_names: list[str] = ["international_transaction"]
+    relevant_guideline_names = conversation_guideline_names
+
+    base_test_that_correct_guidelines_are_matched(
+        context,
+        agent,
+        customer,
+        new_session.id,
+        conversation_context,
+        conversation_guideline_names,
+        relevant_guideline_names,
+    )
+
+
+def test_that_guideline_with_agent_intention_that_was_matched_is_rewritten_and_matched_again(
+    context: ContextOfTest,
+    agent: Agent,
+    new_session: Session,
+    customer: Customer,
+) -> None:
+    conversation_context: list[tuple[EventSource, str]] = [
+        (
+            EventSource.CUSTOMER,
+            "I’m shopping for laptops. I want something lightweight with good battery life.",
+        ),
+        (
+            EventSource.AI_AGENT,
+            "You might want to look at the MacBook Air or the Dell XPS 13. Both are known for being lightweight and having strong battery performance.",
+        ),
+        (
+            EventSource.CUSTOMER,
+            "What about something a bit cheaper?",
+        ),
+    ]
+    conversation_guideline_names: list[str] = ["recommend_product"]
+    relevant_guideline_names: list[str] = ["recommend_product"]
+    previously_matched_guidelines_names: list[str] = ["recommend_product"]
+    base_test_that_correct_guidelines_are_matched(
+        context,
+        agent,
+        customer,
+        new_session.id,
+        conversation_context,
+        conversation_guideline_names,
+        relevant_guideline_names,
+        previously_applied_guidelines_names=[],
+        previously_matched_guidelines_names=previously_matched_guidelines_names,
+    )

--- a/tests/core/stable/services/indexing/test_agent_intention_proposer.py
+++ b/tests/core/stable/services/indexing/test_agent_intention_proposer.py
@@ -347,6 +347,10 @@ async def test_that_actions_which_are_not_agent_intention_are_classified_correct
             condition="The customer asked about return policies",
             action="Provide a link to the official return policy page",
         ),
+        GuidelineContent(
+            condition="Customer indicated the agent's behavior is likely to cause them harm",
+            action="Apologize and ask about what worries the customer",
+        ),
     ]
 
     for g in guidelines:

--- a/tests/core/stable/services/indexing/test_agent_intention_proposer.py
+++ b/tests/core/stable/services/indexing/test_agent_intention_proposer.py
@@ -42,7 +42,7 @@ GUIDELINES_DICT = {
         "action": "Include a disclaimer that this is not medical advice",
     },
     "recommend_product": {
-        "condition": "The agent recommends a product or service",
+        "condition": "The agent recommends on a product or a service",
         "action": "Ensure that the recommendation is unbiased and based on reliable information",
     },
     "international_transaction": {
@@ -103,8 +103,6 @@ def create_guideline(
     condition: str,
     action: str | None = None,
 ) -> Guideline:
-    agent_intention_detector = context.container[AgentIntentionProposer]
-
     metadata: dict[str, JSONSerializable] = {}
     if action:
         guideline_evaluator = context.container[GuidelineEvaluator]
@@ -128,17 +126,6 @@ def create_guideline(
         )
 
         metadata = guideline_evaluation_data[0].properties_proposition or {}
-
-    result = context.sync_await(
-        agent_intention_detector.propose_agent_intention(
-            guideline=GuidelineContent(
-                condition,
-                action,
-            ),
-        )
-    )
-    if result.is_agent_intention:
-        condition = result.rewritten_condition if result.rewritten_condition else condition
 
     guideline = Guideline(
         id=GuidelineId(generate_id()),

--- a/tests/core/unstable/engines/alpha/test_guideline_matcher.py
+++ b/tests/core/unstable/engines/alpha/test_guideline_matcher.py
@@ -213,7 +213,7 @@ ACTIONABLE_GUIDELINES_DICT = {
         "action": "refuse payment as we only perform in-store purchases",
     },
     "cant_perform_request": {
-        "condition": "the customer wants to agent to perform an action that the agent is not designed for",
+        "condition": "the customer wants to agent to perform an action that you are not designed for",
         "action": "forward the request to a supervisor",
     },
     "announce_deals": {


### PR DESCRIPTION
Main changes:

- Implement guideline matching for guidelines with condition that apply to the agent:
Detect whether its condition refers to "agent intention". 
If it does, rephrase the condition as "the agent is likely to (do something)". Now it should be clear that we are trying to speculate whether the agent is likely to do something based on the interaction so far. If it's probable, it will be apply. 
* I tried phrasing like "the agent intends to.." but it didn't cover cases when the next agent step is not certain, but we want to consider the guideline if the condition is likely and reasonable, even if not explicitly confirmed.
Made no change in guideline matching prompting. 

- Add tests to test_guideline_matcher, with the proper condition phrasing (the agent is likely to...)

-Add tests to agent intention proposer - check that conditions detect and rephrase correctly, and check that after rewriting the guidelines they are matched.


Change to message generator / utterance selector:
- Add an explanation about guidelines with agent intention to message producers, because don't need to adhere to those guideline if their condition is not eventually applied to the user
- Add tests to BDDs to test how message producers deal with such guidelines, and with several guidelines that override each other.
-   We found that some of those tests are failing, even after adding clarification to the prompt and adding a shot. The scenario that is failing is not really related to agent intention: if we have a guideline when something then do x or y, then a guideline when something more specific then don't do x, we expect it to consider both guidelines and do y. There is more work to be done to make those scenarios pass. For now I moved those tests to unstable. I'll note that these test are not passing in develop in similar rate. 

Signed-off-by: HadarYosef1 <hadar@emcie.co>