### PR TITLE
Fix canned response vector document IDs

### DIFF
--- a/src/parlant/core/canned_responses.py
+++ b/src/parlant/core/canned_responses.py
@@ -535,15 +535,24 @@ class CannedResponseVectorStore(CannedResponseStore):
     def _list_canned_response_contents(self, canned_response: CannedResponse) -> list[str]:
         return [canned_response.value, *canned_response.signals]
 
+    def _build_vector_document_id(
+        self,
+        canned_response: CannedResponse,
+        index: int,
+        content: str,
+    ) -> ObjectId:
+        checksum = md5_checksum(f"{canned_response.id}:{index}:{content}")
+        return ObjectId(self._id_generator.generate(checksum))
+
     async def _insert_canned_response(
         self,
         canned_response: CannedResponse,
     ) -> CannedResponseDocument:
         insertion_tasks = []
 
-        for content in self._list_canned_response_contents(canned_response):
+        for index, content in enumerate(self._list_canned_response_contents(canned_response)):
             vec_doc = CannedResponseVectorDocument(
-                id=ObjectId(canned_response.id),
+                id=self._build_vector_document_id(canned_response, index, content),
                 canned_response_id=ObjectId(canned_response.id),
                 version=self.VERSION.to_string(),
                 content=content,

--- a/tests/core/stable/test_canned_response_vector_store.py
+++ b/tests/core/stable/test_canned_response_vector_store.py
@@ -1,14 +1,42 @@
-from typing import cast
+# Copyright 2026 Emcie Co Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
-import pytest
+from collections.abc import Mapping
+from typing import Any, cast
+
 from lagom import Container
+import pytest
 
 from parlant.core.canned_responses import (
     CannedResponseStore,
-    CannedResponseVectorDocument,
     CannedResponseVectorStore,
 )
-from parlant.core.persistence.vector_database import InsertResult
+from parlant.core.nlp.embedding import EmbeddingResult
+
+
+def _stub_embedder(store: CannedResponseVectorStore) -> None:
+    dimensions = store._canreps_vector_collection._embedder.dimensions  # type: ignore[attr-defined]
+
+    async def embed(
+        texts: list[str],
+        hints: Mapping[str, Any] = {},
+    ) -> EmbeddingResult:
+        return EmbeddingResult(
+            vectors=[[float((len(text) + i) % 13) for i in range(dimensions)] for text in texts]
+        )
+
+    store._canreps_vector_collection._embedder.embed = embed  # type: ignore[attr-defined, method-assign]
 
 
 @pytest.mark.asyncio
@@ -16,18 +44,51 @@ async def test_that_canned_response_vector_documents_use_unique_ids_for_each_con
     container: Container,
 ) -> None:
     store = cast(CannedResponseVectorStore, container[CannedResponseStore])
-    inserted_documents: list[CannedResponseVectorDocument] = []
+    _stub_embedder(store)
 
-    async def capture_insert(document: CannedResponseVectorDocument) -> InsertResult:
-        inserted_documents.append(document)
-        return InsertResult(acknowledged=True)
-
-    store._canreps_vector_collection.insert_one = capture_insert  # type: ignore[method-assign]
-
-    await store.create_canned_response(
+    canrep = await store.create_canned_response(
         value="Payment failed.",
         signals=["card declined", "card declined", "Payment failed."],
     )
 
-    assert len(inserted_documents) == 4
-    assert len({document["id"] for document in inserted_documents}) == 4
+    vector_docs = await store._canreps_vector_collection.find(  # type: ignore[attr-defined]
+        filters={"canned_response_id": {"$eq": canrep.id}}
+    )
+
+    assert len(vector_docs) == 4
+    assert len({doc["id"] for doc in vector_docs}) == 4
+
+
+@pytest.mark.asyncio
+async def test_that_updating_a_canned_response_replaces_its_vector_documents(
+    container: Container,
+) -> None:
+    store = cast(CannedResponseVectorStore, container[CannedResponseStore])
+    _stub_embedder(store)
+
+    canrep = await store.create_canned_response(
+        value="Payment failed.",
+        signals=["card declined", "billing issue"],
+    )
+
+    original_vector_docs = await store._canreps_vector_collection.find(  # type: ignore[attr-defined]
+        filters={"canned_response_id": {"$eq": canrep.id}}
+    )
+    assert {doc["content"] for doc in original_vector_docs} == {
+        "Payment failed.",
+        "card declined",
+        "billing issue",
+    }
+
+    await store.update_canned_response(
+        canrep.id,
+        {"value": "Transaction declined.", "signals": ["insufficient funds"]},
+    )
+
+    updated_vector_docs = await store._canreps_vector_collection.find(  # type: ignore[attr-defined]
+        filters={"canned_response_id": {"$eq": canrep.id}}
+    )
+    assert {doc["content"] for doc in updated_vector_docs} == {
+        "Transaction declined.",
+        "insufficient funds",
+    }

--- a/tests/core/stable/test_canned_response_vector_store.py
+++ b/tests/core/stable/test_canned_response_vector_store.py
@@ -1,0 +1,33 @@
+from typing import cast
+
+import pytest
+from lagom import Container
+
+from parlant.core.canned_responses import (
+    CannedResponseStore,
+    CannedResponseVectorDocument,
+    CannedResponseVectorStore,
+)
+from parlant.core.persistence.vector_database import InsertResult
+
+
+@pytest.mark.asyncio
+async def test_that_canned_response_vector_documents_use_unique_ids_for_each_content(
+    container: Container,
+) -> None:
+    store = cast(CannedResponseVectorStore, container[CannedResponseStore])
+    inserted_documents: list[CannedResponseVectorDocument] = []
+
+    async def capture_insert(document: CannedResponseVectorDocument) -> InsertResult:
+        inserted_documents.append(document)
+        return InsertResult(acknowledged=True)
+
+    store._canreps_vector_collection.insert_one = capture_insert  # type: ignore[method-assign]
+
+    await store.create_canned_response(
+        value="Payment failed.",
+        signals=["card declined", "card declined", "Payment failed."],
+    )
+
+    assert len(inserted_documents) == 4
+    assert len({document["id"] for document in inserted_documents}) == 4


### PR DESCRIPTION
## What changed
- give each canned response vector document its own ID
- keep the existing multi-vector behavior for `value` plus `signals`
- add a regression test that covers repeated signal text and value overlap

## Why
Persistent vector backends key documents by ID. Reusing the canned response ID for every vector means later inserts can stomp earlier ones, which breaks the whole multi-vector setup.

## Tests
- `PYTHONPATH=src python -m pytest tests/core/stable/test_canned_response_vector_store.py -q`
- tried `PYTHONPATH=src python -m pytest tests/api/test_canned_responses.py -x -vv`
- tried `PYTHONPATH=src python -m pytest tests/sdk/test_canned_responses.py -x -vv`

The API and SDK canned-response suites are blocked locally by the default test embedder setup requiring `EMCIE_API_KEY`.
