### PR TITLE
feat: changeable customer_id & agent_id in session

### DIFF
--- a/src/parlant/api/sessions.py
+++ b/src/parlant/api/sessions.py
@@ -394,6 +394,8 @@ class SessionUpdateParamsDTO(
     consumption_offsets: ConsumptionOffsetsUpdateParamsDTO | None = None
     title: SessionTitleField | None = None
     mode: SessionModeField | None = None
+    customer_id: CustomerId | None = None
+    agent_id: AgentId | None = None
 
 
 ToolResultDataField: TypeAlias = Annotated[
@@ -1457,6 +1459,12 @@ def create_router(
 
             if dto.mode:
                 params["mode"] = dto.mode.value
+
+            if dto.customer_id:
+                params["customer_id"] = dto.customer_id
+
+            if dto.agent_id:
+                params["agent_id"] = dto.agent_id
 
             return params
 


### PR DESCRIPTION
As discussed on [Discord](https://discord.com/channels/1312378700993663007/1415285480500760626), this PR adds the ability to update the `customer_id` and `agent_id` within an active session. This change is particularly helpful in cases where a user logs in on the frontend and their session should reflect the new user. It provides more flexibility for managing session data and ensures that user changes are properly handled during ongoing sessions.