### PR TITLE
Refresh journey vectors after graph edits

### DIFF
--- a/src/parlant/adapters/vector_db/transient.py
+++ b/src/parlant/adapters/vector_db/transient.py
@@ -288,6 +288,8 @@ class TransientVectorCollection(Generic[TDocument], BaseVectorCollection[TDocume
         async with self._lock:
             for i, doc in enumerate(self._documents):
                 if matches_filters(filters, doc):
+                    updated_document = cast(TDocument, {**doc, **params})
+
                     if "content" in params:
                         content = params["content"]
                     else:
@@ -307,16 +309,16 @@ class TransientVectorCollection(Generic[TDocument], BaseVectorCollection[TDocume
                         )
 
                     vector = np.array(embeddings[0], dtype=np.float32)
-                    data = {**params, "__id__": doc["id"], "__vector__": vector}
+                    data = {**updated_document, "__id__": doc["id"], "__vector__": vector}
 
                     self._nano_db.upsert([data])
-                    self._documents[i] = cast(TDocument, {**self._documents[i], **params})
+                    self._documents[i] = updated_document
 
                     return UpdateResult(
                         acknowledged=True,
                         matched_count=1,
                         modified_count=1,
-                        updated_document=self._documents[i],
+                        updated_document=updated_document,
                     )
 
             if upsert:

--- a/src/parlant/core/journeys.py
+++ b/src/parlant/core/journeys.py
@@ -266,13 +266,13 @@ class JourneyStore(ABC):
     @abstractmethod
     async def read_edge(
         self,
-        edge_id: JourneyNodeId,
+        edge_id: JourneyEdgeId,
     ) -> JourneyEdge: ...
 
     @abstractmethod
     async def update_edge(
         self,
-        edge_id: JourneyNodeId,
+        edge_id: JourneyEdgeId,
         params: JourneyEdgeUpdateParams,
     ) -> JourneyEdge: ...
 
@@ -845,6 +845,30 @@ class JourneyVectorStore(JourneyStore):
         # including how many vectors to generate and what content each vector should contain.
         return f"{title}\n{description}\nNodes: {', '.join(n.action for n in nodes if n.action)}\nEdges: {', '.join(e.condition for e in edges if e.condition)}"
 
+    async def _refresh_journey_vector(self, journey_id: JourneyId) -> None:
+        journey_doc = await self._collection.find_one({"id": {"$eq": journey_id}})
+
+        if not journey_doc:
+            raise ItemNotFoundError(item_id=UniqueId(journey_id))
+
+        node_docs = await self._node_association_collection.find({"journey_id": {"$eq": journey_id}})
+        edge_docs = await self._edge_association_collection.find({"journey_id": {"$eq": journey_id}})
+
+        content = self.assemble_content(
+            title=journey_doc["title"],
+            description=journey_doc["description"],
+            nodes=[self._deserialize_node(doc) for doc in node_docs],
+            edges=[self._deserialize_edge(doc) for doc in edge_docs],
+        )
+
+        await self._vector_collection.update_one(
+            filters={"journey_id": {"$eq": journey_id}},
+            params={
+                "content": content,
+                "checksum": md5_checksum(content),
+            },
+        )
+
     @override
     async def create_journey(
         self,
@@ -1274,6 +1298,7 @@ class JourneyVectorStore(JourneyStore):
             await self._node_association_collection.insert_one(
                 document=self._serialize_node(node, journey_id)
             )
+            await self._refresh_journey_vector(journey_id)
 
         return node
 
@@ -1321,6 +1346,7 @@ class JourneyVectorStore(JourneyStore):
                 filters={"node_id": {"$eq": node_id}},
                 params=cast(JourneyNodeAssociationDocument, to_json_dict(updated)),
             )
+            await self._refresh_journey_vector(doc["journey_id"])
 
         assert result.updated_document
 
@@ -1347,6 +1373,7 @@ class JourneyVectorStore(JourneyStore):
             result = await self._node_association_collection.delete_one(
                 filters={"node_id": {"$eq": node_id}}
             )
+            await self._refresh_journey_vector(node_doc["journey_id"])
 
         if result.deleted_count == 0:
             raise ItemNotFoundError(item_id=UniqueId(node_id))
@@ -1451,13 +1478,14 @@ class JourneyVectorStore(JourneyStore):
             await self._edge_association_collection.insert_one(
                 document=self._serialize_edge(edge, journey_id)
             )
+            await self._refresh_journey_vector(journey_id)
 
         return edge
 
     @override
     async def read_edge(
         self,
-        edge_id: JourneyNodeId,
+        edge_id: JourneyEdgeId,
     ) -> JourneyEdge:
         async with self._lock.reader_lock:
             doc = await self._edge_association_collection.find_one({"id": {"$eq": edge_id}})
@@ -1470,7 +1498,7 @@ class JourneyVectorStore(JourneyStore):
     @override
     async def update_edge(
         self,
-        edge_id: JourneyNodeId,
+        edge_id: JourneyEdgeId,
         params: JourneyEdgeUpdateParams,
     ) -> JourneyEdge:
         async with self._lock.writer_lock:
@@ -1485,6 +1513,7 @@ class JourneyVectorStore(JourneyStore):
                 filters={"id": {"$eq": edge_id}},
                 params=cast(JourneyEdgeAssociationDocument, to_json_dict(updated)),
             )
+            await self._refresh_journey_vector(doc["journey_id"])
 
         assert result.updated_document
 
@@ -1523,9 +1552,15 @@ class JourneyVectorStore(JourneyStore):
         edge_id: JourneyEdgeId,
     ) -> None:
         async with self._lock.writer_lock:
+            edge_doc = await self._edge_association_collection.find_one({"id": {"$eq": edge_id}})
+
+            if not edge_doc:
+                raise ItemNotFoundError(item_id=UniqueId(edge_id))
+
             result = await self._edge_association_collection.delete_one(
                 filters={"id": {"$eq": edge_id}}
             )
+            await self._refresh_journey_vector(edge_doc["journey_id"])
 
         if result.deleted_count == 0:
             raise ItemNotFoundError(item_id=UniqueId(edge_id))

--- a/tests/core/stable/test_journey_vector_store.py
+++ b/tests/core/stable/test_journey_vector_store.py
@@ -1,0 +1,143 @@
+from collections.abc import Mapping
+from typing import Any, cast
+
+from lagom import Container
+import pytest
+
+from parlant.core.journeys import JourneyStore
+from parlant.core.nlp.embedding import EmbeddingResult
+
+
+def _stub_embedder(store: JourneyStore) -> None:
+    dimensions = store._vector_collection._embedder.dimensions  # type: ignore[attr-defined]
+
+    async def embed(
+        texts: list[str],
+        hints: Mapping[str, Any] = {},
+    ) -> EmbeddingResult:
+        return EmbeddingResult(
+            vectors=[
+                [float((len(text) + i) % 13) for i in range(dimensions)]
+                for text in texts
+            ]
+        )
+
+    store._vector_collection._embedder.embed = embed  # type: ignore[attr-defined, method-assign]
+
+
+async def _read_journey_vector_content(store: JourneyStore, journey_id: str) -> str:
+    vector_docs = await store._vector_collection.find(  # type: ignore[attr-defined]
+        filters={"journey_id": {"$eq": journey_id}}
+    )
+    assert len(vector_docs) == 1
+    return cast(str, vector_docs[0]["content"])
+
+
+@pytest.mark.asyncio
+async def test_that_journey_vectors_refresh_when_node_and_edge_content_changes(
+    container: Container,
+) -> None:
+    store = container[JourneyStore]
+    _stub_embedder(store)
+
+    journey = await store.create_journey(
+        title="Greeting journey",
+        description="Help with greetings.",
+        conditions=[],
+    )
+
+    node = await store.create_node(
+        journey_id=journey.id,
+        action="Ask for the customer's name",
+        tools=[],
+    )
+    edge = await store.create_edge(
+        journey_id=journey.id,
+        source=journey.root_id,
+        target=node.id,
+        condition="customer says hello",
+    )
+
+    content_after_create = await _read_journey_vector_content(store, journey.id)
+    assert "Ask for the customer's name" in content_after_create
+    assert "customer says hello" in content_after_create
+
+    await store.update_node(node.id, {"action": "Ask for the customer's preferred name"})
+    await store.update_edge(edge.id, {"condition": "customer greets the agent"})
+
+    content_after_update = await _read_journey_vector_content(store, journey.id)
+    assert "Ask for the customer's preferred name" in content_after_update
+    assert "Ask for the customer's name" not in content_after_update
+    assert "customer greets the agent" in content_after_update
+    assert "customer says hello" not in content_after_update
+
+
+@pytest.mark.asyncio
+async def test_that_journey_vectors_refresh_when_nodes_and_edges_are_deleted(
+    container: Container,
+) -> None:
+    store = container[JourneyStore]
+    _stub_embedder(store)
+
+    journey = await store.create_journey(
+        title="Escalation journey",
+        description="Handle escalation.",
+        conditions=[],
+    )
+
+    node = await store.create_node(
+        journey_id=journey.id,
+        action="Escalate to a specialist",
+        tools=[],
+    )
+    edge = await store.create_edge(
+        journey_id=journey.id,
+        source=journey.root_id,
+        target=node.id,
+        condition="customer requests escalation",
+    )
+
+    await store.delete_edge(edge.id)
+    content_after_edge_delete = await _read_journey_vector_content(store, journey.id)
+    assert "customer requests escalation" not in content_after_edge_delete
+    assert "Escalate to a specialist" in content_after_edge_delete
+
+    await store.delete_node(node.id)
+    content_after_node_delete = await _read_journey_vector_content(store, journey.id)
+    assert "Escalate to a specialist" not in content_after_node_delete
+
+
+@pytest.mark.asyncio
+async def test_that_journey_vector_queries_still_work_after_refresh_updates(
+    container: Container,
+) -> None:
+    store = container[JourneyStore]
+    _stub_embedder(store)
+
+    journey = await store.create_journey(
+        title="Password recovery",
+        description="Help with account access.",
+        conditions=[],
+    )
+
+    node = await store.create_node(
+        journey_id=journey.id,
+        action="Ask for the account email",
+        tools=[],
+    )
+    edge = await store.create_edge(
+        journey_id=journey.id,
+        source=journey.root_id,
+        target=node.id,
+        condition="customer forgot their password",
+    )
+
+    await store.update_node(node.id, {"action": "Ask for the account username"})
+    await store.update_edge(edge.id, {"condition": "customer cannot sign in"})
+
+    relevant = await store.find_relevant_journeys(
+        query="customer cannot sign in",
+        available_journeys=[journey],
+    )
+
+    assert [j.id for j in relevant] == [journey.id]


### PR DESCRIPTION
## What changed

- Fix `TransientVectorCollection.update_one` to pass full merged document to `nano_db.upsert` instead of partial params
- Refresh the stored journey vector when nodes or edges are created, updated, or deleted
- Fix `read_edge` and `update_edge` signatures to use `JourneyEdgeId` instead of `JourneyNodeId`

## Why

The previous version of this PR was reverted because the partial-params bug in `update_one` corrupted vector data at runtime. This version fixes that root cause and has been verified by running the healthcare example agent end-to-end.

## Test plan

- [x] New tests in `tests/core/stable/test_journey_vector_store.py` (3 tests, all passing)
- [x] Existing journey test suites pass (`tests/api/test_journeys.py`, `tests/sdk/test_journeys.py`)
- [x] Ruff clean, mypy clean (no new errors)
- [x] Ran healthcare example agent with scheduling journey — vector search, node transitions, and tool calls all work correctly