### PR TITLE
feature: add optional environment variables for azure api versions

### DIFF
--- a/src/parlant/adapters/nlp/azure_service.py
+++ b/src/parlant/adapters/nlp/azure_service.py
@@ -239,7 +239,7 @@ class GPT_4o(AzureSchematicGenerator[T]):
         _client = AsyncAzureOpenAI(
             api_key=os.environ["AZURE_API_KEY"],
             azure_endpoint=os.environ["AZURE_ENDPOINT"],
-            api_version="2024-08-01-preview",
+            api_version=os.environ["AZURE_API_VERSION"] or "2024-08-01-preview",
         )
         super().__init__(model_name="gpt-4o", logger=logger, client=_client)
 
@@ -253,7 +253,7 @@ class GPT_4o_Mini(AzureSchematicGenerator[T]):
         _client = AsyncAzureOpenAI(
             api_key=os.environ["AZURE_API_KEY"],
             azure_endpoint=os.environ["AZURE_ENDPOINT"],
-            api_version="2024-08-01-preview",
+            api_version=os.environ["AZURE_API_VERSION"] or "2024-08-01-preview",
         )
         super().__init__(model_name="gpt-4o-mini", logger=logger, client=_client)
         self._token_estimator = AzureEstimatingTokenizer(model_name=self.model_name)
@@ -319,7 +319,7 @@ class AzureTextEmbedding3Large(AzureEmbedder):
         _client = AsyncAzureOpenAI(
             api_key=os.environ["AZURE_API_KEY"],
             azure_endpoint=os.environ["AZURE_ENDPOINT"],
-            api_version="2023-05-15",
+            api_version=os.environ["AZURE_EMBEDDING_API_VERSION"] or "2023-05-15",
         )
         super().__init__(model_name="text-embedding-3-large", logger=logger, client=_client)
 
@@ -338,7 +338,7 @@ class AzureTextEmbedding3Small(AzureEmbedder):
         _client = AsyncAzureOpenAI(
             api_key=os.environ["AZURE_API_KEY"],
             azure_endpoint=os.environ["AZURE_ENDPOINT"],
-            api_version="2023-05-15",
+            api_version=os.environ["AZURE_EMBEDDING_API_VERSION"] or "2023-05-15",
         )
         super().__init__(model_name="text-embedding-3-small", logger=logger, client=_client)
 

--- a/src/parlant/adapters/nlp/azure_service.py
+++ b/src/parlant/adapters/nlp/azure_service.py
@@ -239,7 +239,7 @@ class GPT_4o(AzureSchematicGenerator[T]):
         _client = AsyncAzureOpenAI(
             api_key=os.environ["AZURE_API_KEY"],
             azure_endpoint=os.environ["AZURE_ENDPOINT"],
-            api_version=os.environ["AZURE_API_VERSION"] or "2024-08-01-preview",
+            api_version=os.environ.get("AZURE_API_VERSION", "2024-08-01-preview"),
         )
         super().__init__(model_name="gpt-4o", logger=logger, client=_client)
 
@@ -253,7 +253,7 @@ class GPT_4o_Mini(AzureSchematicGenerator[T]):
         _client = AsyncAzureOpenAI(
             api_key=os.environ["AZURE_API_KEY"],
             azure_endpoint=os.environ["AZURE_ENDPOINT"],
-            api_version=os.environ["AZURE_API_VERSION"] or "2024-08-01-preview",
+            api_version=os.environ.get("AZURE_API_VERSION", "2024-08-01-preview"),
         )
         super().__init__(model_name="gpt-4o-mini", logger=logger, client=_client)
         self._token_estimator = AzureEstimatingTokenizer(model_name=self.model_name)
@@ -319,7 +319,7 @@ class AzureTextEmbedding3Large(AzureEmbedder):
         _client = AsyncAzureOpenAI(
             api_key=os.environ["AZURE_API_KEY"],
             azure_endpoint=os.environ["AZURE_ENDPOINT"],
-            api_version=os.environ["AZURE_EMBEDDING_API_VERSION"] or "2023-05-15",
+            api_version=os.environ.get("AZURE_EMBEDDING_API_VERSION", "2023-05-15"),
         )
         super().__init__(model_name="text-embedding-3-large", logger=logger, client=_client)
 
@@ -338,7 +338,7 @@ class AzureTextEmbedding3Small(AzureEmbedder):
         _client = AsyncAzureOpenAI(
             api_key=os.environ["AZURE_API_KEY"],
             azure_endpoint=os.environ["AZURE_ENDPOINT"],
-            api_version=os.environ["AZURE_EMBEDDING_API_VERSION"] or "2023-05-15",
+            api_version=os.environ.get("AZURE_EMBEDDING_API_VERSION", "2023-05-15"),
         )
         super().__init__(model_name="text-embedding-3-small", logger=logger, client=_client)
 

--- a/src/parlant/bin/server.py
+++ b/src/parlant/bin/server.py
@@ -1051,7 +1051,7 @@ def main() -> None:
     @click.option(
         "--azure",
         is_flag=True,
-        help="Run with Azure OpenAI. The following environment variables must be set: AZURE_API_KEY, AZURE_ENDPOINT",
+        help="Run with Azure OpenAI. The following environment variables must be set: AZURE_API_KEY, AZURE_ENDPOINT (optinally AZURE_API_VERSION, AZURE_EMBEDDING_API_VERSION if you are using a different version of the API).",
         default=False,
     )
     @click.option(


### PR DESCRIPTION
This pull request adds support for configuring Azure Service Provider parameters via environment variables, addressing the need outlined in Issue #276. Users can now set `AZURE_API_VERSION` and `AZURE_EMBEDDING_API_VERSION` as environment variables, in addition to the existing `AZURE_API_KEY` and `AZURE_ENDPOINT`. This enhancement allows users to specify the API version without modifying the source code, increasing flexibility and improving the deployment experience for different Azure environments.