### PR TITLE
Improve MCP schema parsing and result adaptation

### DIFF
--- a/src/parlant/core/services/tools/mcp_service.py
+++ b/src/parlant/core/services/tools/mcp_service.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 from ast import literal_eval
 from datetime import datetime, timezone
+import json
 from mailbox import FormatError
 from mcp.types import Tool as McpTool
 from types import TracebackType
@@ -216,8 +217,7 @@ class MCPToolClient(ToolService):
             tool = await self.read_tool(name)
             arguments = prepare_tool_arguments(arguments, tool.parameters)
             result = await self._client.call_tool(name, dict(arguments))
-            text = next((r.text for r in result.content if r.type == "text"), None)
-            return ToolResult(data=text)
+            return ToolResult(data=mcp_result_to_tool_result_data(result))
         except Exception as e:
             raise ToolError(str(e))
 
@@ -238,7 +238,7 @@ mcp_parameter_type_map: dict[tuple[str, str | None], ToolParameterType] = {
 
 def mcp_tool_to_parlant_tool(mcp_tool: McpTool) -> Tool:
     parameters = {}
-    for param in mcp_tool.inputSchema["properties"]:
+    for param in mcp_tool.inputSchema.get("properties", {}):
         parameters[param] = (
             mcp_parameter_to_parlant_parameter(param, mcp_tool.inputSchema),
             ToolParameterOptions(),
@@ -249,7 +249,7 @@ def mcp_tool_to_parlant_tool(mcp_tool: McpTool) -> Tool:
         description=(mcp_tool.description if mcp_tool.description else ""),
         metadata={},
         parameters=parameters,
-        required=mcp_tool.inputSchema["required"],
+        required=mcp_tool.inputSchema.get("required", []),
         consequential=True,
         overlap=ToolOverlap.ALWAYS,
     )
@@ -266,7 +266,7 @@ def mcp_parameter_to_parlant_parameter(
 
     param_type = mcp_param.get("type", None)
     param_format = mcp_param.get("format", None)
-    description = mcp_param.get("title", None)
+    description = mcp_param.get("title") or mcp_param.get("description")
 
     if (param_type, param_format) in mcp_parameter_type_map:
         """ basic types + easily serializable types """
@@ -281,8 +281,10 @@ def mcp_parameter_to_parlant_parameter(
         )
 
     if "$ref" in mcp_param:
-        """ Reference to another schema - currently only enum is supported"""
+        """ Reference to another schema - enum and object references are supported"""
         def_ = resolve_ref(mcp_param["$ref"], schema)
+        if _is_object_schema(def_):
+            return ToolParameterDescriptor(type="string", description=description or "")
         return parse_enum_def(def_)
 
     if param_type == "array":
@@ -290,23 +292,82 @@ def mcp_parameter_to_parlant_parameter(
         if "items" not in mcp_param:
             raise FormatError("Only lists and sets are supported collections")
 
-        enum_desc = None
-        if "$ref" in mcp_param["items"]:
-            """ Reference to another schema - currently only enum is supported"""
-            def_ = resolve_ref(mcp_param["items"]["$ref"], schema)
-            enum_desc = parse_enum_def(def_)
+        item_type, enum = parse_mcp_array_item(mcp_param["items"], schema)
 
         return ToolParameterDescriptor(
             type="array",
-            item_type=(
-                enum_desc["type"]
-                if enum_desc
-                else mcp_parameter_type_map[(mcp_param["items"]["type"], None)]
-            ),
-            **({"enum": enum_desc["enum"]} if enum_desc is not None else {}),
+            item_type=item_type,
+            **({"enum": enum} if enum is not None else {}),
             description=mcp_param.get("title", ""),
         )
+    if _is_object_schema(mcp_param):
+        return ToolParameterDescriptor(type="string", description=description or "")
     raise FormatError(f"Unsupported parameter type: {param_type} (parameter is {parameter_name})")
+
+
+def parse_mcp_array_item(
+    item_schema: dict[str, Any],
+    root_schema: dict[str, Any],
+) -> tuple[ToolParameterType, Sequence[str] | None]:
+    if "$ref" in item_schema:
+        def_ = resolve_ref(item_schema["$ref"], root_schema)
+        if _is_object_schema(def_):
+            return ("string", None)
+
+        enum_desc = parse_enum_def(def_)
+        return (enum_desc["type"], enum_desc["enum"])
+
+    item_type = item_schema.get("type")
+    item_format = item_schema.get("format")
+
+    if _is_object_schema(item_schema):
+        return ("string", None)
+
+    if (item_type, item_format) in mcp_parameter_type_map:
+        return (mcp_parameter_type_map[(item_type, item_format)], None)
+
+    raise FormatError(f"Unsupported array item type: {item_type}")
+
+
+def _is_object_schema(schema_part: Mapping[str, Any]) -> bool:
+    return schema_part.get("type") == "object" or "properties" in schema_part
+
+
+def mcp_result_to_tool_result_data(result: Any) -> Any:
+    raw_data = getattr(result, "data", None)
+    if raw_data is not None:
+        return _deserialize_mcp_data(raw_data)
+
+    structured_content = getattr(result, "structuredContent", None)
+    if structured_content is None:
+        structured_content = getattr(result, "structured_content", None)
+    if structured_content is not None:
+        return structured_content
+
+    text_blocks = [content.text for content in getattr(result, "content", []) if content.type == "text"]
+
+    if not text_blocks:
+        return None
+
+    parsed_blocks = [_deserialize_mcp_text(text) for text in text_blocks]
+
+    if len(parsed_blocks) == 1:
+        return parsed_blocks[0]
+
+    return parsed_blocks
+
+
+def _deserialize_mcp_text(text: str) -> Any:
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError:
+        return text
+
+
+def _deserialize_mcp_data(data: Any) -> Any:
+    if isinstance(data, str):
+        return _deserialize_mcp_text(data)
+    return data
 
 
 def resolve_ref(ref_: str, schema: dict[str, Any]) -> dict[str, Any]:

--- a/tests/core/stable/engines/alpha/test_mcp.py
+++ b/tests/core/stable/engines/alpha/test_mcp.py
@@ -12,17 +12,25 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from datetime import datetime, date, timedelta
+from datetime import datetime, date, timedelta, timezone
 from enum import Enum
 import uuid
 from pathlib import Path
+from typing import Any
 
-from parlant.core.services.tools.mcp_service import MCPToolServer, MCPToolClient
+from mcp.types import CallToolResult, TextContent, Tool as McpTool
+from parlant.core.services.tools.mcp_service import (
+    MCPToolServer,
+    MCPToolClient,
+    mcp_result_to_tool_result_data,
+    mcp_tool_to_parlant_tool,
+)
 from lagom import Container
 from parlant.core.agents import Agent
 from parlant.core.emissions import EventEmitterFactory
 from parlant.core.tracer import LocalTracer
 from parlant.core.loggers import StdoutLogger
+from parlant.core.tools import Tool, ToolOverlap
 from parlant.sdk import ToolContext
 from tests.test_utilities import SERVER_BASE_URL, get_random_port
 from parlant.core.services.tools.service_registry import ServiceRegistry
@@ -41,6 +49,47 @@ def create_client(
         tracer=tracer,
         port=server._port,
     )
+
+
+class StubMCPClient:
+    def __init__(self, result: CallToolResult) -> None:
+        self._result = result
+
+    async def call_tool(self, name: str, arguments: dict[str, Any]) -> CallToolResult:
+        return self._result
+
+
+def create_stubbed_tool_client(result: CallToolResult) -> MCPToolClient:
+    client = object.__new__(MCPToolClient)
+    client._client = StubMCPClient(result)  # type: ignore[attr-defined]
+
+    async def read_tool(name: str) -> Tool:
+        return Tool(
+            name=name,
+            creation_utc=datetime.now(timezone.utc),
+            description="",
+            metadata={},
+            parameters={},
+            required=[],
+            consequential=True,
+            overlap=ToolOverlap.ALWAYS,
+        )
+
+    client.read_tool = read_tool  # type: ignore[method-assign]
+    return client
+
+
+class FastMCPStyleResult:
+    def __init__(
+        self,
+        *,
+        content: list[TextContent],
+        data: Any = None,
+        structured_content: Any = None,
+    ) -> None:
+        self.content = content
+        self.data = data
+        self.structured_content = structured_content
 
 
 async def greet_me_like_pirate(name: str, lucky_number: int, am_i_the_goat: bool = True) -> str:
@@ -92,6 +141,52 @@ async def test_that_another_simple_mcp_tool_is_listed_resolved_and_called(
             assert "The date is 2025-01-20T12:05:00 and the factor is 2.3" in result.data
 
 
+def test_that_an_mcp_tool_schema_without_required_defaults_to_no_required_parameters() -> None:
+    tool = mcp_tool_to_parlant_tool(
+        McpTool(
+            name="missing_required",
+            description="",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "payload": {"type": "string", "title": "Payload"},
+                },
+            },
+        )
+    )
+
+    assert tool.required == []
+    assert tool.parameters["payload"][0]["type"] == "string"
+
+
+def test_that_object_parameters_and_object_arrays_are_degraded_to_string_descriptors() -> None:
+    tool = mcp_tool_to_parlant_tool(
+        McpTool(
+            name="object_params",
+            description="",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "payload": {
+                        "type": "object",
+                        "title": "Payload",
+                    },
+                    "items": {
+                        "type": "array",
+                        "title": "Items",
+                        "items": {"type": "object"},
+                    },
+                },
+                "required": [],
+            },
+        )
+    )
+
+    assert tool.parameters["payload"][0]["type"] == "string"
+    assert tool.parameters["items"][0]["type"] == "array"
+    assert tool.parameters["items"][0]["item_type"] == "string"
+
+
 async def test_that_an_mcp_tool_can_be_called_with_enum_and_bool_lists(
     container: Container,
     agent: Agent,
@@ -118,6 +213,60 @@ async def test_that_an_mcp_tool_can_be_called_with_enum_and_bool_lists(
                 {"enum_list": ["a", "b", "c", "a"], "bool_list": [True, False, True]},
             )
             assert "The enum list is" in result.data
+
+
+async def test_that_mcp_call_tool_preserves_multiple_text_blocks() -> None:
+    client = create_stubbed_tool_client(
+        CallToolResult(
+            content=[
+                TextContent(type="text", text="alpha"),
+                TextContent(type="text", text="beta"),
+            ]
+        )
+    )
+
+    result = await client.call_tool("multi_text", ToolContext("", "", ""), {})
+
+    assert result.data == ["alpha", "beta"]
+
+
+def test_that_mcp_result_data_is_deserialized_from_json_text() -> None:
+    data = mcp_result_to_tool_result_data(
+        CallToolResult(
+            content=[
+                TextContent(type="text", text='{"ok": true, "items": [1, 2]}'),
+            ]
+        )
+    )
+
+    assert data == {"ok": True, "items": [1, 2]}
+
+
+def test_that_mcp_result_data_uses_native_fastmcp_data_when_available() -> None:
+    data = mcp_result_to_tool_result_data(
+        FastMCPStyleResult(
+            content=[TextContent(type="text", text="33")],
+            data=33,
+            structured_content={"result": 33},
+        )
+    )
+
+    assert data == 33
+
+
+async def test_that_mcp_call_tool_prefers_structured_content_over_serialized_text() -> None:
+    client = create_stubbed_tool_client(
+        CallToolResult(
+            content=[
+                TextContent(type="text", text='"{\\"ok\\": true}"'),
+            ],
+            structuredContent={"ok": True},
+        )
+    )
+
+    result = await client.call_tool("structured", ToolContext("", "", ""), {})
+
+    assert result.data == {"ok": True}
 
 
 async def test_that_an_mcp_tool_can_be_called_with_a_list_of_date_and_datetime(


### PR DESCRIPTION
## Summary

This PR fixes two MCP integration issues in Parlant:

1. MCP tool schema parsing was too strict:
   - `inputSchema["required"]` was accessed unconditionally even though `required` is optional in JSON Schema
   - object parameters and arrays of objects raised registration errors during tool discovery

2. MCP tool result adaptation was lossy:
   - only the first text content block was returned
   - structured results were not adapted consistently across MCP and FastMCP result shapes
   - JSON payloads returned as text stayed double-serialized

## Changes

- Default missing MCP `required` to an empty list
- Allow top-level object params and arrays of objects by degrading them to string-backed Parlant descriptors so tools can still be registered and listed
- Adapt MCP call results by:
  - preferring native FastMCP `data` when available
  - otherwise using `structuredContent` / `structured_content`
  - otherwise collecting all text blocks
  - JSON-decoding text payloads when possible
- Add regression coverage for the schema and result adaptation cases above

## Validation

- `.venv/bin/ruff check src/parlant/core/services/tools/mcp_service.py tests/core/stable/engines/alpha/test_mcp.py`
- `.venv/bin/pytest tests/core/stable/engines/alpha/test_mcp.py -q`

