### PR TITLE
Reconnect MCP clients after stale sessions

### DIFF
--- a/src/parlant/core/services/tools/mcp_service.py
+++ b/src/parlant/core/services/tools/mcp_service.py
@@ -20,9 +20,10 @@ import json
 from mailbox import FormatError
 from mcp.types import Tool as McpTool
 from types import TracebackType
-from typing import Any, Sequence, Mapping, Optional, Literal, Callable, cast
+from typing import Any, Sequence, Mapping, Optional, Literal, Callable, Awaitable, cast
 from typing_extensions import override
 import asyncio
+import httpx
 
 from fastmcp import FastMCP
 from fastmcp.tools import Tool as FastMCPTool
@@ -46,6 +47,8 @@ from parlant.core.tracer import Tracer
 from parlant.core.emissions import EventEmitterFactory
 
 DEFAULT_MCP_PORT: int = 8181
+DEFAULT_MCP_CONNECTION_ATTEMPTS: int = 3
+DEFAULT_MCP_RETRY_DELAY_SECONDS: float = 0.5
 
 StringBasedTypes = [
     "string",
@@ -147,6 +150,8 @@ class MCPToolClient(ToolService):
         self._event_emitter_factory = event_emitter_factory
         self._logger = logger
         self._tracer = tracer
+        self._client: Client[StreamableHttpTransport] | None = None
+        self._client_lock = asyncio.Lock()
         if ":" in url[-6:]:
             parts = url.split(":")
             self.url = ":".join(parts[:-1])
@@ -157,14 +162,8 @@ class MCPToolClient(ToolService):
         self.endpoint_url = f"{self.url}:{self.port}"
 
     async def __aenter__(self) -> MCPToolClient:
-        try:
-            self._client = Client(StreamableHttpTransport(url=f"{self.url}:{self.port}/mcp"))
-            await asyncio.wait_for(self._client.__aenter__(), timeout=10.0)  # type: ignore
-            return self
-        except asyncio.TimeoutError:
-            raise ConnectionError(f"Connection to MCP service at {self.url}:{self.port} timed out")
-        except Exception as e:
-            raise Exception(f"Failed to connect to MCP service: {str(e)}")
+        await self._connect(force=True)
+        return self
 
     async def __aexit__(
         self,
@@ -172,20 +171,128 @@ class MCPToolClient(ToolService):
         exc_value: Optional[BaseException],
         traceback: Optional[TracebackType],
     ) -> bool:
-        if self._client:
-            try:
-                await self._client.__aexit__(exc_type, exc_value, traceback)  # type: ignore
-            except RuntimeError:
-                pass
+        await self._disconnect(exc_type, exc_value, traceback)
         return False
+
+    def _create_client(self) -> Client[StreamableHttpTransport]:
+        return Client(StreamableHttpTransport(url=f"{self.url}:{self.port}/mcp"))
+
+    def _is_connected(self) -> bool:
+        return self._client is not None and self._client.is_connected()
+
+    def _is_reconnectable_exception(self, exc: Exception) -> bool:
+        if isinstance(
+            exc,
+            (
+                asyncio.TimeoutError,
+                ConnectionError,
+                httpx.HTTPError,
+                httpx.TimeoutException,
+                httpx.TransportError,
+            ),
+        ):
+            return True
+
+        if isinstance(exc, RuntimeError):
+            message = str(exc).lower()
+            reconnectable_markers = (
+                "client is not connected",
+                "session was closed unexpectedly",
+                "closed unexpectedly",
+            )
+            return any(marker in message for marker in reconnectable_markers)
+
+        return False
+
+    async def _close_client(
+        self,
+        client: Client[StreamableHttpTransport],
+        exc_type: Optional[type[BaseException]] = None,
+        exc_value: Optional[BaseException] = None,
+        traceback: Optional[TracebackType] = None,
+    ) -> None:
+        try:
+            await client.__aexit__(exc_type, exc_value, traceback)  # type: ignore[arg-type]
+        except RuntimeError:
+            pass
+        except Exception as exc:
+            self._logger.warning(f"Failed to close MCP client cleanly: {exc}")
+
+    async def _disconnect(
+        self,
+        exc_type: Optional[type[BaseException]] = None,
+        exc_value: Optional[BaseException] = None,
+        traceback: Optional[TracebackType] = None,
+    ) -> None:
+        async with self._client_lock:
+            if self._client:
+                client = self._client
+                self._client = None
+                await self._close_client(client, exc_type, exc_value, traceback)
+
+    async def _connect(self, force: bool = False) -> Client[StreamableHttpTransport]:
+        async with self._client_lock:
+            if not force and self._is_connected():
+                assert self._client is not None
+                return self._client
+
+            if self._client:
+                stale_client = self._client
+                self._client = None
+                await self._close_client(stale_client)
+
+            last_error: Exception | None = None
+
+            for attempt in range(1, DEFAULT_MCP_CONNECTION_ATTEMPTS + 1):
+                client = self._create_client()
+
+                try:
+                    await asyncio.wait_for(client.__aenter__(), timeout=10.0)  # type: ignore[arg-type]
+                    self._client = client
+                    return client
+                except asyncio.TimeoutError:
+                    last_error = ConnectionError(
+                        f"Connection to MCP service at {self.url}:{self.port} timed out"
+                    )
+                except Exception as exc:
+                    last_error = Exception(f"Failed to connect to MCP service: {str(exc)}")
+                finally:
+                    if self._client is None:
+                        await self._close_client(client)
+
+                if attempt < DEFAULT_MCP_CONNECTION_ATTEMPTS:
+                    self._logger.warning(
+                        f"MCP connection attempt {attempt} failed for {self.url}:{self.port}; retrying"
+                    )
+                    await asyncio.sleep(DEFAULT_MCP_RETRY_DELAY_SECONDS * attempt)
+
+            assert last_error is not None
+            raise last_error
+
+    async def _with_reconnect(
+        self,
+        operation: Callable[[Client[StreamableHttpTransport]], Awaitable[Any]],
+        *,
+        retry_once: bool = True,
+    ) -> Any:
+        client = await self._connect()
+
+        try:
+            return await operation(client)
+        except Exception as exc:
+            if not retry_once or not self._is_reconnectable_exception(exc):
+                raise
+
+            self._logger.warning(
+                f"MCP client session dropped for {self.url}:{self.port}; reconnecting and retrying"
+            )
+            client = await self._connect(force=True)
+            return await operation(client)
 
     @override
     async def list_tools(self) -> Sequence[Tool]:
         try:
-            if not self._client:
-                raise ToolError("Client not initialized.")
-
-            tools = await self._client.list_tools()
+            tools = await self._with_reconnect(lambda client: client.list_tools())
             return [mcp_tool_to_parlant_tool(t) for t in tools]
         except Exception as e:
             raise ToolError(str(e))
@@ -193,7 +300,7 @@ class MCPToolClient(ToolService):
     @override
     async def read_tool(self, name: str) -> Tool:
         try:
-            tools = await self._client.list_tools()
+            tools = await self._with_reconnect(lambda client: client.list_tools())
             tool = next(t for t in tools if t.name == name)
             return mcp_tool_to_parlant_tool(tool)
         except Exception as e:
@@ -217,7 +324,8 @@ class MCPToolClient(ToolService):
         try:
             tool = await self.read_tool(name)
             arguments = prepare_tool_arguments(arguments, tool.parameters)
-            result = await self._client.call_tool(name, dict(arguments))
+            client = await self._connect()
+            result = await client.call_tool(name, dict(arguments))
             return ToolResult(data=mcp_result_to_tool_result_data(result))
         except Exception as e:
             raise ToolError(str(e))

--- a/src/parlant/core/services/tools/mcp_service.py
+++ b/src/parlant/core/services/tools/mcp_service.py
@@ -212,7 +212,7 @@ class MCPToolClient(ToolService):
         traceback: Optional[TracebackType] = None,
     ) -> None:
         try:
