### PR TITLE
Fix #568: Resolve DeepSeek service initialization

### DIFF
--- a/src/parlant/adapters/nlp/deepseek_service.py
+++ b/src/parlant/adapters/nlp/deepseek_service.py
@@ -191,6 +191,18 @@ class DeepSeek_Chat(DeepSeekSchematicGenerator[T]):
 
 
 class DeepSeekService(NLPService):
+    @staticmethod
+    def verify_environment() -> str | None:
+        """Returns an error message if the environment is not set up correctly."""
+
+        if not os.environ.get("DEEPSEEK_API_KEY"):
+            return """\
+You're using the DeepSeek NLP service, but DEEPSEEK_API_KEY is not set.
+Please set DEEPSEEK_API_KEY in your environment before running Parlant.
+"""
+
+        return None
+    
     def __init__(
         self,
         logger: Logger,

--- a/src/parlant/sdk.py
+++ b/src/parlant/sdk.py
@@ -354,6 +354,16 @@ class NLPServices:
             raise SDKError(error)
 
         return QwenService(container[Logger])
+    
+    @staticmethod
+    def deepseek(container: Container) -> NLPService:
+        """Creates a DeepSeek NLPService instance using the provided container."""
+        from parlant.adapters.nlp.deepseek_service import DeepSeekService
+
+        if error := DeepSeekService.verify_environment():
+            raise SDKError(error)
+
+        return DeepSeekService(container[Logger])
 
     @staticmethod
     def snowflake(container: Container) -> NLPService:


### PR DESCRIPTION
Hi team,
This PR fixes #568 where DeepSeek service was not working.

**Changes:**
- Added deepseek() method in sdk.py for service creation
- Implemented verify_environment() in deepseek_service.py
- Validates DEEPSEEK_API_KEY presence before initialization

​**Testing:**
[x] Valid API key scenario

Please review when you have a moment. Thanks!