### PR TITLE
Enhance NLPServices.openai() with Direct Model Specification and Fallback Support

### DIFF
--- a/src/parlant/sdk.py
+++ b/src/parlant/sdk.py
@@ -241,14 +241,23 @@ class NLPServices:
         return AzureService(container[Logger])
 
     @staticmethod
-    def openai(container: Container) -> NLPService:
-        """Creates an OpenAI NLPService instance using the provided container."""
+    def openai(container: Optional[Container] = None, generative_model_name: Optional[str | list[str]] = None) -> NLPService:
+        """
+        Returns a callable that creates an OpenAI NLPService instance using the provided container and generative_model_name.
+        If container is None, the callable expects the container to be provided later (by the Server).
+        If generative_model_name is None, the default model selection is used.
+        """
         from parlant.adapters.nlp.openai_service import OpenAIService
 
-        if error := OpenAIService.verify_environment():
-            raise SDKError(error)
+        def factory(c: Container) -> NLPService:
+            if error := OpenAIService.verify_environment():
+                raise SDKError(error)
+            return OpenAIService(c[Logger], generative_model_name=generative_model_name)
 
-        return OpenAIService(container[Logger])
+        if container is not None:
+            return factory(container)
+
+        return factory
 
     @staticmethod
     def anthropic(container: Container) -> NLPService:


### PR DESCRIPTION
# Pull Request: Enhance `NLPServices.openai()` with Direct Model Specification and Fallback Support

This update introduces enhanced model selection flexibility to the Parlant NLP pipeline by extending `NLPServices.openai()` to accept an optional `generative_model_name` parameter.

## Key Changes

### `src/parlant/sdk.py`
- Added optional `generative_model_name` argument (accepts a `str` or `list[str]`) to `NLPServices.openai()` for direct model specification.

### `src/parlant/adapters/nlp/openai_service.py`
- Updated `OpenAIService.__init__()` and `get_schematic_generator()` to handle the new parameter.
- Introduced `_get_generator_for_model()` to manage model-to-generator mapping and fallback logic.
- Added support for `FallbackSchematicGenerator` when multiple models are provided, ensuring resilience and continuity in case of model failures.

## Benefits
- Enables programmatic model selection for OpenAI-based NLP operations.  
- Ensures graceful fallback across multiple models, improving robustness and parity with Gemini’s architecture.  
- Maintains backward compatibility, requiring no changes for existing implementations.  

## Impact
This change improves flexibility and fault tolerance for downstream consumers of the Parlant NLP API while aligning OpenAI model handling behavior with the existing Gemini adapter design.
