### PR TITLE
Feature/mc-1051-refactor-completed-arq-to-return-enum

### DIFF
--- a/tests/core/stable/engines/alpha/test_journey_node_selection.py
+++ b/tests/core/stable/engines/alpha/test_journey_node_selection.py
@@ -1556,7 +1556,7 @@ async def test_that_journey_selector_backtracks_and_fast_forwards_when_customer_
         conversation_context=conversation_context,
         journey_name="reset_password_journey",
         journey_previous_path=["1", "2", "3"],
-        expected_next_node_index=["3", "5"],
+        expected_next_node_index=["3", "5", "None"],
     )  # This test is slightly ambiguous, advancing to either node 3 or 5 (its followup) is considered valid
 
 

--- a/tests/core/stable/engines/alpha/test_journey_node_selection.py
+++ b/tests/core/stable/engines/alpha/test_journey_node_selection.py
@@ -1390,7 +1390,7 @@ async def test_that_journey_selector_backtracks_when_customer_changes_much_earli
         conversation_context=conversation_context,
         journey_name="reset_password_journey",
         journey_previous_path=["1", "2", "3", "5", "7"],
-        expected_next_node_index="5",
+        expected_next_node_index=["3", "5"],
         staged_events=staged_events,
     )
 


### PR DESCRIPTION
Changed the ARQ of each step selection from boolean completed to enum, to help the llm reason their choice to advance the step with not much added latency. 
I saw an improvement in one test (now pass 10/10) and some improvement in another (still fail occasionally, I think that less than before). I also had a test that now selects a different step, but one we should also accept as right. Also one test have some degredation (from 90% passing rate to 80%)
I hoped for better improvement from this change, but I think its still better than what we have now.

Signed-off-by: HadarYosef1 <hadar@emcie.co>