### PR TITLE
Fix canned response field extraction to handle falsy values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to Parlant will be documented here.
 
 TBD
 
+## [3.1.2] - 2026-01-05
+
+### Changed
+
+- Set EmcieService back as default NLPService
+
 ## [3.1.1] - 2026-01-05
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to Parlant will be documented here.
 
 TBD
 
+## [3.1.1] - 2026-01-05
+
+### Changed
+
+- Set OpenAI as default service until EmcieService is live
+
 ## [3.1.0] - 2026-01-05
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "parlant"
-version = "3.1.0"
+version = "3.1.1"
 description = ""
 readme = "README.md"
 license = "Apache-2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "parlant"
-version = "3.1.1"
+version = "3.1.2"
 description = ""
 readme = "README.md"
 license = "Apache-2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
     "opentelemetry-exporter-otlp>=1.37.0",
     "opentelemetry-instrumentation>=0.58b0",
     "opentelemetry-sdk>=1.37.0",
-    "parlant-client @ git+https://github.com/emcie-co/parlant-client-python.git@v3.1.0",
+    "parlant-client>=3.1.0",
     "python-dateutil>=2.8.2",
     "python-dotenv>=1.0.1",
     "requests>=2.32.5",

--- a/src/parlant/core/engines/alpha/canned_response_generator.py
+++ b/src/parlant/core/engines/alpha/canned_response_generator.py
@@ -259,7 +259,8 @@ class ToolBasedFieldExtraction(CannedResponseFieldExtractionMethod):
         )
 
         for tool_call in tool_calls_in_order_of_importance:
-            if value := tool_call["result"].get("canned_response_fields", {}).get(field_name, None):
+            value = tool_call["result"].get("canned_response_fields", {}).get(field_name, None)
+            if value is not None:
                 return True, value
 
         return False, None

--- a/src/parlant/core/version.py
+++ b/src/parlant/core/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-VERSION = "3.1.1"
+VERSION = "3.1.2"

--- a/src/parlant/core/version.py
+++ b/src/parlant/core/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-VERSION = "3.1.0"
+VERSION = "3.1.1"

--- a/src/parlant/sdk.py
+++ b/src/parlant/sdk.py
@@ -3147,7 +3147,7 @@ class Server:
         host: str = "0.0.0.0",
         port: int = 8800,
         tool_service_port: int = 8818,
-        nlp_service: Callable[[Container], NLPService] = NLPServices.openai,
+        nlp_service: Callable[[Container], NLPService] = NLPServices.emcie,
         session_store: Literal["transient", "local"] | str | SessionStore = "transient",
         customer_store: Literal["transient", "local"] | str | CustomerStore = "transient",
         variable_store: Literal["transient", "local"] | str | ContextVariableStore = "transient",

--- a/src/parlant/sdk.py
+++ b/src/parlant/sdk.py
@@ -3147,7 +3147,7 @@ class Server:
         host: str = "0.0.0.0",
         port: int = 8800,
         tool_service_port: int = 8818,
-        nlp_service: Callable[[Container], NLPService] = NLPServices.emcie,
+        nlp_service: Callable[[Container], NLPService] = NLPServices.openai,
         session_store: Literal["transient", "local"] | str | SessionStore = "transient",
         customer_store: Literal["transient", "local"] | str | CustomerStore = "transient",
         variable_store: Literal["transient", "local"] | str | ContextVariableStore = "transient",

