### PR TITLE
Feature/mc 854 add test for returning to an earlier journey step

### DIFF
--- a/src/parlant/core/engines/alpha/engine.py
+++ b/src/parlant/core/engines/alpha/engine.py
@@ -967,6 +967,10 @@ class AlphaEngine(Engine):
 
         return [m for m in problematic_parameters if m.precedence == min(precedence_values)]
 
+    def _todo_add_associated_guidelines(self, guideline_matches: Sequence[GuidelineMatch]) -> None:
+        # TODO write this method - it should add guidelines that are associated with the previously matched guidelines (due to having similar actions, as flagged by the conversation designer)
+        return
+
     async def _add_agent_state(
         self,
         context: LoadedContext,
@@ -980,6 +984,8 @@ class AlphaEngine(Engine):
             and not match.guideline.metadata.get("continuous", False)
             and match.guideline.content.action
         ]
+
+        self._todo_add_associated_guidelines(matches_to_analyze)
 
         result = await self._guideline_matcher.analyze_response(
             agent=context.agent,

--- a/tests/core/stable/engines/alpha/features/baseline/journeys.feature
+++ b/tests/core/stable/engines/alpha/features/baseline/journeys.feature
@@ -127,8 +127,7 @@ Feature: Journeys
         And a customer message, "I'd like a sandwich"
         And an agent message, "Got it. What kind of bread would you like?"
         And a customer message, "I'd like a baguette"
-        And an agent message, "Got it. What main filling would you like? We have either peanut butter, jam or pesto."
-        
+        And an agent message, "Got it. What main filling would you like? We have either peanut butter, jam or pesto."        
         When processing is triggered
         Then a single message event is emitted
         And the message contains asking asking what green base the customer wants for their salad 

--- a/tests/core/stable/engines/alpha/features/baseline/journeys.feature
+++ b/tests/core/stable/engines/alpha/features/baseline/journeys.feature
@@ -106,3 +106,16 @@ Feature: Journeys
         When processing is triggered
         Then a single message event is emitted
         And the message contains recommendations for either mushrooms or tomatoes, but not pepperoni
+
+    Scenario: Journey returns to earlier step when the conversation justifies doing so 1
+        Given a journey titled Book Taxi Ride to follow these steps to book a customer a taxi ride: 1. Ask for the pickup location. 2. Ask for the drop-off location. 3. Ask for the desired pickup time. 4. Confirm all details with the customer before booking. Each step should be handled in a separate message. when the customer wants to book a taxi
+        And a customer message, "Hi, I'd like to book a taxi for myself"
+        And an agent message, "Great! What's your pickup location?"
+        And a customer message, "Main street 1234"
+        And an agent message, "Got it. What's your drop-off location?"
+        And a customer message, "3rd Avenue by the river"
+        And an agent message, "Got it. What time would you like to pick up?"
+        And a customer message, "Oh hold up, my plans have changed. I'm actually going to need pickup from JFK airport."
+        When processing is triggered
+        Then a single message event is emitted
+        And the message contains asking the customer for the drop-off location

--- a/tests/core/stable/engines/alpha/features/baseline/journeys.feature
+++ b/tests/core/stable/engines/alpha/features/baseline/journeys.feature
@@ -115,7 +115,7 @@ Feature: Journeys
         And an agent message, "Got it. What's your drop-off location?"
         And a customer message, "3rd Avenue by the river"
         And an agent message, "Got it. What time would you like to pick up?"
-        And a customer message, "Oh hold up, my plans have changed. I'm actually going to need a cab for my son, he'll be waiting at JFK airport."
+        And a customer message, "Oh hold up, my plans have changed. I'm actually going to need a cab for my son, he'll be waiting at JFK airport, at the taxi stand."
         When processing is triggered
         Then a single message event is emitted
         And the message contains asking the customer for the drop-off location

--- a/tests/core/stable/engines/alpha/features/baseline/journeys.feature
+++ b/tests/core/stable/engines/alpha/features/baseline/journeys.feature
@@ -107,7 +107,7 @@ Feature: Journeys
         Then a single message event is emitted
         And the message contains recommendations for either mushrooms or tomatoes, but not pepperoni
 
-    Scenario: Journey returns to earlier step when the conversation justifies doing so 1
+    Scenario: Journey returns to earlier step when the conversation justifies doing so (1)
         Given a journey titled Book Taxi Ride to follow these steps to book a customer a taxi ride: 1. Ask for the pickup location. 2. Ask for the drop-off location. 3. Ask for the desired pickup time. 4. Confirm all details with the customer before booking. Each step should be handled in a separate message. when the customer wants to book a taxi
         And a customer message, "Hi, I'd like to book a taxi for myself"
         And an agent message, "Great! What's your pickup location?"
@@ -115,19 +115,20 @@ Feature: Journeys
         And an agent message, "Got it. What's your drop-off location?"
         And a customer message, "3rd Avenue by the river"
         And an agent message, "Got it. What time would you like to pick up?"
-        And a customer message, "Oh hold up, my plans have changed. I'm actually going to need pickup from JFK airport."
+        And a customer message, "Oh hold up, my plans have changed. I'm actually going to need a cab for my son, he'll be waiting at JFK airport."
         When processing is triggered
         Then a single message event is emitted
         And the message contains asking the customer for the drop-off location
 
-    Scenario: Journey returns to earlier step when the conversation justifies doing so 2
+    Scenario: Journey returns to earlier step when the conversation justifies doing so (2)
         Given a journey titled Place Food Order to follow these steps to place a customer’s order: 1. Ask if they’d like a salad or a sandwich. 2. If they choose a sandwich, ask what kind of bread they’d like. 3. If they choose a sandwich, ask what main filling they’d like from: Peanut butter, jam or pesto. 4. If they choose a sandwich, ask if they want any extras. 5. If they choose a salad, ask what base greens they want. 6. If they choose a salad, ask what toppings they’d like. 7. If they choose a salad, ask what kind of dressing they prefer. 8. Confirm the full order before placing it. Each step should be handled in a separate message, when the customer wants to order food 
         And a customer message, "Hey, I'd like to make an order"
         And an agent message, "Great! What would you like to order? We have either a salad or a sandwich."
         And a customer message, "I'd like a sandwich"
         And an agent message, "Got it. What kind of bread would you like?"
         And a customer message, "I'd like a baguette"
-        And an agent message, "Got it. What main filling would you like? We have either peanut butter, jam or pesto."        
+        And an agent message, "Got it. What main filling would you like? We have either peanut butter, jam or pesto."
+        And a customer message, "If that's your only options, can I get a salad instead?"
         When processing is triggered
         Then a single message event is emitted
         And the message contains asking asking what green base the customer wants for their salad 

--- a/tests/core/stable/engines/alpha/features/baseline/journeys.feature
+++ b/tests/core/stable/engines/alpha/features/baseline/journeys.feature
@@ -119,3 +119,16 @@ Feature: Journeys
         When processing is triggered
         Then a single message event is emitted
         And the message contains asking the customer for the drop-off location
+
+    Scenario: Journey returns to earlier step when the conversation justifies doing so 2
+        Given a journey titled Place Food Order to follow these steps to place a customer’s order: 1. Ask if they’d like a salad or a sandwich. 2. If they choose a sandwich, ask what kind of bread they’d like. 3. If they choose a sandwich, ask what main filling they’d like from: Peanut butter, jam or pesto. 4. If they choose a sandwich, ask if they want any extras. 5. If they choose a salad, ask what base greens they want. 6. If they choose a salad, ask what toppings they’d like. 7. If they choose a salad, ask what kind of dressing they prefer. 8. Confirm the full order before placing it. Each step should be handled in a separate message, when the customer wants to order food 
+        And a customer message, "Hey, I'd like to make an order"
+        And an agent message, "Great! What would you like to order? We have either a salad or a sandwich."
+        And a customer message, "I'd like a sandwich"
+        And an agent message, "Got it. What kind of bread would you like?"
+        And a customer message, "I'd like a baguette"
+        And an agent message, "Got it. What main filling would you like? We have either peanut butter, jam or pesto."
+        
+        When processing is triggered
+        Then a single message event is emitted
+        And the message contains asking asking what green base the customer wants for their salad 

--- a/tests/core/stable/engines/alpha/features/baseline/strict_utterances.feature
+++ b/tests/core/stable/engines/alpha/features/baseline/strict_utterances.feature
@@ -325,3 +325,44 @@ Feature: Strict Utterance
         When processing is triggered
         Then a single message event is emitted
         And the message contains the text "Your current balance is $1244 as of today."
+
+    
+    Scenario: Journey returns to earlier step when the conversation justifies doing so (1) (strict utterance) 
+        Given an agent whose job is to book taxi rides
+        And that the agent uses the strict_utterance message composition mode
+        And a journey titled Book Taxi Ride to follow these steps to book a customer a taxi ride: 1. Ask for the pickup location. 2. Ask for the drop-off location. 3. Ask for the desired pickup time. 4. Confirm all details with the customer before booking. Each step should be handled in a separate message. when the customer wants to book a taxi
+        And a customer message, "Hi, I'd like to book a taxi for myself"
+        And an agent message, "Great! What's the pickup location?"
+        And a customer message, "Main street 1234"
+        And an agent message, "Got it. What's the drop-off location?"
+        And a customer message, "3rd Avenue by the river"
+        And an agent message, "Got it. What time would you like to pick up?"
+        And a customer message, "Oh hold up, my plans have changed. I'm actually going to need a cab for my son, he'll be waiting at JFK airport, at the taxi stand."
+        And an utterance, "What's the pickup location?"
+        And an utterance, "Got it. What's the drop-off location?"
+        And an utterance, "What time would you like to pick up?"
+        When processing is triggered
+        Then a single message event is emitted
+        And the message contains asking the customer for the drop-off location
+
+    Scenario: Journey returns to earlier step when the conversation justifies doing so (2) (strict utterance)
+        Given an agent whose job is to handle food orders
+        And that the agent uses the strict_utterance message composition mode
+        And a journey titled Place Food Order to follow these steps to place a customer’s order: 1. Ask if they’d like a salad or a sandwich. 2. If they choose a sandwich, ask what kind of bread they’d like. 3. If they choose a sandwich, ask what main filling they’d like from: Peanut butter, jam or pesto. 4. If they choose a sandwich, ask if they want any extras. 5. If they choose a salad, ask what base greens they want. 6. If they choose a salad, ask what toppings they’d like. 7. If they choose a salad, ask what kind of dressing they prefer. 8. Confirm the full order before placing it. Each step should be handled in a separate message, when the customer wants to order food 
+        And a customer message, "Hey, I'd like to make an order"
+        And an agent message, "Great! What would you like to order? We have either a salad or a sandwich."
+        And a customer message, "I'd like a sandwich"
+        And an agent message, "Got it. What kind of bread would you like?"
+        And a customer message, "I'd like a baguette"
+        And an agent message, "Got it. What main filling would you like? We have either peanut butter, jam or pesto."
+        And a customer message, "If that's your only options, can I get a salad instead?"
+        And an utterance, "What would you like to order? We have either a salad or a sandwich."
+        And an utterance, "Got it. What kind of bread would you like?"
+        And an utterance, "Got it. What main filling would you like? We have either peanut butter, jam or pesto."
+        And an utterance, "Got it. Would you want anything extra in your sandwich?"
+        And an utterance, "Got it. What toppings would you like?"
+        And an utterance, "Got it. What kind of dressing would you like?"
+        And an utterance, "Got it. Since you want a salad - what base greens would you like" 
+        When processing is triggered
+        Then a single message event is emitted
+        And the message contains asking asking what green base the customer wants for their salad 

--- a/tests/core/stable/engines/alpha/features/baseline/strict_utterances.feature
+++ b/tests/core/stable/engines/alpha/features/baseline/strict_utterances.feature
@@ -362,7 +362,8 @@ Feature: Strict Utterance
         And an utterance, "Got it. Would you want anything extra in your sandwich?"
         And an utterance, "Got it. What toppings would you like?"
         And an utterance, "Got it. What kind of dressing would you like?"
-        And an utterance, "Got it. Since you want a salad - what base greens would you like" 
+        And an utterance, "Got it. Since you want a salad - what base greens would you like"
+        And an utterance, "Got it. What base greens would you like for your salad?"
         When processing is triggered
         Then a single message event is emitted
         And the message contains asking asking what green base the customer wants for their salad 


### PR DESCRIPTION
- Added 4 tests that verify that the agent returns to an older journey step if the conversation requires so.
- Added a todo note to the engine about including connected guideline in the response analysis

Sidenote: one of the added stable tests (Journey returns to earlier step when the conversation justifies doing so (2) (strict utterance)) fails due to what I believe is an unrelated bug with the utterance loader. Once this bug is fixed the test will pass.