### PR TITLE
changed relative action arq from str to seq[str]

### DIFF
--- a/src/parlant/core/services/indexing/relative_action_proposer.py
+++ b/src/parlant/core/services/indexing/relative_action_proposer.py
@@ -32,7 +32,7 @@ class RelativeActionProposition(DefaultBaseModel):
 
 class RelativeActionBatch(DefaultBaseModel):
     index: str
-    conditions: Sequence[str]
+    conditions: Sequence[str] | None = None
     action: str
     needs_rewrite_rational: str
     needs_rewrite: bool


### PR DESCRIPTION
Changed the 'conditions' ARQ to be a sequence of strings instead of a string.

The previous type confused smaller language models occasionally. They would output a list and not a string of a list.