--- a/tests/core/stable/engines/alpha/test_canned_response_field_extraction.py
+++ b/tests/core/stable/engines/alpha/test_canned_response_field_extraction.py
@@ -1,0 +1,152 @@
+"""Tests for canned response field extraction methods."""
+
+from typing import Any
+from unittest.mock import Mock
+
+import pytest
+
+from parlant.core.engines.alpha.canned_response_generator import (
+    CannedResponseContext,
+    ToolBasedFieldExtraction,
+)
+from parlant.core.sessions import EventKind, ToolCall, ToolEventData, ToolResult
+
+
+@pytest.fixture
+def tool_based_extractor() -> ToolBasedFieldExtraction:
+    """Create a ToolBasedFieldExtraction instance."""
+    return ToolBasedFieldExtraction()
+
+
+def create_context_with_tool_result(
+    field_name: str,
+    field_value: Any,
+) -> CannedResponseContext:
+    """Helper to create a CannedResponseContext with a tool call result."""
+    tool_call: ToolCall = {
+        "tool_id": "test_tool",
+        "arguments": {},
+        "result": ToolResult(
+            data={},
+            metadata={},
+            control={},
+            canned_responses=[],
+            canned_response_fields={
+                field_name: field_value,
+            },
+        ),
+    }
+
+    tool_event_data: ToolEventData = {"tool_calls": [tool_call]}
+
+    event = Mock()
+    event.kind = EventKind.TOOL
+    event.data = tool_event_data
+
+    context = Mock(spec=CannedResponseContext)
+    context.interaction_history = [event]
+    context.staged_tool_events = []
+
+    return context  # type: ignore[return-value]
+
+
+@pytest.mark.asyncio
+async def test_that_tool_based_field_extraction_returns_integer_zero_value(
+    tool_based_extractor: ToolBasedFieldExtraction,
+) -> None:
+    """Test that integer zero (0) is correctly extracted as a valid field value."""
+    context = create_context_with_tool_result("result_count", 0)
+
+    found, value = await tool_based_extractor.extract(
+        canned_response="Test response",
+        field_name="result_count",
+        context=context,
+    )
+
+    assert found is True
+    assert value == 0
+
+
+@pytest.mark.asyncio
+async def test_that_tool_based_field_extraction_returns_false_boolean_value(
+    tool_based_extractor: ToolBasedFieldExtraction,
+) -> None:
+    """Test that boolean False is correctly extracted as a valid field value."""
+    context = create_context_with_tool_result("is_available", False)
+
+    found, value = await tool_based_extractor.extract(
+        canned_response="Test response",
+        field_name="is_available",
+        context=context,
+    )
+
+    assert found is True
+    assert value is False
+
+
+@pytest.mark.asyncio
+async def test_that_tool_based_field_extraction_returns_empty_string_value(
+    tool_based_extractor: ToolBasedFieldExtraction,
+) -> None:
+    """Test that empty string is correctly extracted as a valid field value."""
+    context = create_context_with_tool_result("description", "")
+
+    found, value = await tool_based_extractor.extract(
+        canned_response="Test response",
+        field_name="description",
+        context=context,
+    )
+
+    assert found is True
+    assert value == ""
+
+
+@pytest.mark.asyncio
+async def test_that_tool_based_field_extraction_returns_empty_list_value(
+    tool_based_extractor: ToolBasedFieldExtraction,
+) -> None:
+    """Test that empty list is correctly extracted as a valid field value."""
+    context = create_context_with_tool_result("items", [])
+
+    found, value = await tool_based_extractor.extract(
+        canned_response="Test response",
+        field_name="items",
+        context=context,
+    )
+
+    assert found is True
+    assert value == []
+
+
+@pytest.mark.asyncio
+async def test_that_tool_based_field_extraction_returns_empty_dict_value(
+    tool_based_extractor: ToolBasedFieldExtraction,
+) -> None:
+    """Test that empty dict is correctly extracted as a valid field value."""
+    context = create_context_with_tool_result("metadata", {})
+
+    found, value = await tool_based_extractor.extract(
+        canned_response="Test response",
+        field_name="metadata",
+        context=context,
+    )
+
+    assert found is True
+    assert value == {}
+
+
+@pytest.mark.asyncio
+async def test_that_tool_based_field_extraction_returns_none_when_field_not_found(
+    tool_based_extractor: ToolBasedFieldExtraction,
+) -> None:
+    """Test that None is returned when the field is not found."""
+    context = create_context_with_tool_result("other_field", "some_value")
+
+    found, value = await tool_based_extractor.extract(
+        canned_response="Test response",
+        field_name="nonexistent_field",
+        context=context,
+    )
+
+    assert found is False
+    assert value is None

--- a/uv.lock
+++ b/uv.lock
@@ -3756,7 +3756,7 @@ requires-dist = [
     { name = "opentelemetry-exporter-otlp", specifier = ">=1.37.0" },
     { name = "opentelemetry-instrumentation", specifier = ">=0.58b0" },
     { name = "opentelemetry-sdk", specifier = ">=1.37.0" },
-    { name = "parlant-client", git = "https://github.com/emcie-co/parlant-client-python.git?rev=v3.1.0" },
+    { name = "parlant-client", specifier = ">=3.1.0" },
     { name = "pymongo", marker = "extra == 'mongo'", specifier = ">=4.11.1" },
     { name = "python-dateutil", specifier = ">=2.8.2" },
     { name = "python-dotenv", specifier = ">=1.0.1" },
@@ -3818,12 +3818,16 @@ dev = [
 [[package]]
 name = "parlant-client"
 version = "3.1.0"
-source = { git = "https://github.com/emcie-co/parlant-client-python.git?rev=v3.1.0#f6a1b8cc5834cb6e8d28bfcc8b5495ea218098c7" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
     { name = "mypy" },
     { name = "nanoid" },
     { name = "pydantic" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b4/f1/536e9960789099407d3f79626d29fe33f6b66ee26df494db6af640da1184/parlant_client-3.1.0.tar.gz", hash = "sha256:8eb13e8df674ddfd203569948cbcae5a293cedba6feed270ddcf5d4c1213dbf7", size = 52294, upload-time = "2026-01-05T12:45:54.789Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/13/03/4c6fad599466ccb0374d4c4097fd400042b1a1bca556c8b7be3465242b65/parlant_client-3.1.0-py3-none-any.whl", hash = "sha256:e348eb9bf7d82a5d8b8226194fab867fe6ef05075ff4d167d4be11991786d161", size = 111847, upload-time = "2026-01-05T12:45:53.791Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -3569,7 +3569,7 @@ wheels = [
 
 [[package]]
 name = "parlant"
-version = "3.1.1"
+version = "3.1.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },

--- a/uv.lock
+++ b/uv.lock
@@ -3569,7 +3569,7 @@ wheels = [
 
 [[package]]
 name = "parlant"
-version = "3.1.0"
+version = "3.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Summary

Fixes a bug in `ToolBasedFieldExtraction.extract()` where falsy but valid values (0, False, "", [], {}) set in tool call results were incorrectly skipped due to truthiness evaluation.

## Changes

- Changed the field extraction logic to explicitly check for `None` instead of using truthiness
- Added comprehensive unit tests covering all falsy value types

## Impact

This bug prevented canned response Jinja templates from using conditionals like `{% if result_count == 0 %}` when a tool returned 0 as a valid value. For example, a database query returning 0 results couldn't set `result_count = 0` for template rendering.

## Test Coverage

Added 6 new unit tests in `tests/core/stable/engines/alpha/test_canned_response_field_extraction.py`:
- Integer zero (0)
- Boolean False
- Empty string ("")
- Empty list ([])
- Empty dict ({})
- Verification that None is still returned for missing fields

All tests pass with the fix applied.