### PR TITLE
Keep capability vectors in sync

### DIFF
--- a/src/parlant/core/capabilities.py
+++ b/src/parlant/core/capabilities.py
@@ -308,6 +308,18 @@ class CapabilityVectorStore(CapabilityStore):
 
         return doc
 
+    async def _delete_capability_vectors(self, capability_id: CapabilityId) -> None:
+        vector_docs = await self._vector_collection.find(
+            filters={"capability_id": {"$eq": capability_id}}
+        )
+
+        await async_utils.safe_gather(
+            *[
+                self._vector_collection.delete_one(filters={"id": {"$eq": doc["id"]}})
+                for doc in vector_docs
+            ]
+        )
+
     @override
     async def create_capability(
         self,
@@ -366,6 +378,7 @@ class CapabilityVectorStore(CapabilityStore):
 
             for doc in all_docs:
                 await self._collection.delete_one(filters={"id": {"$eq": doc["id"]}})
+            await self._delete_capability_vectors(capability_id)
 
             title = params.get("title", doc["title"])
             description = params.get("description", doc["description"])
@@ -461,6 +474,7 @@ class CapabilityVectorStore(CapabilityStore):
 
             for doc in docs:
                 await self._collection.delete_one(filters={"id": {"$eq": doc["id"]}})
+            await self._delete_capability_vectors(capability_id)
 
             for tag_assoc in tag_associations:
                 await self._tag_association_collection.delete_one(

--- a/tests/core/stable/test_capability_vector_store.py
+++ b/tests/core/stable/test_capability_vector_store.py
@@ -1,0 +1,86 @@
+from collections.abc import Mapping
+from typing import Any
+
+from lagom import Container
+import pytest
+
+from parlant.core.capabilities import CapabilityStore
+from parlant.core.nlp.embedding import EmbeddingResult
+
+
+def _stub_embedder(store: CapabilityStore) -> None:
+    dimensions = store._vector_collection._embedder.dimensions  # type: ignore[attr-defined]
+
+    async def embed(
+        texts: list[str],
+        hints: Mapping[str, Any] = {},
+    ) -> EmbeddingResult:
+        return EmbeddingResult(
+            vectors=[
+                [float((len(text) + i) % 13) for i in range(dimensions)]
+                for text in texts
+            ]
+        )
+
+    store._vector_collection._embedder.embed = embed  # type: ignore[attr-defined, method-assign]
+
+
+@pytest.mark.asyncio
+async def test_that_updating_a_capability_replaces_its_vector_documents(
+    container: Container,
+) -> None:
+    store = container[CapabilityStore]
+    _stub_embedder(store)
+
+    capability = await store.create_capability(
+        title="Phone replacement",
+        description="Provide a loaner phone.",
+        signals=["broken phone", "replacement device"],
+    )
+
+    original_vector_docs = await store._vector_collection.find(  # type: ignore[attr-defined]
+        filters={"capability_id": {"$eq": capability.id}}
+    )
+    assert {doc["content"] for doc in original_vector_docs} == {
+        "Phone replacement: Provide a loaner phone.",
+        "broken phone",
+        "replacement device",
+    }
+
+    await store.update_capability(
+        capability.id,
+        {
+            "title": "Tablet replacement",
+            "description": "Provide a loaner tablet.",
+            "signals": ["broken tablet"],
+        },
+    )
+
+    updated_vector_docs = await store._vector_collection.find(  # type: ignore[attr-defined]
+        filters={"capability_id": {"$eq": capability.id}}
+    )
+    assert {doc["content"] for doc in updated_vector_docs} == {
+        "Tablet replacement: Provide a loaner tablet.",
+        "broken tablet",
+    }
+
+
+@pytest.mark.asyncio
+async def test_that_deleting_a_capability_removes_its_vector_documents(
+    container: Container,
+) -> None:
+    store = container[CapabilityStore]
+    _stub_embedder(store)
+
+    capability = await store.create_capability(
+        title="FAQ",
+        description="Answer common questions.",
+        signals=["faq"],
+    )
+
+    await store.delete_capability(capability.id)
+
+    vector_docs = await store._vector_collection.find(  # type: ignore[attr-defined]
+        filters={"capability_id": {"$eq": capability.id}}
+    )
+    assert vector_docs == []


### PR DESCRIPTION
## What changed
- remove old vector docs before re-inserting capability vectors on update
- remove capability vector docs on delete too
- add regression coverage around update and delete behavior

## Why
Without the cleanup, capability vectors can stick around after updates or deletes and keep showing up in retrieval.

## Tests
- `PYTHONPATH=src python -m pytest tests/core/stable/test_capability_vector_store.py -q`

I kept the tests self-contained with a tiny local embedder stub so they don't depend on external credentials.
