### PR TITLE
feat(openai): add specific multi-model selection and fallback support issue #586

### DIFF
--- a/docs/adapters/nlp/openai.md
+++ b/docs/adapters/nlp/openai.md
@@ -1,0 +1,205 @@
+# OpenAI NLP Service
+
+The OpenAI NLP service provides access to OpenAI's powerful language models for conversational AI applications. This adapter supports both default model selection and custom model specification with automatic fallback.
+
+## Setup
+
+### Environment Variables
+
+Set your OpenAI API key:
+
+```bash
+export OPENAI_API_KEY="sk-your-api-key-here"
+```
+
+### Basic Usage
+
+```python
+import parlant.sdk as p
+
+# Use default model selection
+async with p.Server(
+    nlp_service=p.NLPServices.openai()
+) as server:
+    agent = await server.create_agent(
+        name="Assistant",
+        description="A helpful AI assistant"
+    )
+```
+
+## Model Selection
+
+### Single Model
+
+You can specify a specific model to use:
+
+```python
+import parlant.sdk as p
+
+async with p.Server(
+    nlp_service=p.NLPServices.openai(generative_model_name="gpt-4o-mini")
+) as server:
+    agent = await server.create_agent(
+        name="Budget Assistant",
+        description="A cost-effective AI assistant"
+    )
+```
+
+### Multiple Models with Fallback
+
+For improved reliability, you can specify multiple models. If the first model fails or is unavailable, the system automatically falls back to the next model in the list:
+
+```python
+import parlant.sdk as p
+
+async with p.Server(
+    nlp_service=p.NLPServices.openai(
+        generative_model_name=["gpt-4o-mini", "gpt-4o", "gpt-4o-2024-08-06"]
+    )
+) as server:
+    agent = await server.create_agent(
+        name="Reliable Assistant",
+        description="An AI assistant with fallback support"
+    )
+```
+
+### Custom Models
+
+You can use any OpenAI model, including newer models not yet in the predefined list:
+
+```python
+import parlant.sdk as p
+
+async with p.Server(
+    nlp_service=p.NLPServices.openai(generative_model_name="gpt-3.5-turbo")
+) as server:
+    agent = await server.create_agent(
+        name="Custom Model Assistant",
+        description="Using a custom model configuration"
+    )
+```
+
+## Supported Models
+
+### Predefined Models
+
+The service includes optimized configurations for these models:
+
+- **gpt-4o** (`gpt-4o-2024-11-20`) - Latest GPT-4 Omni model
+- **gpt-4o-2024-08-06** - GPT-4 Omni from August 2024
+- **gpt-4.1** - Latest GPT-4 model
+- **gpt-4o-mini** - Smaller, faster GPT-4 variant
+
+### Custom Models
+
+Any OpenAI model can be used by specifying its exact name. For models not in the predefined list, the service will create a dynamic configuration.
+
+## Default Behavior
+
+When no `generative_model_name` is specified, the service uses schema-specific model selection:
+
+- `SingleToolBatchSchema`: GPT-4o
+- `JourneyNodeSelectionSchema`: GPT-4.1
+- `CannedResponseDraftSchema`: GPT-4.1
+- `CannedResponseSelectionSchema`: GPT-4.1
+- All other schemas: GPT-4o (2024-08-06)
+
+## Error Handling
+
+The fallback mechanism automatically handles:
+
+- **Rate Limiting**: Tries the next model if the current one hits rate limits
+- **Model Unavailability**: Falls back if a model is temporarily unavailable
+- **API Errors**: Attempts alternative models on connection or API issues
+
+## Best Practices
+
+### Cost Optimization
+
+Start with smaller, more cost-effective models and fall back to larger ones:
+
+```python
+generative_model_name=["gpt-4o-mini", "gpt-4o"]
+```
+
+### Performance Optimization  
+
+Use the fastest models first for better response times:
+
+```python
+generative_model_name=["gpt-4o-mini", "gpt-4o-2024-08-06"]
+```
+
+### Reliability
+
+Include multiple models for maximum uptime:
+
+```python
+generative_model_name=["gpt-4o", "gpt-4o-2024-08-06", "gpt-4o-mini"]
+```
+
+## Troubleshooting
+
+### Common Issues
+
+1. **Authentication Errors**
+   ```
+   OpenAI API key not found
+   ```
+   **Solution**: Ensure `OPENAI_API_KEY` is set in your environment
+
+2. **Model Not Found**
+   ```
+   Model 'custom-model' not found
+   ```
+   **Solution**: Verify the model name exists in your OpenAI account and is properly spelled
+
+3. **Rate Limit Errors**
+   ```
+   Rate limit exceeded
+   ```
+   **Solution**: Use multiple models with fallback to automatically handle rate limits
+
+4. **Quota Exceeded**
+   ```
+   You have exceeded your quota
+   ```
+   **Solution**: Check your OpenAI account billing and usage limits
+
+## Advanced Configuration
+
+### Mixing Different Model Types
+
+You can mix different OpenAI model families in your fallback list:
+
+```python
+generative_model_name=[
+    "gpt-4o-mini",           # Fast and cost-effective
+    "gpt-4o",                # High quality
+    "gpt-3.5-turbo"          # Backup option
+]
+```
+
+### Environment-Specific Configuration
+
+Configure different models for different environments:
+
+```python
+import os
+
+model_config = {
+    "development": "gpt-4o-mini",
+    "staging": ["gpt-4o-mini", "gpt-4o"],
+    "production": ["gpt-4o", "gpt-4o-2024-08-06", "gpt-4o-mini"]
+}
+
+environment = os.getenv("ENVIRONMENT", "development")
+selected_models = model_config[environment]
+
+async with p.Server(
+    nlp_service=p.NLPServices.openai(generative_model_name=selected_models)
+) as server:
+    # ... rest of your code
+```
+
+This approach provides flexibility for experimentation in development while ensuring reliability in production.

