### PR TITLE
Explicitly output the MongoDB session-related library name in the error message.

### DIFF
--- a/src/parlant/sdk.py
+++ b/src/parlant/sdk.py
@@ -2768,7 +2768,7 @@ class Server:
                 if importlib.util.find_spec("pymongo") is None:
                     raise SDKError(
                         "MongoDB requires an additional package to be installed. "
-                        "Please install parlant[mongo] to use MongoDB."
+                        "Please install pymongo to use MongoDB."
                     )
 
                 from pymongo import AsyncMongoClient


### PR DESCRIPTION
I tried to use MongoDB as a session store in Parlant, but I got this message:

```
parlant.sdk.SDKError: MongoDB requires an additional package to be installed. Please install parlant[mongo] to use MongoDB.
MongoDB requires an additional package to be installed. Please install parlant[mongo] to use MongoDB.
```
I tried several times with like

```
uv add parlant[mongo]
```

and also searched on Google and Discord, but eventually I checked the source code and found out that the required library is actually pymongo.

I think it would be better if others didn’t have to go through the same experience.