### PR TITLE
Improve session persistence hot paths

### DIFF
--- a/src/parlant/adapters/db/json_file.py
+++ b/src/parlant/adapters/db/json_file.py
@@ -29,6 +29,8 @@ from parlant.core.persistence.common import (
 )
 from parlant.core.async_utils import ReaderWriterLock
 from parlant.core.persistence.document_database import (
+    CollectionIndex,
+    CollectionSort,
     BaseDocument,
     DeleteResult,
     DocumentCollection,
@@ -305,6 +307,21 @@ class JSONFileDocumentCollection(DocumentCollection[TDocument]):
 
         return docs
 
+    def _apply_field_sort(
+        self,
+        documents: Sequence[TDocument],
+        sort: CollectionSort,
+    ) -> list[TDocument]:
+        docs = list(documents)
+
+        for field_name, direction in reversed(sort):
+            docs.sort(
+                key=lambda d: d.get(field_name),
+                reverse=direction == SortDirection.DESC,
+            )
+
+        return docs
+
     def _apply_cursor_filter(
         self,
         documents: list[TDocument],
@@ -345,12 +362,24 @@ class JSONFileDocumentCollection(DocumentCollection[TDocument]):
     async def find_one(
         self,
         filters: Where,
+        sort: Optional[CollectionSort] = None,
     ) -> Optional[TDocument]:
         async with self._lock.reader_lock:
-            for doc in self.documents:
-                if matches_filters(filters, doc):
-                    return doc
+            matching_documents = [doc for doc in self.documents if matches_filters(filters, doc)]
 
+            if sort:
+                matching_documents = self._apply_field_sort(matching_documents, sort)
+
+            for doc in matching_documents:
+                return doc
+
+        return None
+
+    @override
+    async def ensure_indexes(
+        self,
+        indexes: Sequence[CollectionIndex],
+    ) -> None:
         return None
 
     @override

--- a/src/parlant/adapters/db/json_file.py
+++ b/src/parlant/adapters/db/json_file.py
@@ -316,7 +316,7 @@ class JSONFileDocumentCollection(DocumentCollection[TDocument]):
 
         for field_name, direction in reversed(sort):
             docs.sort(
-                key=lambda d: d.get(field_name),
+                key=lambda d: cast(Any, d.get(field_name)),
                 reverse=direction == SortDirection.DESC,
             )
 

--- a/src/parlant/adapters/db/mongo_db.py
+++ b/src/parlant/adapters/db/mongo_db.py
@@ -12,12 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Awaitable, Callable, Optional
+from typing import Any, Awaitable, Callable, Optional, Sequence
 from bson import CodecOptions
 from typing_extensions import Self
 from parlant.core.loggers import Logger
 from parlant.core.persistence.common import Cursor, SortDirection, Where, ObjectId
 from parlant.core.persistence.document_database import (
+    CollectionIndex,
+    CollectionSort,
     BaseDocument,
     DeleteResult,
     DocumentCollection,
@@ -60,10 +62,10 @@ class MongoDocumentDatabase(DocumentDatabase):
             codec_options=CodecOptions(document_class=schema),
         )
 
-        # Create index on creation_utc field
-        await collection.create_index([("creation_utc", 1)])
-
         self._collections[name] = MongoDocumentCollection(self, collection)
+        await self._collections[name].ensure_indexes(
+            [CollectionIndex(fields=(("creation_utc", SortDirection.ASC),))]
+        )
         return self._collections[name]
 
     async def get_collection(
@@ -118,10 +120,10 @@ class MongoDocumentDatabase(DocumentDatabase):
                 )
                 await failed_migration_collection.insert_one(doc)
 
-        # Create index on creation_utc field
-        await result_collection.create_index([("creation_utc", 1)])
-
         self._collections[name] = MongoDocumentCollection(self, result_collection)
+        await self._collections[name].ensure_indexes(
+            [CollectionIndex(fields=(("creation_utc", SortDirection.ASC),))]
+        )
         return self._collections[name]
 
     async def get_or_create_collection(
@@ -230,9 +232,33 @@ class MongoDocumentCollection(DocumentCollection[TDocument]):
             items=items, total_count=total_count, has_more=has_more, next_cursor=next_cursor
         )
 
-    async def find_one(self, filters: Where) -> TDocument | None:
-        result = await self._collection.find_one(filters)
+    def _translate_sort(
+        self,
+        sort: CollectionSort,
+    ) -> list[tuple[str, int]]:
+        return [
+            (field_name, -1 if direction == SortDirection.DESC else 1)
+            for field_name, direction in sort
+        ]
+
+    async def find_one(
+        self,
+        filters: Where,
+        sort: Optional[CollectionSort] = None,
+    ) -> TDocument | None:
+        mongo_sort = self._translate_sort(sort) if sort else None
+        result = await self._collection.find_one(filters, sort=mongo_sort)
         return result
+
+    async def ensure_indexes(
+        self,
+        indexes: Sequence[CollectionIndex],
+    ) -> None:
+        for index in indexes:
+            await self._collection.create_index(
+                self._translate_sort(index.fields),
+                unique=index.unique,
+            )
 
     async def insert_one(self, document: TDocument) -> InsertResult:
         insert_result = await self._collection.insert_one(document)

--- a/src/parlant/adapters/db/mongo_db.py
+++ b/src/parlant/adapters/db/mongo_db.py
@@ -182,7 +182,7 @@ class MongoDocumentCollection(DocumentCollection[TDocument]):
                     {
                         "$and": [
                             {"creation_utc": cursor.creation_utc},
-                            {"_id": {"$lt": cursor.id}},
+                            {"id": {"$lt": cursor.id}},
                         ]
                     },
                 ]
@@ -192,15 +192,15 @@ class MongoDocumentCollection(DocumentCollection[TDocument]):
                     {
                         "$and": [
                             {"creation_utc": cursor.creation_utc},
-                            {"_id": {"$gt": cursor.id}},
+                            {"id": {"$gt": cursor.id}},
                         ]
                     },
                 ]
             query["$or"] = cursor_conditions
 