--- a/src/parlant/adapters/nlp/openai_service.py
+++ b/src/parlant/adapters/nlp/openai_service.py
@@ -52,6 +52,7 @@ from parlant.core.nlp.generation import (
     T,
     SchematicGenerator,
     SchematicGenerationResult,
+    FallbackSchematicGenerator,
 )
 from parlant.core.nlp.generation_info import GenerationInfo, UsageInfo
 from parlant.core.nlp.moderation import (
@@ -464,18 +465,71 @@ Please set OPENAI_API_KEY in your environment before running Parlant.
     def __init__(
         self,
         logger: Logger,
+        generative_model_name: str | list[str] | None = None,
     ) -> None:
         self._logger = logger
+        self._generative_model_name = generative_model_name
         self._logger.info("Initialized OpenAIService")
+
+    def _get_generator_class_for_model(self, model_name: str):
+        """Returns the appropriate generator class for the given model name."""
+        model_mapping = {
+            "gpt-4o": GPT_4o,
+            "gpt-4o-2024-11-20": GPT_4o,
+            "gpt-4o-2024-08-06": GPT_4o_24_08_06,
+            "gpt-4.1": GPT_4_1,
+            "gpt-4o-mini": GPT_4o_Mini,
+        }
+        
+        # Check if it's a known model
+        if model_name in model_mapping:
+            return model_mapping[model_name]
+        else:
+            # For unknown models, create a dynamic generator
+            self._logger.warning(
+                f"Unrecognized model name '{model_name}'. Using dynamic OpenAISchematicGenerator."
+            )
+            
+            class CustomOpenAIGenerator(OpenAISchematicGenerator[T]):
+                def __init__(self, logger: Logger):
+                    super().__init__(model_name=model_name, logger=logger)
+                
+                @property
+                def max_tokens(self) -> int:
+                    return 4096  # Default max tokens for custom models
+            
+            return CustomOpenAIGenerator
 
     @override
     async def get_schematic_generator(self, t: type[T]) -> OpenAISchematicGenerator[T]:
-        return {
-            SingleToolBatchSchema: GPT_4o[SingleToolBatchSchema],
-            JourneyNodeSelectionSchema: GPT_4_1[JourneyNodeSelectionSchema],
-            CannedResponseDraftSchema: GPT_4_1[CannedResponseDraftSchema],
-            CannedResponseSelectionSchema: GPT_4_1[CannedResponseSelectionSchema],
-        }.get(t, GPT_4o_24_08_06[t])(self._logger)  # type: ignore
+        if self._generative_model_name:
+            # If specific model(s) requested, use them with fallback support
+            model_names = (
+                self._generative_model_name
+                if isinstance(self._generative_model_name, list)
+                else [self._generative_model_name]
+            )
+            
+            generators = []
+            for model_name in model_names:
+                generator_class = self._get_generator_class_for_model(model_name)
+                generators.append(generator_class[t](self._logger))  # type: ignore
+            
+            if len(generators) == 1:
+                return generators[0]
+            else:
+                return FallbackSchematicGenerator[t](  # type: ignore
+                    *generators,
+                    logger=self._logger,
+                )
+        else:
+            # Default behavior with schema-specific model selection
+            return {
+                SingleToolBatchSchema: GPT_4o[SingleToolBatchSchema],
+                JourneyNodeSelectionSchema: GPT_4_1[JourneyNodeSelectionSchema],
+                CannedResponseDraftSchema: GPT_4_1[CannedResponseDraftSchema],
+                CannedResponseSelectionSchema: GPT_4_1[CannedResponseSelectionSchema],
+            }.get(t, GPT_4o_24_08_06[t])(self._logger)  # type: ignore
 
     @override
     async def get_embedder(self) -> Embedder:

--- a/src/parlant/sdk.py
+++ b/src/parlant/sdk.py
@@ -252,14 +252,23 @@ class NLPServices:
         return AzureService(container[Logger])
 
     @staticmethod
-    def openai(container: Container) -> NLPService:
-        """Creates an OpenAI NLPService instance using the provided container."""
+    def openai(container: Container | None = None, generative_model_name: str | list[str] | None = None) -> NLPService | Callable[[Container], NLPService]:
+        """
+        Returns a callable that creates an OpenAI NLPService instance using the provided container and generative_model_name.
+        If container is None, the callable expects the container to be provided later (by the Server).
+        If generative_model_name is None, the default model selection behavior is used.
+        """
         from parlant.adapters.nlp.openai_service import OpenAIService
 
-        if error := OpenAIService.verify_environment():
-            raise SDKError(error)
+        def factory(c: Container) -> NLPService:
+            if error := OpenAIService.verify_environment():
+                raise SDKError(error)
+            return OpenAIService(c[Logger], generative_model_name=generative_model_name)
 
-        return OpenAIService(container[Logger])
+        if container is not None:
+            return factory(container)
+
+        return factory
 
     @staticmethod
     def anthropic(container: Container) -> NLPService:


### PR DESCRIPTION
### Description

#586 This PR extends the OpenAIService provider to support multiple model names with automatic fallback handling.

Key Updates
Added support for passing generative_model_name as:

- a single string (e.g., "gpt-4o-mini")
- a list of model names (e.g., ["gpt-4o-mini", "gpt-4o"])  
- or left None, for default model fallback behavior.

Integrated FallbackSchematicGenerator to automatically switch to the next model in the list if one fails or is overloaded.

Kept backward compatibility — existing usages like p.NLPServices.openai() continue to work.

Example Usage
```python
import asyncio
import parlant.sdk as p

async def main():
    async with p.Server(
        nlp_service=p.NLPServices.openai(
            generative_model_name=["gpt-4o-mini", "gpt-4o"]
        )
    ) as server:
        agent = await server.create_agent(
            name="Otto Carmen", 
            description="You work at a car dealership",
        )

asyncio.run(main())
```

Files Modified
- src/parlant/adapters/nlp/openai_service.py
- src/parlant/sdk.py

Files Added  
- tests/adapters/nlp/test_openai_service.py
- docs/adapters/nlp/openai.md