### PR TITLE
fix: Add CORS headers to exception handler responses

### DIFF
--- a/tests/api/test_app.py
+++ b/tests/api/test_app.py
@@ -21,3 +21,16 @@ async def test_health_check_endpoint(async_client: httpx.AsyncClient) -> None:
 
     assert response.status_code == status.HTTP_200_OK
     assert response.json() == {"status": "ok"}
+
+
+async def test_that_404_error_responses_include_cors_headers(
+    async_client: httpx.AsyncClient,
+) -> None:
+    """CORS headers must be present on error responses for cross-origin clients."""
+    response = await async_client.get(
+        "/agents/nonexistent-agent-id",
+        headers={"Origin": "http://localhost:3000"},
+    )
+
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+    assert "access-control-allow-origin" in response.headers


### PR DESCRIPTION
## Summary

- Exception handler responses weren't getting CORS headers from FastAPI's CORSMiddleware, causing browsers to block error responses entirely due to missing `Access-Control-Allow-Origin` headers
- Changed exception handlers to return `JSONResponse` instead of raising `HTTPException`
- Added explicit CORS headers via helper function to all error responses (404, 403, 429, 500)
- Fixed incorrect type annotation on `server_error_handler` (was `ItemNotFoundError`, should be `Exception`)

## Test plan

- [x] Added test to verify CORS headers are present on 404 error responses