-            await client.__aexit__(exc_type, exc_value, traceback)  # type: ignore[arg-type]
+            await client.__aexit__(exc_type, exc_value, traceback)  # type: ignore[no-untyped-call]
         except RuntimeError:
             pass
         except Exception as exc:
@@ -247,7 +247,7 @@ class MCPToolClient(ToolService):
                 client = self._create_client()
 
                 try:
-                    await asyncio.wait_for(client.__aenter__(), timeout=10.0)  # type: ignore[arg-type]
+                    await asyncio.wait_for(client.__aenter__(), timeout=10.0)  # type: ignore[no-untyped-call]
                     self._client = client
                     return client
                 except asyncio.TimeoutError:

--- a/tests/core/stable/engines/alpha/test_mcp.py
+++ b/tests/core/stable/engines/alpha/test_mcp.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import asyncio
 from datetime import datetime, date, timedelta, timezone
 from enum import Enum
 import uuid
@@ -56,14 +57,19 @@ def create_client(
 class StubMCPClient:
     def __init__(self, result: CallToolResult) -> None:
         self._result = result
+        self.connected = True
 
     async def call_tool(self, name: str, arguments: dict[str, Any]) -> CallToolResult:
         return self._result
+
+    def is_connected(self) -> bool:
+        return self.connected
 
 
 def create_stubbed_tool_client(result: CallToolResult) -> MCPToolClient:
     client = object.__new__(MCPToolClient)
     client._client = StubMCPClient(result)  # type: ignore[assignment,attr-defined]
+    client._client_lock = asyncio.Lock()  # type: ignore[attr-defined]
 
     async def read_tool(name: str) -> Tool:
         return Tool(

--- a/tests/core/stable/services/tools/test_mcp_client.py
+++ b/tests/core/stable/services/tools/test_mcp_client.py
@@ -1,0 +1,82 @@
+import asyncio
+
+from lagom import Container
+
+from parlant.core.agents import Agent
+from parlant.core.emissions import EventEmitterFactory
+from parlant.core.loggers import StdoutLogger
+from parlant.core.services.tools.mcp_service import MCPToolClient, MCPToolServer
+from parlant.core.tracer import LocalTracer
+from parlant.sdk import ToolContext
+from tests.core.stable.engines.alpha.test_mcp import create_client, greet_me_like_pirate
+from tests.test_utilities import SERVER_BASE_URL, get_random_port
+
+
+async def test_that_mcp_client_reconnects_after_its_session_is_closed(
+    container: Container,
+    agent: Agent,
+) -> None:
+    async with MCPToolServer([greet_me_like_pirate], port=get_random_port()) as server:
+        client = create_client(server, container)
+
+        async with client:
+            result = await client.call_tool(
+                "greet_me_like_pirate",
+                ToolContext("", "", ""),
+                {"name": "Short Jon Nickel", "lucky_number": 7},
+            )
+            assert "Ahoy Short Jon Nickel! I doubled your lucky number to 14 !" in result.data
+
+            assert client._client is not None
+            await client._client.close()
+
+            reconnected_result = await client.call_tool(
+                "greet_me_like_pirate",
+                ToolContext("", "", ""),
+                {"name": "Another Pirate", "lucky_number": 9},
+            )
+
+            assert "Ahoy Another Pirate! I doubled your lucky number to 18 !" in reconnected_result.data
+
+
+async def test_that_mcp_client_retries_initial_connection(
+    container: Container,
+) -> None:
+    client = MCPToolClient(
+        url=SERVER_BASE_URL,
+        event_emitter_factory=container[EventEmitterFactory],
+        logger=StdoutLogger(LocalTracer()),
+        tracer=LocalTracer(),
+        port=get_random_port(),
+    )
+
+    class FakeClient:
+        def __init__(self, should_fail: bool) -> None:
+            self.should_fail = should_fail
+            self.connected = False
+
+        async def __aenter__(self) -> "FakeClient":
+            if self.should_fail:
+                raise asyncio.TimeoutError()
+            self.connected = True
+            return self
+
+        async def __aexit__(self, exc_type: object, exc_value: object, traceback: object) -> bool:
+            self.connected = False
+            return False
+
+        def is_connected(self) -> bool:
+            return self.connected
+
+    attempted_clients: list[FakeClient] = []
+
+    def fake_create_client() -> FakeClient:
+        fake_client = FakeClient(should_fail=not attempted_clients)
+        attempted_clients.append(fake_client)
+        return fake_client
+
+    client._create_client = fake_create_client  # type: ignore[method-assign]
+
+    async with client:
+        assert len(attempted_clients) == 2
+        assert attempted_clients[-1].is_connected()

--- a/tests/core/stable/services/tools/test_mcp_client.py
+++ b/tests/core/stable/services/tools/test_mcp_client.py
@@ -28,7 +28,7 @@ async def test_that_mcp_client_reconnects_after_its_session_is_closed(
             assert "Ahoy Short Jon Nickel! I doubled your lucky number to 14 !" in result.data
 
             assert client._client is not None
-            await client._client.close()
+            await client._client.close()  # type: ignore[no-untyped-call]
 
             reconnected_result = await client.call_tool(
                 "greet_me_like_pirate",
@@ -36,7 +36,10 @@ async def test_that_mcp_client_reconnects_after_its_session_is_closed(
                 {"name": "Another Pirate", "lucky_number": 9},
             )
 
-            assert "Ahoy Another Pirate! I doubled your lucky number to 18 !" in reconnected_result.data
+            assert (
+                "Ahoy Another Pirate! I doubled your lucky number to 18 !"
+                in reconnected_result.data
+            )
 
 
 async def test_that_mcp_client_retries_initial_connection(
@@ -75,7 +78,7 @@ async def test_that_mcp_client_retries_initial_connection(
         attempted_clients.append(fake_client)
         return fake_client
 
-    client._create_client = fake_create_client  # type: ignore[method-assign]
+    client._create_client = fake_create_client  # type: ignore[method-assign, assignment]
 
     async with client:
         assert len(attempted_clients) == 2


### PR DESCRIPTION
This one is about making the MCP wrapper less brittle when the underlying FastMCP session goes stale.

What changed:
- initialize and manage the FastMCP client through a single lock-protected connection path
- recreate the client when the current session is no longer connected
- retry initial MCP connection attempts a few times before giving up
- retry metadata reads once after reconnect when the failure looks like a dropped session
- add tests for stale-session recovery and initial connection retry

Why this matters:
Right now once the wrapped FastMCP client falls out of a connected state, Parlant just keeps talking to the same dead client and MCP calls fail from there. This PR gives the wrapper a way to heal itself instead of staying broken until the whole service object is replaced.

Testing:
- `PYTHONPATH=src /Users/santangelo/projects/parlant/.venv/bin/pytest tests/core/stable/engines/alpha/test_mcp.py`