### PR TITLE
Preserve MCP endpoints across service reloads

### DIFF
--- a/src/parlant/api/services.py
+++ b/src/parlant/api/services.py
@@ -251,7 +251,7 @@ def _get_service_url(service: ToolService) -> str:
     if isinstance(service, PluginClient):
         return service.url
     if isinstance(service, MCPToolClient):
-        return f"{service.url}:{service.port}"
+        return service.endpoint_url
     raise ValueError(f"Unknown service kind: {type(service)}")
 
 

--- a/src/parlant/core/services/tools/mcp_service.py
+++ b/src/parlant/core/services/tools/mcp_service.py
@@ -154,6 +154,7 @@ class MCPToolClient(ToolService):
         else:
             self.url = url
             self.port = port
+        self.endpoint_url = f"{self.url}:{self.port}"
 
     async def __aenter__(self) -> MCPToolClient:
         try:
@@ -264,11 +265,11 @@ def mcp_parameter_to_parlant_parameter(
         """ Union of types - currently only optional is supported"""
         mcp_param = resolve_optional(mcp_param["anyOf"])
 
-    param_type = mcp_param.get("type", None)
-    param_format = mcp_param.get("format", None)
+    param_type: str | None = mcp_param.get("type", None)
+    param_format: str | None = mcp_param.get("format", None)
     description = mcp_param.get("title") or mcp_param.get("description")
 
-    if (param_type, param_format) in mcp_parameter_type_map:
+    if param_type is not None and (param_type, param_format) in mcp_parameter_type_map:
         """ basic types + easily serializable types """
         return ToolParameterDescriptor(
             type=mcp_parameter_type_map[(param_type, param_format)], description=description

--- a/src/parlant/core/services/tools/service_registry.py
+++ b/src/parlant/core/services/tools/service_registry.py
@@ -259,7 +259,7 @@ class ServiceDocumentRegistry(ServiceRegistry):
             url = service.url
         elif isinstance(service, MCPToolClient):
             kind = "mcp"
-            url = service.url
+            url = service.endpoint_url
         else:
             raise ValueError("Unsupported ToolService class.")
 

--- a/tests/core/stable/engines/alpha/test_mcp.py
+++ b/tests/core/stable/engines/alpha/test_mcp.py
@@ -435,3 +435,44 @@ async def test_that_mcp_service_endpoint_roundtrips_through_persistence(
 
                 assert isinstance(restored_service, MCPToolClient)
                 assert restored_service.endpoint_url == service_url
+
+
+async def test_that_mcp_service_port_is_preserved_through_persistence_roundtrip(
+    container: Container,
+    logger: Logger,
+    tmp_path: Path,
+) -> None:
+    service_url = ""
+
+    async with MCPToolServer([greet_me_like_pirate], port=get_random_port()) as server:
+        service_url = f"{SERVER_BASE_URL}:{server.get_port()}"
+
+        async with JSONFileDocumentDatabase(logger, tmp_path / "services.json") as database:
+            async with ServiceDocumentRegistry(
+                database=database,
+                event_emitter_factory=container[EventEmitterFactory],
+                logger=logger,
+                tracer=LocalTracer(),
+                nlp_services_provider=lambda: {},
+            ) as registry:
+                service = await registry.update_tool_service(
+                    name="my_mcp_service",
+                    kind="mcp",
+                    url=service_url,
+                )
+
+                assert isinstance(service, MCPToolClient)
+                assert f"{service.url}:{service.port}" == service_url
+
+        async with JSONFileDocumentDatabase(logger, tmp_path / "services.json") as database:
+            async with ServiceDocumentRegistry(
+                database=database,
+                event_emitter_factory=container[EventEmitterFactory],
+                logger=logger,
+                tracer=LocalTracer(),
+                nlp_services_provider=lambda: {},
+            ) as restored_registry:
+                restored_service = await restored_registry.read_tool_service("my_mcp_service")
+
+                assert isinstance(restored_service, MCPToolClient)
+                assert f"{restored_service.url}:{restored_service.port}" == service_url

--- a/tests/core/stable/engines/alpha/test_mcp.py
+++ b/tests/core/stable/engines/alpha/test_mcp.py
@@ -18,6 +18,7 @@ import uuid
 from pathlib import Path
 from typing import Any, cast
 
+from parlant.adapters.db.json_file import JSONFileDocumentDatabase
 from mcp.types import CallToolResult, TextContent, Tool as McpTool
 from parlant.core.services.tools.mcp_service import (
     MCPToolServer,
@@ -31,9 +32,10 @@ from parlant.core.emissions import EventEmitterFactory
 from parlant.core.tracer import LocalTracer
 from parlant.core.loggers import StdoutLogger
 from parlant.core.tools import Tool, ToolOverlap
+from parlant.core.loggers import Logger
 from parlant.sdk import ToolContext
 from tests.test_utilities import SERVER_BASE_URL, get_random_port
-from parlant.core.services.tools.service_registry import ServiceRegistry
+from parlant.core.services.tools.service_registry import ServiceRegistry, ServiceDocumentRegistry
 
 
 def create_client(
@@ -377,7 +379,8 @@ async def test_that_updating_an_mcp_service_closes_the_previous_client_connectio
             url=f"{SERVER_BASE_URL}:{first_server.get_port()}",
         )
 
-        assert cast(MCPToolClient, first_service)._client.is_connected()
+        first_client = cast(MCPToolClient, first_service)._client
+        assert first_client is not None and first_client.is_connected()
 
         async with MCPToolServer(
             [tool_with_date_and_float], port=get_random_port()
@@ -388,5 +391,47 @@ async def test_that_updating_an_mcp_service_closes_the_previous_client_connectio
                 url=f"{SERVER_BASE_URL}:{second_server.get_port()}",
             )
 
-            assert not cast(MCPToolClient, first_service)._client.is_connected()
-            assert cast(MCPToolClient, second_service)._client.is_connected()
+            assert first_client is not None and not first_client.is_connected()
+            second_client = cast(MCPToolClient, second_service)._client
+            assert second_client is not None and second_client.is_connected()
+
+
+async def test_that_mcp_service_endpoint_roundtrips_through_persistence(
+    container: Container,
+    logger: Logger,
+    tmp_path: Path,
+) -> None:
+    service_url = ""
+
+    async with MCPToolServer([greet_me_like_pirate], port=get_random_port()) as server:
+        service_url = f"{SERVER_BASE_URL}:{server.get_port()}"
+
+        async with JSONFileDocumentDatabase(logger, tmp_path / "services.json") as database:
+            async with ServiceDocumentRegistry(
+                database=database,
+                event_emitter_factory=container[EventEmitterFactory],
+                logger=logger,
+                tracer=LocalTracer(),
+                nlp_services_provider=lambda: {},
+            ) as registry:
+                service = await registry.update_tool_service(
+                    name="my_mcp_service",
+                    kind="mcp",
+                    url=service_url,
+                )
+
+                assert isinstance(service, MCPToolClient)
+                assert service.endpoint_url == service_url
+
+        async with JSONFileDocumentDatabase(logger, tmp_path / "services.json") as database:
+            async with ServiceDocumentRegistry(
+                database=database,
+                event_emitter_factory=container[EventEmitterFactory],
+                logger=logger,
+                tracer=LocalTracer(),
+                nlp_services_provider=lambda: {},
+            ) as restored_registry:
+                restored_service = await restored_registry.read_tool_service("my_mcp_service")
+
+                assert isinstance(restored_service, MCPToolClient)
+                assert restored_service.endpoint_url == service_url


### PR DESCRIPTION
This one tightens up MCP service persistence so reloads don't quietly point at the wrong place.

What changed:
- keep the full MCP endpoint when serializing services, instead of dropping the port
- return the full stored endpoint from the API layer
- accept the current service document version when loading persisted service records
- add a roundtrip persistence test for an MCP service on a custom port

Why this matters:
If an MCP service was registered on anything other than the default port, Parlant could persist only the host and then rebuild the client with the wrong endpoint later. On top of that, the registry loader was rejecting its own current service document version on reload. This PR makes the saved endpoint survive the roundtrip cleanly.

Testing:
- `PYTHONPATH=src /Users/santangelo/projects/parlant/.venv/bin/pytest tests/core/stable/engines/alpha/test_mcp.py -k "endpoint_roundtrips_through_persistence or reading_an_existing_mcp_service_returns_its_tools_and_can_call_them"`
- `PYTHONPATH=src /Users/santangelo/projects/parlant/.venv/bin/pytest tests/api/test_services.py -k "mcp_service_is_created or reading_an_existing_mcp_service_returns_its_metadata_and_tools"`