### PR TITLE
Feature/mc 1073 fix bug with opus with previously executed tools in journeys

### DIFF
--- a/src/parlant/core/engines/alpha/guideline_matching/generic/journey_node_selection_batch.py
+++ b/src/parlant/core/engines/alpha/guideline_matching/generic/journey_node_selection_batch.py
@@ -43,7 +43,7 @@ SINGLE_FOLLOW_UP_CONDITION_STR = "This step was completed"
 FORK_NODE_ACTION_STR = (
     "No action necessary - always advance to the next step based on the relevant transition"
 )
-LAST_PRESENTED_NODE_INSTRUCTION = "Do not advance past this step"
+LAST_PRESENTED_NODE_INSTRUCTION = "Do not advance past this step. If you got here - mark this step as incomplete and return it as next_step"
 
 
 class JourneyNodeKind(Enum):
@@ -747,7 +747,7 @@ Evaluate whether the last executed step is complete:
  If not, set completed to 'needs_customer_input' and do not advance past this step.
 - For REQUIRES AGENT ACTION steps: The agent has performed the required communication or action. If so, set completed to 'completed'. If not, set completed to 'needs_agent_action'
 and do not advance past this step.
-- For REQUIRES_TOOL_CALLS steps: The step requires a tool call to be executed. Always stop at this step and mark it as not complete, even if the tool it requires was already executed. If you get to such a step while traversing the journey, stop and return it as the next_step.
+- For REQUIRES_TOOL_CALLS steps: The step requires a tool call to execute for it to be completed. If you begin your advancement at this step, mark it as complete if the tool executed, and move onwards. Otherwise, always set completed to false and return it as next_step.
 - If the last step is incomplete, set next_step to the current step ID (repeat the step) and document this in the step_advancement array.
 
 ## 4: Journey Advancement

--- a/src/parlant/core/engines/alpha/guideline_matching/generic/journey_node_selection_batch.py
+++ b/src/parlant/core/engines/alpha/guideline_matching/generic/journey_node_selection_batch.py
@@ -747,8 +747,7 @@ Evaluate whether the last executed step is complete:
  If not, set completed to 'needs_customer_input' and do not advance past this step.
 - For REQUIRES AGENT ACTION steps: The agent has performed the required communication or action. If so, set completed to 'completed'. If not, set completed to 'needs_agent_action'
 and do not advance past this step.
-- For REQUIRES_TOOL_CALLS steps: The step requires a tool call that has been executed. If so, set completed to 'completed'. If not, set completed to 'needs_tool_call' and do not
-advance past this step.
+- For REQUIRES_TOOL_CALLS steps: The step requires a tool call to be executed. Always stop at this step and mark it as not complete, even if the tool it requires was already executed. If you get to such a step while traversing the journey, stop and return it as the next_step.
 - If the last step is incomplete, set next_step to the current step ID (repeat the step) and document this in the step_advancement array.
 
 ## 4: Journey Advancement

--- a/tests/core/stable/engines/alpha/test_journey_node_selection.py
+++ b/tests/core/stable/engines/alpha/test_journey_node_selection.py
@@ -1303,7 +1303,7 @@ async def test_that_journey_selector_backtracks_and_fast_forwards_when_customer_
         customer=customer,
         conversation_context=conversation_context,
         journey_name="calzone_journey",
-        journey_previous_path=["1", "2", "7", "8"],
+        journey_previous_path=["1", "2", "7", "8", "9", "10", "11"],
         expected_path=["8", "9", "10"],
         expected_next_node_index="10",  # Should check stock again
         staged_events=staged_events,


### PR DESCRIPTION
Slightly changed journey node selection prompt to fix a previously seen issue where it exits the journey upon reaching a tool running step that was previously executed.

Added one relevant test.