### PR TITLE
Add region selection for Qwen NLP adapter

### DIFF
--- a/src/parlant/adapters/nlp/qwen_service.py
+++ b/src/parlant/adapters/nlp/qwen_service.py
@@ -344,6 +344,13 @@ You're using the Qwen NLP service, but DASHSCOPE_API_KEY is not set.
 Please set DASHSCOPE_API_KEY in your environment before running Parlant.
 """
 
+        if region := os.environ.get("QWEN_REGION"):
+            if region.lower() not in QWEN_REGION_BASE_URLS:
+                return f"""\
+Invalid QWEN_REGION '{region}'.
+Must be one of: {', '.join(QWEN_REGION_BASE_URLS.keys())}
+"""
+
         return None
 
     def __init__(

--- a/tests/adapters/nlp/test_qwen_service.py
+++ b/tests/adapters/nlp/test_qwen_service.py
@@ -31,6 +31,19 @@ def test_that_missing_api_key_returns_error_message() -> None:
         assert "DASHSCOPE_API_KEY is not set" in error
 
 
+def test_that_verify_environment_returns_error_for_invalid_region() -> None:
+    """Test that verify_environment returns error for invalid QWEN_REGION."""
+    with patch.dict(
+        os.environ,
+        {"DASHSCOPE_API_KEY": "test-key", "QWEN_REGION": "invalid-region"},
+        clear=True,
+    ):
+        error = QwenService.verify_environment()
+        assert error is not None
+        assert "Invalid QWEN_REGION 'invalid-region'" in error
+        assert "Must be one of: international, domestic" in error
+
+
 def test_that_get_qwen_base_url_returns_international_by_default() -> None:
     """Test that get_qwen_base_url returns international URL by default."""
     with patch.dict(os.environ, {}, clear=True):


### PR DESCRIPTION
## Summary
- Add `QWEN_REGION` environment variable to select between international (Singapore) and domestic (Beijing) API endpoints
- Accepts 'international' or 'domestic' values (case-insensitive)
- Defaults to 'international' for backward compatibility
- `QWEN_BASE_URL` can still be used to override the URL completely
- Add comprehensive tests for the region selection functionality

Closes #698

## Test Plan
- [x] New tests for region selection (`test_qwen_service.py`)
- [x] All tests pass
- [x] Lint checks pass (mypy, ruff)
- [x] Backward compatible - existing deployments work without changes