### PR TITLE
fix: adjust the dimension of the text-embedding-3-small embedding model from 3072 to 1536

### DIFF
--- a/src/parlant/adapters/nlp/openai_service.py
+++ b/src/parlant/adapters/nlp/openai_service.py
@@ -398,7 +398,7 @@ class OpenAITextEmbedding3Small(OpenAIEmbedder):
 
     @property
     def dimensions(self) -> int:
-        return 3072
+        return 1536
 
 
 class OpenAIModerationService(BaseModerationService):


### PR DESCRIPTION
Adjust the dimension of the text-embedding-3-small embedding model from 3072 to 1536

Signed-off-by: SeasonPilot <pilot1@foxmail.com>


https://platform.openai.com/docs/guides/embeddings#how-to-get-embeddings:~:text=5%0A%20%20%7D%0A%7D-,By%20default%2C%20the%20length%20of%20the%20embedding%20vector%20is,.,-Embedding%20models