-        # Sort by creation_utc with _id as tiebreaker according to sort_direction
+        # Sort by creation_utc with id as tiebreaker according to sort_direction
         sort_order = -1 if sort_direction == SortDirection.DESC else 1
-        sort_spec = [("creation_utc", sort_order), ("_id", sort_order)]
+        sort_spec = [("creation_utc", sort_order), ("id", sort_order)]
 
         # Get one extra document to check if there are more
         query_limit = (limit + 1) if limit else None
@@ -225,7 +225,7 @@ class MongoDocumentCollection(DocumentCollection[TDocument]):
                 last_item = items[-1]
                 next_cursor = Cursor(
                     creation_utc=str(last_item.get("creation_utc", "")),
-                    id=ObjectId(str(last_item.get("_id", last_item.get("id", "")))),
+                    id=ObjectId(str(last_item.get("id", ""))),
                 )
 
         return FindResult(

--- a/src/parlant/adapters/db/snowflake_db.py
+++ b/src/parlant/adapters/db/snowflake_db.py
@@ -469,7 +469,7 @@ class SnowflakeDocumentCollection(DocumentCollection[TDocument]):
 
         for field_name, direction in reversed(sort):
             docs.sort(
-                key=lambda d: d.get(field_name),
+                key=lambda d: cast(Any, d.get(field_name)),
                 reverse=direction == SortDirection.DESC,
             )
 

--- a/src/parlant/adapters/db/snowflake_db.py
+++ b/src/parlant/adapters/db/snowflake_db.py
@@ -38,6 +38,8 @@ from typing_extensions import Self
 from parlant.core.loggers import Logger
 from parlant.core.persistence.common import Cursor, ObjectId, SortDirection, Where, ensure_is_total
 from parlant.core.persistence.document_database import (
+    CollectionIndex,
+    CollectionSort,
     BaseDocument,
     DeleteResult,
     DocumentCollection,
@@ -458,7 +460,31 @@ class SnowflakeDocumentCollection(DocumentCollection[TDocument]):
             next_cursor=next_cursor,
         )
 
-    async def find_one(self, filters: Where) -> Optional[TDocument]:
+    def _apply_field_sort(
+        self,
+        documents: Sequence[TDocument],
+        sort: CollectionSort,
+    ) -> list[TDocument]:
+        docs = list(documents)
+
+        for field_name, direction in reversed(sort):
+            docs.sort(
+                key=lambda d: d.get(field_name),
+                reverse=direction == SortDirection.DESC,
+            )
+
+        return docs
+
+    async def find_one(
+        self,
+        filters: Where,
+        sort: Optional[CollectionSort] = None,
+    ) -> Optional[TDocument]:
+        if sort:
+            matching_documents = list((await self.find(filters=filters)).items)
+            sorted_documents = self._apply_field_sort(matching_documents, sort)
+            return sorted_documents[0] if sorted_documents else None
+
         clause, params = _build_where_clause(filters, self.INDEXED_FIELDS)
         sql = f"SELECT DATA FROM {self._table} {clause} LIMIT 1"
         row = await self._database._execute(sql, params, fetch="one")
@@ -466,6 +492,12 @@ class SnowflakeDocumentCollection(DocumentCollection[TDocument]):
             return None
 
         return cast(TDocument, self._row_to_document(row))
+
+    async def ensure_indexes(
+        self,
+        indexes: Sequence[CollectionIndex],
+    ) -> None:
+        return None
 
     async def insert_one(self, document: TDocument) -> InsertResult:
         ensure_is_total(document, self._schema)

--- a/src/parlant/adapters/db/transient.py
+++ b/src/parlant/adapters/db/transient.py
@@ -26,6 +26,8 @@ from parlant.core.persistence.common import (
     ensure_is_total,
 )
 from parlant.core.persistence.document_database import (
+    CollectionIndex,
+    CollectionSort,
     BaseDocument,
     DeleteResult,
     DocumentCollection,
@@ -174,6 +176,21 @@ class TransientDocumentCollection(DocumentCollection[TDocument]):
 
         return docs
 
+    def _apply_field_sort(
+        self,
+        documents: Sequence[TDocument],
+        sort: CollectionSort,
+    ) -> list[TDocument]:
+        docs = list(documents)
+
+        for field_name, direction in reversed(sort):
+            docs.sort(
+                key=lambda d: d.get(field_name),
+                reverse=direction == SortDirection.DESC,
+            )
+
+        return docs
+
     def _apply_cursor_filter(
         self,
         documents: list[TDocument],
@@ -216,11 +233,23 @@ class TransientDocumentCollection(DocumentCollection[TDocument]):
     async def find_one(
         self,
         filters: Where,
+        sort: Optional[CollectionSort] = None,
     ) -> Optional[TDocument]:
-        for doc in self._documents:
-            if matches_filters(filters, doc):
-                return doc
+        matching_documents = [doc for doc in self._documents if matches_filters(filters, doc)]
 
+        if sort:
+            matching_documents = self._apply_field_sort(matching_documents, sort)
+
+        for doc in matching_documents:
+            return doc
+
+        return None
+
+    @override
+    async def ensure_indexes(
+        self,
+        indexes: Sequence[CollectionIndex],
+    ) -> None:
         return None
 
     @override

--- a/src/parlant/adapters/db/transient.py
+++ b/src/parlant/adapters/db/transient.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from __future__ import annotations
-from typing import Awaitable, Callable, Optional, Sequence, cast
+from typing import Any, Awaitable, Callable, Optional, Sequence, cast
 from typing_extensions import override
 from typing_extensions import get_type_hints
 
@@ -185,7 +185,7 @@ class TransientDocumentCollection(DocumentCollection[TDocument]):
 
         for field_name, direction in reversed(sort):
             docs.sort(
-                key=lambda d: d.get(field_name),
+                key=lambda d: cast(Any, d.get(field_name)),
                 reverse=direction == SortDirection.DESC,
             )
 

--- a/src/parlant/core/customers.py
+++ b/src/parlant/core/customers.py
@@ -25,8 +25,9 @@ from parlant.core.common import ItemNotFoundError, UniqueId, Version, IdGenerato
 from parlant.core.persistence.common import Cursor, ObjectId, SortDirection, Where
 from parlant.core.persistence.document_database import (
     BaseDocument,
-    DocumentDatabase,
+    CollectionIndex,
     DocumentCollection,
+    DocumentDatabase,
 )
 
 CustomerId = NewType("CustomerId", str)
@@ -205,6 +206,21 @@ class CustomerDocumentStore(CustomerStore):
                 name="customer_tag_associations",
                 schema=_CustomerTagAssociationDocument,
                 document_loader=self._association_document_loader,
+            )
+            await self._customers_collection.ensure_indexes(
+                [CollectionIndex(fields=(("id", SortDirection.ASC),))]
+            )
+            await self._tag_association_collection.ensure_indexes(
+                [
+                    CollectionIndex(fields=(("customer_id", SortDirection.ASC),)),
+                    CollectionIndex(fields=(("tag_id", SortDirection.ASC),)),
+                    CollectionIndex(
+                        fields=(
+                            ("customer_id", SortDirection.ASC),
+                            ("tag_id", SortDirection.ASC),
+                        )
+                    ),
+                ]
             )
 
         return self

--- a/src/parlant/core/persistence/document_database.py
+++ b/src/parlant/core/persistence/document_database.py
@@ -96,6 +96,15 @@ class DeleteResult(Generic[TDocument]):
     deleted_document: Optional[TDocument]
 
 
+CollectionSort = Sequence[tuple[str, SortDirection]]
+
+
+@dataclass(frozen=True)
+class CollectionIndex:
+    fields: CollectionSort
+    unique: bool = False
+
+
 async def identity_loader(doc: BaseDocument) -> BaseDocument:
     return doc
 
@@ -172,8 +181,17 @@ class DocumentCollection(ABC, Generic[TDocument]):
     async def find_one(
         self,
         filters: Where,
+        sort: Optional[CollectionSort] = None,
     ) -> Optional[TDocument]:
         """Returns the first document that matches the query criteria."""
+        ...
+
+    @abstractmethod
+    async def ensure_indexes(
+        self,
+        indexes: Sequence[CollectionIndex],
+    ) -> None:
+        """Ensures the requested indexes exist for the collection."""
         ...
 
     @abstractmethod

--- a/src/parlant/core/sessions.py
+++ b/src/parlant/core/sessions.py
@@ -918,6 +918,12 @@ class SessionDocumentStore(SessionStore):
                     CollectionIndex(fields=(("id", SortDirection.ASC),)),
                     CollectionIndex(
                         fields=(
+                            ("creation_utc", SortDirection.ASC),
+                            ("id", SortDirection.ASC),
+                        )
+                    ),
+                    CollectionIndex(
+                        fields=(
                             ("agent_id", SortDirection.ASC),
                             ("creation_utc", SortDirection.ASC),
                             ("id", SortDirection.ASC),

--- a/src/parlant/core/sessions.py
+++ b/src/parlant/core/sessions.py
@@ -920,14 +920,14 @@ class SessionDocumentStore(SessionStore):
                         fields=(
                             ("agent_id", SortDirection.ASC),
                             ("creation_utc", SortDirection.ASC),
-                            ("_id", SortDirection.ASC),
+                            ("id", SortDirection.ASC),
                         )
                     ),
                     CollectionIndex(
                         fields=(
                             ("customer_id", SortDirection.ASC),
                             ("creation_utc", SortDirection.ASC),
-                            ("_id", SortDirection.ASC),
+                            ("id", SortDirection.ASC),
                         )
                     ),
                 ]
@@ -1316,10 +1316,7 @@ class SessionDocumentStore(SessionStore):
             creation_utc = creation_utc or datetime.now(timezone.utc)
             latest_event = await self._event_collection.find_one(
                 filters={"session_id": {"$eq": session_id}},
-                sort=(
-                    ("offset", SortDirection.DESC),
-                    ("id", SortDirection.DESC),
-                ),
+                sort=(("offset", SortDirection.DESC),),
             )
             offset = latest_event["offset"] + 1 if latest_event else 0
 

--- a/src/parlant/core/sessions.py
+++ b/src/parlant/core/sessions.py
@@ -56,6 +56,7 @@ from parlant.core.persistence.common import (
 )
 from parlant.core.persistence.document_database import (
     BaseDocument,
+    CollectionIndex,
     DocumentDatabase,
     DocumentCollection,
 )
@@ -912,6 +913,43 @@ class SessionDocumentStore(SessionStore):
                 schema=_EventDocument,
                 document_loader=self._event_document_loader,
             )
+            await self._session_collection.ensure_indexes(
+                [
+                    CollectionIndex(fields=(("id", SortDirection.ASC),)),
+                    CollectionIndex(
+                        fields=(
+                            ("agent_id", SortDirection.ASC),
+                            ("creation_utc", SortDirection.ASC),
+                            ("_id", SortDirection.ASC),
+                        )
+                    ),
+                    CollectionIndex(
+                        fields=(
+                            ("customer_id", SortDirection.ASC),
+                            ("creation_utc", SortDirection.ASC),
+                            ("_id", SortDirection.ASC),
+                        )
+                    ),
+                ]
+            )
+            await self._event_collection.ensure_indexes(
+                [
+                    CollectionIndex(fields=(("id", SortDirection.ASC),)),
+                    CollectionIndex(
+                        fields=(
+                            ("session_id", SortDirection.ASC),
+                            ("offset", SortDirection.ASC),
+                        )
+                    ),
+                    CollectionIndex(
+                        fields=(
+                            ("session_id", SortDirection.ASC),
+                            ("deleted", SortDirection.ASC),
+                            ("offset", SortDirection.ASC),
+                        )
+                    ),
+                ]
+            )
 
         return self
 
@@ -1275,11 +1313,15 @@ class SessionDocumentStore(SessionStore):
             if not await self._session_collection.find_one(filters={"id": {"$eq": session_id}}):
                 raise ItemNotFoundError(item_id=UniqueId(session_id), message="Session not found")
 
-            session_events = await self.list_events(
-                session_id
-            )  # FIXME: we need a more efficient way to do this
             creation_utc = creation_utc or datetime.now(timezone.utc)
-            offset = len(list(session_events))
+            latest_event = await self._event_collection.find_one(
+                filters={"session_id": {"$eq": session_id}},
+                sort=(
+                    ("offset", SortDirection.DESC),
+                    ("id", SortDirection.DESC),
+                ),
+            )
+            offset = latest_event["offset"] + 1 if latest_event else 0
 
             event = Event(
                 id=EventId(generate_id()),

--- a/tests/adapters/db/test_mongodb.py
+++ b/tests/adapters/db/test_mongodb.py
@@ -1241,6 +1241,7 @@ async def test_that_session_store_creates_indexes_for_session_hot_paths(
 
             assert (("creation_utc", 1),) in session_index_keys
             assert (("id", 1),) in session_index_keys
+            assert (("creation_utc", 1), ("id", 1)) in session_index_keys
             assert (
                 ("agent_id", 1),
                 ("creation_utc", 1),

--- a/tests/adapters/db/test_mongodb.py
+++ b/tests/adapters/db/test_mongodb.py
@@ -975,6 +975,64 @@ async def test_that_cursor_pagination_works_with_descending_sort(
         assert third_page.next_cursor is None
 
 
+async def test_that_cursor_pagination_uses_document_id_as_tiebreaker(
+    container: Container,
+    test_mongo_client: AsyncMongoClient[Any],
+    test_database_name: str,
+) -> None:
+    await test_mongo_client.drop_database(test_database_name)
+
+    async with MongoDocumentDatabase(
+        test_mongo_client, test_database_name, container[Logger]
+    ) as dummy_db:
+        collection = await dummy_db.get_or_create_collection(
+            name="test_collection",
+            schema=MongoTestDocument,
+            document_loader=identity_loader_for(MongoTestDocument),
+        )
+
+        creation_utc = "2023-01-01T10:00:00Z"
+        docs = [
+            MongoTestDocument(
+                id=ObjectId("doc3"),
+                creation_utc=creation_utc,
+                version=Version.String("1.0.0"),
+                name="third",
+            ),
+            MongoTestDocument(
+                id=ObjectId("doc1"),
+                creation_utc=creation_utc,
+                version=Version.String("1.0.0"),
+                name="first",
+            ),
+            MongoTestDocument(
+                id=ObjectId("doc2"),
+                creation_utc=creation_utc,
+                version=Version.String("1.0.0"),
+                name="second",
+            ),
+        ]
+
+        for doc in docs:
+            await collection.insert_one(doc)
+
+        first_page = await collection.find({}, limit=1, sort_direction=SortDirection.ASC)
+
+        assert len(first_page.items) == 1
+        assert first_page.items[0]["id"] == ObjectId("doc1")
+        assert first_page.next_cursor == Cursor(creation_utc=creation_utc, id=ObjectId("doc1"))
+
+        second_page = await collection.find(
+            {},
+            limit=1,
+            cursor=first_page.next_cursor,
+            sort_direction=SortDirection.ASC,
+        )
+
+        assert len(second_page.items) == 1
+        assert second_page.items[0]["id"] == ObjectId("doc2")
+
+
 async def test_that_default_sort_direction_is_ascending(
     container: Container,
     test_mongo_client: AsyncMongoClient[Any],
@@ -1186,12 +1244,12 @@ async def test_that_session_store_creates_indexes_for_session_hot_paths(
             assert (
                 ("agent_id", 1),
                 ("creation_utc", 1),
-                ("_id", 1),
+                ("id", 1),
             ) in session_index_keys
             assert (
                 ("customer_id", 1),
                 ("creation_utc", 1),
-                ("_id", 1),
+                ("id", 1),
             ) in session_index_keys
 
             assert (("creation_utc", 1),) in event_index_keys

--- a/tests/adapters/db/test_mongodb.py
+++ b/tests/adapters/db/test_mongodb.py
@@ -22,7 +22,9 @@ from lagom import Container
 from pytest import fixture, raises
 
 from parlant.core.common import Version
-from parlant.adapters.db.mongo_db import MongoDocumentDatabase
+from parlant.adapters.db.mongo_db import MongoDocumentCollection, MongoDocumentDatabase
+from parlant.core.common import IdGenerator
+from parlant.core.customers import CustomerDocumentStore
 from parlant.core.persistence.common import Cursor, MigrationRequired, ObjectId, SortDirection
 from parlant.core.persistence.document_database import (
     BaseDocument,
@@ -32,6 +34,7 @@ from parlant.core.persistence.document_database import (
     identity_loader_for,
 )
 from parlant.core.persistence.document_database_helper import DocumentStoreMigrationHelper
+from parlant.core.sessions import SessionDocumentStore
 from parlant.core.loggers import Logger
 
 
@@ -176,6 +179,17 @@ class DummyStore:
     async def delete_dummy(self, doc_id: str) -> bool:
         result = await self._collection.delete_one({"id": {"$eq": doc_id}})
         return result.acknowledged and result.deleted_count > 0
+
+
+async def index_keys(
+    collection: MongoDocumentCollection[Any],
+) -> set[tuple[tuple[str, int], ...]]:
+    indexes = await collection._collection.index_information()
+    return {
+        tuple(cast(list[tuple[str, int]], index_info.get("key", [])))
+        for index_name, index_info in indexes.items()
+        if index_name != "_id_"
+    }
 
 
 async def test_that_dummy_documents_can_be_created_and_persisted(
@@ -1145,3 +1159,78 @@ async def test_that_creation_utc_index_is_created_for_get_or_create_collections(
         assert creation_utc_index_found, (
             "creation_utc index should be created for get_or_create collections"
         )
+
+
+async def test_that_session_store_creates_indexes_for_session_hot_paths(
+    container: Container,
+    test_mongo_client: AsyncMongoClient[Any],
+    test_database_name: str,
+) -> None:
+    session_database_name = f"{test_database_name}_sessions"
+    await test_mongo_client.drop_database(session_database_name)
+
+    async with MongoDocumentDatabase(
+        test_mongo_client, session_database_name, container[Logger]
+    ) as document_database:
+        async with SessionDocumentStore(document_database) as session_store:
+            session_collection = cast(
+                MongoDocumentCollection[Any], session_store._session_collection
+            )
+            event_collection = cast(MongoDocumentCollection[Any], session_store._event_collection)
+
+            session_index_keys = await index_keys(session_collection)
+            event_index_keys = await index_keys(event_collection)
+
+            assert (("creation_utc", 1),) in session_index_keys
+            assert (("id", 1),) in session_index_keys
+            assert (
+                ("agent_id", 1),
+                ("creation_utc", 1),
+                ("_id", 1),
+            ) in session_index_keys
+            assert (
+                ("customer_id", 1),
+                ("creation_utc", 1),
+                ("_id", 1),
+            ) in session_index_keys
+
+            assert (("creation_utc", 1),) in event_index_keys
+            assert (("id", 1),) in event_index_keys
+            assert (("session_id", 1), ("offset", 1)) in event_index_keys
+            assert (("session_id", 1), ("deleted", 1), ("offset", 1)) in event_index_keys
+
+
+async def test_that_customer_store_creates_indexes_for_customer_and_tag_lookups(
+    container: Container,
+    test_mongo_client: AsyncMongoClient[Any],
+    test_database_name: str,
+) -> None:
+    customer_database_name = f"{test_database_name}_customers"
+    await test_mongo_client.drop_database(customer_database_name)
+
+    async with MongoDocumentDatabase(
+        test_mongo_client, customer_database_name, container[Logger]
+    ) as document_database:
+        async with CustomerDocumentStore(
+            container[IdGenerator], document_database
+        ) as customer_store:
+            customer_collection = cast(
+                MongoDocumentCollection[Any], customer_store._customers_collection
+            )
+            tag_association_collection = cast(
+                MongoDocumentCollection[Any], customer_store._tag_association_collection
+            )
+
+            customer_index_keys = await index_keys(customer_collection)
+            tag_association_index_keys = await index_keys(tag_association_collection)
+
+            assert (("creation_utc", 1),) in customer_index_keys
+            assert (("id", 1),) in customer_index_keys
+
+            assert (("creation_utc", 1),) in tag_association_index_keys
+            assert (("customer_id", 1),) in tag_association_index_keys
+            assert (("tag_id", 1),) in tag_association_index_keys
+            assert (
+                ("customer_id", 1),
+                ("tag_id", 1),
+            ) in tag_association_index_keys

--- a/tests/api/test_sessions.py
+++ b/tests/api/test_sessions.py
@@ -988,6 +988,44 @@ async def test_that_deleted_events_no_longer_show_up_in_the_listing(
     assert all(e["offset"] > event_to_delete["offset"] for e in remaining_events) is False
 
 
+async def test_that_new_events_keep_increasing_offsets_after_deleted_events(
+    container: Container,
+    session_id: SessionId,
+) -> None:
+    session_store = container[SessionStore]
+
+    first_event = await session_store.create_event(
+        session_id=session_id,
+        source=EventSource.CUSTOMER,
+        kind=EventKind.CUSTOM,
+        trace_id=generate_id(),
+        data={},
+    )
+    second_event = await session_store.create_event(
+        session_id=session_id,
+        source=EventSource.CUSTOMER,
+        kind=EventKind.CUSTOM,
+        trace_id=generate_id(),
+        data={},
+    )
+
+    await session_store.delete_event(event_id=second_event.id)
+
+    third_event = await session_store.create_event(
+        session_id=session_id,
+        source=EventSource.CUSTOMER,
+        kind=EventKind.CUSTOM,
+        trace_id=generate_id(),
+        data={},
+    )
+    visible_events = await session_store.list_events(session_id=session_id)
+
+    assert first_event.offset == 0
+    assert second_event.offset == 1
+    assert third_event.offset == 2
+    assert [event.offset for event in visible_events] == [0, 2]
+
+
 async def test_that_delete_events_raises_if_not_first_of_trace_id(
     async_client: httpx.AsyncClient,
     container: Container,


### PR DESCRIPTION
## Summary

This PR improves Parlant's session persistence hot paths in two ways:

1. `SessionDocumentStore.create_event()` no longer lists every visible event in a session just to compute the next offset.
2. Mongo-backed session and customer stores now register indexes for the query patterns they already rely on.

The event-offset change also fixes a correctness bug: deleted events were excluded from the offset calculation, so creating a new event after deleting the latest one could reuse an existing offset.

## Changes

- add a sorted `find_one()` capability to document collections so stores can fetch the latest matching document efficiently
- add collection-level `ensure_indexes()` support, with MongoDB creating the requested indexes and other document backends treating it as a no-op
- allocate new event offsets from the highest existing session offset, including deleted events
- register Mongo indexes for:
  - session lookup by `id`
  - session listings by `agent_id` / `customer_id` with `creation_utc` pagination
  - event lookup by `id`
  - per-session event scans by `session_id` and `offset`
  - customer lookup by `id`
  - customer tag association lookups by `customer_id` / `tag_id`
- add a regression test that verifies offsets keep increasing after deleted events
- add Mongo integration tests that assert the session and customer stores provision the expected indexes

## Tests

Ran locally:

- `ruff check src/parlant/core/persistence/document_database.py src/parlant/adapters/db/mongo_db.py src/parlant/adapters/db/transient.py src/parlant/adapters/db/json_file.py src/parlant/adapters/db/snowflake_db.py src/parlant/core/sessions.py src/parlant/core/customers.py tests/api/test_sessions.py tests/adapters/db/test_mongodb.py`
- `python -m py_compile src/parlant/core/persistence/document_database.py src/parlant/adapters/db/mongo_db.py src/parlant/adapters/db/transient.py src/parlant/adapters/db/json_file.py src/parlant/adapters/db/snowflake_db.py src/parlant/core/sessions.py src/parlant/core/customers.py tests/api/test_sessions.py tests/adapters/db/test_mongodb.py`
- `pytest tests/api/test_sessions.py -q -k "deleted_events_no_longer_show_up_in_the_listing or keep_increasing_offsets_after_deleted_events"`
- `pytest tests/adapters/db/test_json_file.py -q -k "dummy_documents_can_be_created or dummy_documents_can_be_read_by_id"`
- `pytest tests/adapters/db/test_mongodb.py -q -k "session_store_creates_indexes or customer_store_creates_indexes"`
