### PR TITLE
Feature/mc-1058-support-invalid-data-in-overlapping-tools

### DIFF
--- a/tests/core/common/engines/alpha/steps/tools.py
+++ b/tests/core/common/engines/alpha/steps/tools.py
@@ -433,6 +433,32 @@ TOOLS: dict[str, dict[str, Any]] = {
         },
         "required": ["name", "manager", "director", "cleaner"],
     },
+    "calculate_expected_salary": {
+        "name": "calculate_expected_salary",
+        "description": "Calculate the expected salary of an employee according to their features",
+        "module_path": "tests.tool_utilities",
+        "parameters": {
+            "name": {
+                "type": "string",
+                "enum": ["John", "Shone", "David"],
+            },
+            "Residence": (
+                {
+                    "type": "string",
+                    "enum": [" City Center", "Suburban", "Kibbutz"],
+                },
+                ToolParameterOptions(hidden=True),
+            ),
+            "Car": (
+                {
+                    "type": "string",
+                    "enum": ["Toyota", "Tesla", "Ford"],
+                },
+                ToolParameterOptions(hidden=True),
+            ),
+        },
+        "required": ["name", "manager", "director", "cleaner"],
+    },
     "get_products_by_type": {
         "name": "get_products_by_type",
         "description": "Get all products that match the specified product type ",

--- a/tests/core/stable/engines/alpha/features/baseline/tools.feature
+++ b/tests/core/stable/engines/alpha/features/baseline/tools.feature
@@ -632,6 +632,25 @@ Feature: Tools
         And the message mentions the robot, mistress and homie
         And the message mentions Chris Pikrim, Mike Andike, Jay Libelly and Bruno Twix
 
+    Scenario: Overlapped tool that has both missing and invalid parameters, some hidden and some have display names, communicate the problems correctly
+        Given an empty session
+        And a guideline "calculate your salary" to calculate the salary of a person when the customer wants to know their salary
+        And the tool "calculate_salary"
+        And an association between "calculate your salary" and "calculate_salary"
+        And the tool "calculate_expected_salary"
+        And an association between "calculate your salary" and "calculate_expected_salary"
+        And a tool relationship whereby "calculate_salary" overlaps with "calculate_expected_salary"
+        And a customer message, "Hi, My name is Chris Pikrim, I work in Mike Andike's team. My mistress KittyKat and my friend Shuki asked me for my salary, so I would like you to calculate my salary based on those people I mentioned. Please provide me with all details regarding missing or invalid data."
+        When processing is triggered
+        Then no tool calls event is emitted
+        And a single message event is emitted
+        And the message mentions that parameters are missing
+        And the number of missing parameters is exactly 1
+        And the message mentions that parameters are invalid
+        And the number of invalid parameters is exactly 2
+        And the message mentions the robot, mistress and homie
+        And the message mentions Chris Pikrim, Mike Andike, Jay Libelly and Bruno Twix
+
     Scenario: Tool caller chooses the right tool for scheduling when three are overlapping
         Given a customer named "Hailey"
         And an empty session with "Hailey"

--- a/tests/core/stable/engines/alpha/test_tool_caller.py
+++ b/tests/core/stable/engines/alpha/test_tool_caller.py
@@ -411,10 +411,12 @@ async def test_that_a_tool_from_a_plugin_gets_called_with_an_enum_list_parameter
 
     assert "categories" in tool_call.arguments
     assert isinstance(tool_call.arguments["categories"], str)
-    assert literal_eval(tool_call.arguments["categories"]) == [
-        ProductCategory.LAPTOPS.value,
-        ProductCategory.PERIPHERALS.value,
-    ]
+    assert set(literal_eval(tool_call.arguments["categories"])) == set(
+        [
+            ProductCategory.LAPTOPS.value,
+            ProductCategory.PERIPHERALS.value,
+        ]
+    )
     assert ProductCategory.LAPTOPS.value in tool_call.arguments["categories"]
     assert ProductCategory.PERIPHERALS.value in tool_call.arguments["categories"]
 

--- a/tests/tool_utilities.py
+++ b/tests/tool_utilities.py
@@ -248,6 +248,17 @@ def calculate_salary(
     return ToolResult({"salary": 100})
 
 
+def calculate_expected_salary(
+    name: Employees,
+    manager: Employees,
+    director: Employees,
+    friend: Employees,
+    mistress: Employees,
+    cleaner: Employees,
+) -> ToolResult:
+    return ToolResult({"salary": 100})
+
+
 async def get_electronic_products_by_type(
     product_type: ElectronicProductType,
 ) -> ToolResult:


### PR DESCRIPTION
Small implementaion detail - I entered the check of valid data to the if of is_applicable because in overlapping we check is applicable before we evaluate the calls and not for each call  (do it per tool) , and calls and parameter_name can be None. We can discuss if its a good implementation but I think its ok for now 

Signed-off-by: HadarYosef1 <hadar@emcie.co>