### PR TITLE
Fix MCP service teardown when replacing services

### DIFF
--- a/src/parlant/core/services/tools/service_registry.py
+++ b/src/parlant/core/services/tools/service_registry.py
@@ -332,12 +332,6 @@ class ServiceDocumentRegistry(ServiceRegistry):
 
             self._running_services[name] = service
 
-        await self._exit_stack.enter_async_context(
-            self._cast_to_specific_tool_service_class(service)
-        )
-
-        self._running_services[name] = service
-
         if not transient:
             await self._tool_services_collection.update_one(
                 filters={"name": {"$eq": name}},

--- a/tests/core/stable/engines/alpha/test_mcp.py
+++ b/tests/core/stable/engines/alpha/test_mcp.py
@@ -214,3 +214,28 @@ async def test_that_reading_an_existing_mcp_service_returns_its_tools_and_can_ca
             "my_async_tool", ToolContext("", "", ""), {"message": "Hello"}
         )
         assert str(result.data) == "Echo: Hello"
+
+
+async def test_that_updating_an_mcp_service_closes_the_previous_client_connection(
+    container: Container,
+) -> None:
+    service_registry = container[ServiceRegistry]
+
+    async with MCPToolServer([greet_me_like_pirate], port=get_random_port()) as first_server:
+        first_service = await service_registry.update_tool_service(
+            name="my_mcp_service",
+            kind="mcp",
+            url=f"{SERVER_BASE_URL}:{first_server.get_port()}",
+        )
+
+        assert first_service._client.is_connected()
+
+        async with MCPToolServer([tool_with_date_and_float], port=get_random_port()) as second_server:
+            second_service = await service_registry.update_tool_service(
+                name="my_mcp_service",
+                kind="mcp",
+                url=f"{SERVER_BASE_URL}:{second_server.get_port()}",
+            )
+
+            assert not first_service._client.is_connected()
+            assert second_service._client.is_connected()


### PR DESCRIPTION
A small one, but it fixes a real lifecycle bug in the MCP path.

What changed:
- remove the duplicate `enter_async_context()` call in `ServiceDocumentRegistry.update_tool_service()`
- add a regression test that proves the previous MCP client is actually disconnected after a service update

Why this matters:
The registry was entering remote services twice and only manually exiting them once on update/delete. For MCP clients that means the old connection could stay half-alive instead of being fully torn down, which makes recovery and replacement a lot messier than it should be.

Testing:
- `PYTHONPATH=src /Users/santangelo/projects/parlant/.venv/bin/pytest tests/core/stable/engines/alpha/test_mcp.py -k "updating_an_mcp_service_closes_the_previous_client_connection or reading_an_existing_mcp_service_returns_its_tools_and_can_call_them"`