### PR TITLE
Fixed mermaid syntax issue when creating a journey graph

### DIFF
--- a/src/parlant/api/journeys.py
+++ b/src/parlant/api/journeys.py
@@ -15,6 +15,7 @@
 from collections import defaultdict
 from fastapi import APIRouter, Path, Query, Request, status
 from fastapi.responses import PlainTextResponse
+from html import escape
 from pydantic import Field
 from typing import Annotated, Sequence, TypeAlias, cast
 
@@ -36,6 +37,7 @@ from parlant.core.journeys import (
 )
 from parlant.core.guidelines import GuidelineId
 from parlant.core.tags import TagId
+import re
 
 API_GROUP = "journeys"
 
@@ -307,6 +309,19 @@ async def _build_mermaid_chart(
     transitions: list[str] = []
     style_lines: list[str] = []
 
+    def escape_mermaid(s: str) -> str:
+        def convert_match(match):
+            number = match.group(1)
+            if number.startswith('x'):
+                dec_num = int(number[1:], 16)  # convert hex to decimal
+                return f"#{dec_num};"
+            else:
+                return f"#{number};"  # keep decimal as is
+
+        html_escaped = escape(s, quote=True)
+        # apply regex replacement to fix numeric character references for mermaid syntax
+        return re.sub(r"&#(x[0-9a-fA-F]+|[0-9]+);", convert_match, html_escaped)
+
     def declare(nid: JourneyNodeId) -> None:
         if nid == JourneyStore.END_NODE_ID or nid in declared:
             return
@@ -315,7 +330,7 @@ async def _build_mermaid_chart(
             return
         declared.add(nid)
         m = mermaid_id(nid)
-        state_decls.append(f"    {m}: {lbl}")
+        state_decls.append(f"    state \"{escape_mermaid(lbl)}\" as {m}")
         node = node_by_id.get(nid)
         if node and _is_tool_node(node):
             style_lines.append(f"style {m} {TOOL_STYLE}")


### PR DESCRIPTION
When using the REST-API to create Mermaid diagrams of journeys, invalid mermaid syntax is generated when a transition contains a colon character (`:`):

```python
s0 = await journey.initial_state.transition_to(
    chat_state="Foo: bar",
    canned_responses=[
```

Mermaid Live Screenshot:

<img width="738" height="274" alt="image" src="https://github.com/user-attachments/assets/f7313246-6956-4ba2-8388-ffedb5f0d2f1" />

This pull requests uses Marmaid's [alternate syntax](https://mermaid.js.org/syntax/stateDiagram.html#states) for states and special characters are properly [escaped](https://mermaid.js.org/syntax/flowchart.html#entity-codes-to-escape-characters):

```
stateDiagram-v2
    state "Foo: bar" as N0:
```