### PR TITLE
Retry empty OpenRouter embedding responses

### DIFF
--- a/src/parlant/adapters/nlp/openrouter_service.py
+++ b/src/parlant/adapters/nlp/openrouter_service.py
@@ -73,6 +73,10 @@ Recommended actions:
 """
 
 
+class OpenRouterEmptyEmbeddingResponseError(Exception):
+    """Raised when OpenRouter returns an embedding response with no vectors."""
+
+
 class OpenRouterEstimatingTokenizer(EstimatingTokenizer):
     def __init__(self, model_name: str) -> None:
         self.model_name = model_name
@@ -138,6 +142,7 @@ class OpenRouterSchematicGenerator(BaseSchematicGenerator[T]):
                     ConflictError,
                     RateLimitError,
                     APIResponseValidationError,
+                    OpenRouterEmptyEmbeddingResponseError,
                 ),
             ),
             retry(InternalServerError, max_exceptions=2, wait_times=(1.0, 5.0)),
@@ -429,6 +434,7 @@ class OpenRouterEmbedder(BaseEmbedder):
                     ConflictError,
                     RateLimitError,
                     APIResponseValidationError,
+                    OpenRouterEmptyEmbeddingResponseError,
                 ),
             ),
             retry(InternalServerError, max_exceptions=2, wait_times=(1.0, 5.0)),
@@ -447,6 +453,10 @@ class OpenRouterEmbedder(BaseEmbedder):
                 input=texts,
                 **filtered_hints,
             )
+        except ValueError as exc:
+            if "No embedding data received" in str(exc):
+                raise OpenRouterEmptyEmbeddingResponseError(str(exc)) from exc
+            raise
         except RateLimitError:
             self.logger.error(
                 f"\nRate limit exceeded for embedder model '{self.model_name}'.\n"
@@ -457,6 +467,9 @@ class OpenRouterEmbedder(BaseEmbedder):
                 f"  - Adding your own API key for higher limits\n"
             )
             raise
+
+        if not response.data:
+            raise OpenRouterEmptyEmbeddingResponseError("No embedding data received")
 
         vectors = [data_point.embedding for data_point in response.data]
 

--- a/tests/adapters/nlp/test_openrouter_service.py
+++ b/tests/adapters/nlp/test_openrouter_service.py
@@ -25,6 +25,7 @@ from openai.types.completion_usage import CompletionUsage
 from parlant.adapters.nlp.openrouter_service import (  # type: ignore[reportMissingImports]
     OpenRouterService,
     OpenRouterSchematicGenerator,
+    OpenRouterEmbedder,
     OpenRouterGPT4O,
     OpenRouterGPT4OMini,
     OpenRouterClaude35Sonnet,
@@ -413,6 +414,93 @@ def test_that_openrouter_service_sets_default_max_tokens_for_llama(container: Co
         )
         generator = asyncio.run(service.get_schematic_generator(SchemaData))
         assert generator.max_tokens == 8192
+
+
+@patch("parlant.core.nlp.policies.asyncio.sleep", new_callable=AsyncMock)
+@patch("parlant.adapters.nlp.openrouter_service.AsyncClient")
+async def test_that_openrouter_embedder_retries_empty_embedding_value_error(
+    mock_client_class: Mock,
+    mock_sleep: AsyncMock,
+    container: Container,
+) -> None:
+    mock_client = AsyncMock()
+    mock_client.embeddings.create = AsyncMock(
+        side_effect=[
+            ValueError("No embedding data received"),
+            Mock(data=[Mock(embedding=[0.1, 0.2, 0.3])]),
+        ]
+    )
+    mock_client_class.return_value = mock_client
+
+    embedder = OpenRouterEmbedder(
+        model_name="openai/text-embedding-3-small",
+        logger=container[Logger],
+        tracer=container[Tracer],
+        meter=container[Meter],
+    )
+
+    result = await embedder.do_embed(["hello"])
+
+    assert result.vectors == [[0.1, 0.2, 0.3]]
+    assert mock_client.embeddings.create.await_count == 2
+    mock_sleep.assert_awaited_once()
+
+
+@patch("parlant.core.nlp.policies.asyncio.sleep", new_callable=AsyncMock)
+@patch("parlant.adapters.nlp.openrouter_service.AsyncClient")
+async def test_that_openrouter_embedder_retries_empty_embedding_response_data(
+    mock_client_class: Mock,
+    mock_sleep: AsyncMock,
+    container: Container,
+) -> None:
+    mock_client = AsyncMock()
+    mock_client.embeddings.create = AsyncMock(
+        side_effect=[
+            Mock(data=[]),
+            Mock(data=[Mock(embedding=[0.4, 0.5])]),
+        ]
+    )
+    mock_client_class.return_value = mock_client
+
+    embedder = OpenRouterEmbedder(
+        model_name="openai/text-embedding-3-small",
+        logger=container[Logger],
+        tracer=container[Tracer],
+        meter=container[Meter],
+    )
+
+    result = await embedder.do_embed(["hello"])
+
+    assert result.vectors == [[0.4, 0.5]]
+    assert mock_client.embeddings.create.await_count == 2
+    mock_sleep.assert_awaited_once()
+
+
+@patch("parlant.core.nlp.policies.asyncio.sleep", new_callable=AsyncMock)
+@patch("parlant.adapters.nlp.openrouter_service.AsyncClient")
+async def test_that_openrouter_embedder_does_not_retry_unrelated_value_error(
+    mock_client_class: Mock,
+    mock_sleep: AsyncMock,
+    container: Container,
+) -> None:
+    mock_client = AsyncMock()
+    mock_client.embeddings.create = AsyncMock(
+        side_effect=ValueError("Embedding payload is malformed")
+    )
+    mock_client_class.return_value = mock_client
+
+    embedder = OpenRouterEmbedder(
+        model_name="openai/text-embedding-3-small",
+        logger=container[Logger],
+        tracer=container[Tracer],
+        meter=container[Meter],
+    )
+
+    with pytest.raises(ValueError, match="Embedding payload is malformed"):
+        await embedder.do_embed(["hello"])
+
+    assert mock_client.embeddings.create.await_count == 1
+    mock_sleep.assert_not_awaited()
 
 
 @pytest.mark.skip(


### PR DESCRIPTION
## Summary

Fixes #739.

`OpenRouterEmbedder.do_embed()` retried transport and validation failures, but it did not retry the plain `ValueError("No embedding data received")` raised by the OpenAI SDK when an embedding response came back with an empty `data` array. That caused transient upstream failures to bubble out of embedding preparation and abort the iteration.

## Changes

- add a dedicated `OpenRouterEmptyEmbeddingResponseError` in [openrouter_service.py](/Users/santangelo/projects/parlant/src/parlant/adapters/nlp/openrouter_service.py)
- include that adapter error in the existing retry policy for `OpenRouterEmbedder.do_embed()`
- convert the SDK's exact `ValueError("No embedding data received")` into the retryable adapter error
- also treat a successful response with an empty `response.data` array as the same retryable condition
- keep unrelated `ValueError`s non-retryable, so this stays narrow to the issue report

## Tests

Added regression coverage in [test_openrouter_service.py](/Users/santangelo/projects/parlant/tests/adapters/nlp/test_openrouter_service.py) for:

- retrying when the SDK raises `ValueError("No embedding data received")`
- retrying when the response object has `data=[]`
- not retrying unrelated `ValueError`s

Validated locally with:

- `ruff check src/parlant/adapters/nlp/openrouter_service.py tests/adapters/nlp/test_openrouter_service.py`
- `python -m py_compile src/parlant/adapters/nlp/openrouter_service.py tests/adapters/nlp/test_openrouter_service.py`
- `pytest tests/adapters/nlp/test_openrouter_service.py -q`
