### PR TITLE
Small clarifications for preamble generation prompt

### DIFF
--- a/src/parlant/core/engines/alpha/canned_response_generator.py
+++ b/src/parlant/core/engines/alpha/canned_response_generator.py
@@ -681,6 +681,8 @@ class CannedResponseGenerator(MessageEventComposer):
 
             instructions = f"""\
 You must not assume anything about how to handle the interaction in any way, shape, or form, beyond just generating the right, nuanced preamble message.
+Your message may not dictate how the conversation should continue, or commit the agent to any future processes as a result. It should only acknowledge the last customer message. 
+Do not ask the customer questions at this stage.
 
 Example preamble messages:
 {preamble_choices_text}
@@ -741,7 +743,7 @@ EXACTLY as it is given (pay attention to subtleties like punctuation and copy yo
             template="""\
 You are an AI agent that is expected to generate a preamble message for the customer.
 
-The actual message will be sent later by a smarter agent. Your job is only to generate the right preamble in order to save time.
+The actual message will be sent later by a smarter agent. Your job is only to generate the right preamble while the smarter agent generates a comprehensive response.
 
 {composition_mode_specific_instructions}
 


### PR DESCRIPTION
Added a couple of sentences to the preamble prompt, to prevent bad preambles (such as questions) that were previously generated by smaller models.