### PR TITLE
Fix for #522

### DIFF
--- a/docs/adapters/nlp/ollama.md
+++ b/docs/adapters/nlp/ollama.md
@@ -82,6 +82,7 @@ ollama pull llama3.1:405b
 
 To use custom embedding model set OLLAMA_EMBEDDING_MODEL environment value as required name
 Note that this implementation is tested using nomic-embed-text
+NOTE: You should use a model which can generate 512, 768 or 1024 size vectors
 
 ```bash
 # Alternative embedding model (512 dimensions)

--- a/src/parlant/adapters/nlp/ollama_service.py
+++ b/src/parlant/adapters/nlp/ollama_service.py
@@ -418,15 +418,13 @@ class OllamaEmbedder(Embedder):
 
     def __init__(
         self,
-        logger: Logger,
-        base_url: str = "http://localhost:11434",
-        model_name: str = "nomic-embed-text",
+        logger: Logger
     ):
-        self.model_name = model_name
-        self.base_url = base_url.rstrip("/")
+        self.model_name = os.environ.get("OLLAMA_EMBEDDING_MODEL", "nomic-embed-text")
+        self.base_url = os.environ.get("OLLAMA_BASE_URL", "http://localhost:11434").rstrip("/")
         self._logger = logger
-        self._tokenizer = OllamaEstimatingTokenizer(model_name)
-        self._client = ollama.AsyncClient(host=base_url)
+        self._tokenizer = OllamaEstimatingTokenizer(self.model_name)
+        self._client = ollama.AsyncClient(host=self.base_url)
 
     @property
     @override
@@ -450,6 +448,8 @@ class OllamaEmbedder(Embedder):
             return 768
         elif "mxbai" in self.model_name.lower():
             return 512
+        elif "bge" in self.model_name.lower():
+            return 1024
         else:
             return 768
 
@@ -606,9 +606,7 @@ Please set these environment variables before running Parlant.
     @override
     async def get_embedder(self) -> Embedder:
         """Get an embedder for text embeddings."""
-        return OllamaEmbedder(
-            logger=self._logger, base_url=self.base_url, model_name=self.embedding_model
-        )
+        return OllamaEmbedder(logger=self._logger)
 
     @override
     async def get_moderation_service(self) -> ModerationService:


### PR DESCRIPTION
Hi,

This PR is a fix for https://github.com/emcie-co/parlant/issues/522 

The problem was in the OllamaEmbedder constructor - i was putting in base_url and model_name as separate parameters, but the dependency injection system doesn't work that way

Also, updated the docs that embedding models which can produce 512, 768 and 1024 vectors are supported.