### PR TITLE
Correct transient cosine distance mapping

### DIFF
--- a/src/parlant/adapters/vector_db/transient.py
+++ b/src/parlant/adapters/vector_db/transient.py
@@ -356,6 +356,10 @@ class TransientVectorCollection(Generic[TDocument], BaseVectorCollection[TDocume
             deleted_document=None,
         )
 
+    @staticmethod
+    def _distance_from_similarity(similarity: float) -> float:
+        return 1 - similarity
+
     async def do_find_similar_documents(
         self,
         filters: Where,
@@ -395,7 +399,7 @@ class TransientVectorCollection(Generic[TDocument], BaseVectorCollection[TDocume
         results = [
             SimilarDocumentResult(
                 document=cast(TDocument, d),
-                distance=1 - abs(sim),
+                distance=self._distance_from_similarity(sim),
             )
             for d, sim in docs_and_similarities
         ]

--- a/tests/adapters/vector_db/test_transient.py
+++ b/tests/adapters/vector_db/test_transient.py
@@ -1,0 +1,7 @@
+from parlant.adapters.vector_db.transient import TransientVectorCollection
+
+
+def test_that_negative_cosine_similarity_is_not_treated_as_close_distance() -> None:
+    assert TransientVectorCollection._distance_from_similarity(1.0) == 0.0
+    assert TransientVectorCollection._distance_from_similarity(0.0) == 1.0
+    assert TransientVectorCollection._distance_from_similarity(-1.0) == 2.0


### PR DESCRIPTION
## What changed
- change the transient backend's distance conversion from `1 - abs(similarity)` to `1 - similarity`
- add a focused regression test for the distance mapping

## Why
`nano-vectordb` returns cosine similarity in the usual `[-1, 1]` range. Using `abs()` makes a strong negative match look just as close as a strong positive one, which flips the ranking logic.

## Tests
- `PYTHONPATH=src python -m pytest tests/adapters/vector_db/test_transient.py -q`
