### PR TITLE
fix: add ValueError to OpenRouterEmbedder retry policy

### DIFF
--- a/src/parlant/adapters/nlp/openrouter_service.py
+++ b/src/parlant/adapters/nlp/openrouter_service.py
@@ -432,6 +432,7 @@ class OpenRouterEmbedder(BaseEmbedder):
                 ),
             ),
             retry(InternalServerError, max_exceptions=2, wait_times=(1.0, 5.0)),
+            retry(ValueError, max_exceptions=2, wait_times=(1.0, 5.0)),
         ]
     )
     @override

--- a/tests/adapters/nlp/test_openrouter_service.py
+++ b/tests/adapters/nlp/test_openrouter_service.py
@@ -25,6 +25,7 @@ from openai.types.completion_usage import CompletionUsage
 from parlant.adapters.nlp.openrouter_service import (  # type: ignore[reportMissingImports]
     OpenRouterService,
     OpenRouterSchematicGenerator,
+    OpenRouterEmbedder,
     OpenRouterGPT4O,
     OpenRouterGPT4OMini,
     OpenRouterClaude35Sonnet,
@@ -463,3 +464,43 @@ def test_that_openrouter_generator_supports_correct_parameters(container: Contai
 
     expected_params = ["temperature", "max_tokens"]
     assert generator.supported_openrouter_params == expected_params
+
+
+@patch("parlant.adapters.nlp.openrouter_service.AsyncClient")
+async def test_that_openrouter_embedder_retries_on_valueerror(mock_client_class: Mock) -> None:
+    """Test that OpenRouterEmbedder retries when ValueError is raised.
+
+    The OpenAI SDK raises ValueError("No embedding data received") when
+    the API returns HTTP 200 with an empty data array. This should be
+    retried by the policy decorator.
+    """
+    mock_client = AsyncMock()
+    mock_client_class.return_value = mock_client
+
+    mock_embedding = Mock()
+    mock_embedding.embedding = [0.1, 0.2, 0.3]
+
+    mock_success_response = Mock()
+    mock_success_response.data = [mock_embedding]
+
+    # First call raises ValueError (transient empty response), second call succeeds
+    mock_client.embeddings.create = AsyncMock(
+        side_effect=[ValueError("No embedding data received"), mock_success_response]
+    )
+
+    mock_logger = Mock()
+    mock_tracer = Mock()
+    mock_meter = Mock()
+
+    with patch.dict(os.environ, {"OPENROUTER_API_KEY": "test-key"}, clear=False):
+        embedder = OpenRouterEmbedder(
+            model_name="openai/text-embedding-3-large",
+            logger=mock_logger,
+            tracer=mock_tracer,
+            meter=mock_meter,
+        )
+
+    result = await embedder.do_embed(["test text"])
+
+    assert result.vectors == [[0.1, 0.2, 0.3]]
+    assert mock_client.embeddings.create.call_count == 2


### PR DESCRIPTION
## Summary

Fixes #739

The `@policy` retry decorator on `OpenRouterEmbedder.do_embed` only covered API transport errors (`APIConnectionError`, `APITimeoutError`, etc.) and `InternalServerError`. When the upstream provider returns HTTP 200 with an empty data array, the OpenAI SDK raises `ValueError("No embedding data received")` in its post-parser. Because `ValueError` is a plain Python exception, it bypassed the retry policy entirely, causing the full `_run_preparation_iteration` to fail on a transient issue.

This PR adds `ValueError` to the embedder's retry policy with conservative limits (max 2 retries, 1s/5s backoff), matching the existing `InternalServerError` retry entry.

## Changes

- `src/parlant/adapters/nlp/openrouter_service.py`: Added `retry(ValueError, max_exceptions=2, wait_times=(1.0, 5.0))` to the `do_embed` policy decorator
- `tests/adapters/nlp/test_openrouter_service.py`: Added regression test that verifies `do_embed` retries on `ValueError` and succeeds on a subsequent call

## Testing

- New test `test_that_openrouter_embedder_retries_on_valueerror` mocks a `ValueError` on the first call followed by a successful response, then asserts the embedder retries and returns correct results
- Full test suite passes (26 passed, 1 skipped)