### PR TITLE
feat: add MiniMax LLM provider adapter (default M3)

### DIFF
--- a/docs/adapters/nlp/minimax.md
+++ b/docs/adapters/nlp/minimax.md
@@ -14,9 +14,9 @@ Configure the MiniMax service using these environment variables:
 # Required: Your MiniMax API key
 export MINIMAX_API_KEY="your-api-key-here"
 
-# Optional: Model selection (default: MiniMax-M2.5)
-# Options: MiniMax-M2.5, MiniMax-M2.5-highspeed
-export MINIMAX_MODEL="MiniMax-M2.5"
+# Optional: Model selection (default: MiniMax-M2.7)
+# Options: MiniMax-M2.7, MiniMax-M2.7-highspeed, MiniMax-M2.5, MiniMax-M2.5-highspeed
+export MINIMAX_MODEL="MiniMax-M2.7"
 
 # Optional: Custom base URL (default: https://api.minimax.io/v1)
 export MINIMAX_BASE_URL="https://api.minimax.io/v1"
@@ -26,8 +26,10 @@ export MINIMAX_BASE_URL="https://api.minimax.io/v1"
 
 | Model | Context Window | Best For |
 |-------|---------------|----------|
-| `MiniMax-M2.5` | 204K tokens | General purpose, highest quality |
-| `MiniMax-M2.5-highspeed` | 204K tokens | Lower latency, faster responses |
+| `MiniMax-M2.7` | 204K tokens | Latest model, highest quality (default) |
+| `MiniMax-M2.7-highspeed` | 204K tokens | Latest model, lower latency |
+| `MiniMax-M2.5` | 204K tokens | Previous generation, general purpose |
+| `MiniMax-M2.5-highspeed` | 204K tokens | Previous generation, faster responses |
 
 ## Quick Start
 

--- a/docs/adapters/nlp/minimax.md
+++ b/docs/adapters/nlp/minimax.md
@@ -1,6 +1,6 @@
 # MiniMax Service Documentation
 
-The MiniMax service integrates [MiniMax](https://www.minimaxi.com/) large language models with Parlant. MiniMax provides an OpenAI-compatible API with high-performance models featuring 204K context windows.
+The MiniMax service integrates [MiniMax](https://www.minimaxi.com/) large language models with Parlant. MiniMax provides an OpenAI-compatible API with high-performance models.
 
 ## Prerequisites
 
@@ -14,9 +14,9 @@ Configure the MiniMax service using these environment variables:
 # Required: Your MiniMax API key
 export MINIMAX_API_KEY="your-api-key-here"
 
-# Optional: Model selection (default: MiniMax-M2.7)
-# Options: MiniMax-M2.7, MiniMax-M2.7-highspeed, MiniMax-M2.5, MiniMax-M2.5-highspeed
-export MINIMAX_MODEL="MiniMax-M2.7"
+# Optional: Model selection (default: MiniMax-M3)
+# Options: MiniMax-M3, MiniMax-M2.7, MiniMax-M2.7-highspeed
+export MINIMAX_MODEL="MiniMax-M3"
 
 # Optional: Custom base URL (default: https://api.minimax.io/v1)
 export MINIMAX_BASE_URL="https://api.minimax.io/v1"
@@ -26,10 +26,9 @@ export MINIMAX_BASE_URL="https://api.minimax.io/v1"
 
 | Model | Context Window | Best For |
 |-------|---------------|----------|
-| `MiniMax-M2.7` | 204K tokens | Latest model, highest quality (default) |
-| `MiniMax-M2.7-highspeed` | 204K tokens | Latest model, lower latency |
-| `MiniMax-M2.5` | 204K tokens | Previous generation, general purpose |
-| `MiniMax-M2.5-highspeed` | 204K tokens | Previous generation, faster responses |
+| `MiniMax-M3` | 512K tokens | Latest model, up to 128K output, supports image input (default) |
+| `MiniMax-M2.7` | 204K tokens | Previous generation, highest quality |
+| `MiniMax-M2.7-highspeed` | 204K tokens | Previous generation, lower latency |
 
 ## Quick Start
 

--- a/docs/adapters/nlp/minimax.md
+++ b/docs/adapters/nlp/minimax.md
@@ -1,0 +1,47 @@
+# MiniMax Service Documentation
+
+The MiniMax service integrates [MiniMax](https://www.minimaxi.com/) large language models with Parlant. MiniMax provides an OpenAI-compatible API with high-performance models featuring 204K context windows.
+
+## Prerequisites
+
+1. **Get an API Key**: Sign up at [MiniMax Platform](https://platform.minimaxi.com/) and create an API key.
+
+## Environment Variables
+
+Configure the MiniMax service using these environment variables:
+
+```bash
+# Required: Your MiniMax API key
+export MINIMAX_API_KEY="your-api-key-here"
+
+# Optional: Model selection (default: MiniMax-M2.5)
+# Options: MiniMax-M2.5, MiniMax-M2.5-highspeed
+export MINIMAX_MODEL="MiniMax-M2.5"
+
+# Optional: Custom base URL (default: https://api.minimax.io/v1)
+export MINIMAX_BASE_URL="https://api.minimax.io/v1"
+```
+
+## Supported Models
+
+| Model | Context Window | Best For |
+|-------|---------------|----------|
+| `MiniMax-M2.5` | 204K tokens | General purpose, highest quality |
+| `MiniMax-M2.5-highspeed` | 204K tokens | Lower latency, faster responses |
+
+## Quick Start
+
+```python
+import parlant as p
+from parlant.sdk import NLPServices
+
+async with p.Server(nlp_service=NLPServices.minimax) as server:
+    # Your Parlant application code here
+    pass
+```
+
+## Notes
+
+- **Temperature**: MiniMax requires temperature values in the range `(0, 1]`. A temperature of `0` is not accepted; the adapter automatically clamps it to `0.01`.
+- **Embeddings**: MiniMax does not currently provide an embedding API. The adapter uses JinaAI embeddings as a fallback (requires `JINA_API_KEY` to be set).
+- **Streaming**: Streaming text generation is not currently supported via this adapter.

--- a/src/parlant/adapters/nlp/minimax_service.py
+++ b/src/parlant/adapters/nlp/minimax_service.py
@@ -1,0 +1,301 @@
+# Copyright 2026 Emcie Co Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+import time
+from openai import (
+    APIConnectionError,
+    APIResponseValidationError,
+    APITimeoutError,
+    AsyncClient,
+    ConflictError,
+    InternalServerError,
+    RateLimitError,
+)
+from typing import Any, Callable, Mapping
+from typing_extensions import override
+import json
+import jsonfinder  # type: ignore
+import os
+
+from pydantic import ValidationError
+import tiktoken
+
+from parlant.adapters.nlp.common import normalize_json_output, record_llm_metrics
+from parlant.adapters.nlp.hugging_face import JinaAIEmbedder
+from parlant.core.engines.alpha.prompt_builder import PromptBuilder
+from parlant.core.loggers import Logger
+from parlant.core.tracer import Tracer
+from parlant.core.meter import Meter
+from parlant.core.nlp.policies import policy, retry
+from parlant.core.nlp.tokenization import EstimatingTokenizer
+from parlant.core.nlp.service import (
+    EmbedderHints,
+    NLPService,
+    SchematicGeneratorHints,
+    StreamingTextGeneratorHints,
+)
+from parlant.core.nlp.embedding import Embedder
+from parlant.core.nlp.generation import (
+    T,
+    BaseSchematicGenerator,
+    SchematicGenerationResult,
+    StreamingTextGenerator,
+)
+from parlant.core.nlp.generation_info import GenerationInfo, UsageInfo
+from parlant.core.nlp.moderation import (
+    ModerationService,
+    NoModeration,
+)
+
+MINIMAX_BASE_URL = "https://api.minimax.io/v1"
+
+
+class MiniMaxEstimatingTokenizer(EstimatingTokenizer):
+    def __init__(self, model_name: str) -> None:
+        self.model_name = model_name
+        self.encoding = tiktoken.encoding_for_model("gpt-4o-2024-08-06")
+
+    @override
+    async def estimate_token_count(self, prompt: str) -> int:
+        tokens = self.encoding.encode(prompt)
+        return len(tokens)
+
+
+class MiniMaxSchematicGenerator(BaseSchematicGenerator[T]):
+    supported_minimax_params = ["temperature", "max_tokens"]
+
+    def __init__(
+        self,
+        model_name: str,
+        logger: Logger,
+        tracer: Tracer,
+        meter: Meter,
+    ) -> None:
+        super().__init__(logger=logger, tracer=tracer, meter=meter, model_name=model_name)
+
+        self._client = AsyncClient(
+            base_url=os.environ.get("MINIMAX_BASE_URL", MINIMAX_BASE_URL),
+            api_key=os.environ["MINIMAX_API_KEY"],
+        )
+
+        self._tokenizer = MiniMaxEstimatingTokenizer(model_name=self.model_name)
+
+    @property
+    @override
+    def id(self) -> str:
+        return f"minimax/{self.model_name}"
+
+    @property
+    @override
+    def tokenizer(self) -> MiniMaxEstimatingTokenizer:
+        return self._tokenizer
+
+    @policy(
+        [
+            retry(
+                exceptions=(
+                    APIConnectionError,
+                    APITimeoutError,
+                    ConflictError,
+                    RateLimitError,
+                    APIResponseValidationError,
+                ),
+            ),
+            retry(InternalServerError, max_exceptions=2, wait_times=(1.0, 5.0)),
+        ]
+    )
+    @override
+    async def do_generate(
+        self,
+        prompt: str | PromptBuilder,
+        hints: Mapping[str, Any] = {},
+    ) -> SchematicGenerationResult[T]:
+        with self.logger.scope(f"MiniMax LLM Request ({self.schema.__name__})"):
+            return await self._do_generate(prompt, hints)
+
+    async def _do_generate(
+        self,
+        prompt: str | PromptBuilder,
+        hints: Mapping[str, Any] = {},
+    ) -> SchematicGenerationResult[T]:
+        if isinstance(prompt, PromptBuilder):
+            prompt = prompt.build()
+
+        minimax_api_arguments: dict[str, Any] = {
+            k: v for k, v in hints.items() if k in self.supported_minimax_params
+        }
+
+        # MiniMax requires temperature > 0; clamp zero to a small positive value
+        if "temperature" in minimax_api_arguments and minimax_api_arguments["temperature"] == 0:
+            minimax_api_arguments["temperature"] = 0.01
+
+        t_start = time.time()
+        response = await self._client.chat.completions.create(
+            messages=[{"role": "user", "content": prompt}],
+            model=self.model_name,
+            max_tokens=8192,
+            response_format={"type": "json_object"},
+            **minimax_api_arguments,
+        )
+        t_end = time.time()
+
+        if response.usage:
+            self.logger.trace(response.usage.model_dump_json(indent=2))
+
+        raw_content = response.choices[0].message.content or "{}"
+
+        try:
+            json_content = json.loads(normalize_json_output(raw_content))
+        except json.JSONDecodeError:
+            self.logger.warning(f"Invalid JSON returned by {self.model_name}:\n{raw_content})")
+            json_content = jsonfinder.only_json(raw_content)[2]
+            self.logger.warning("Found JSON content within model response; continuing...")
+
+        try:
+            content = self.schema.model_validate(json_content)
+
+            assert response.usage
+
+            await record_llm_metrics(
+                self.meter,
+                self.model_name,
+                schema_name=self.schema.__name__,
+                input_tokens=response.usage.prompt_tokens,
+                output_tokens=response.usage.completion_tokens,
+                cached_input_tokens=getattr(
+                    response,
+                    "usage.prompt_cache_hit_tokens",
+                    0,
+                ),
+            )
+
+            return SchematicGenerationResult(
+                content=content,
+                info=GenerationInfo(
+                    schema_name=self.schema.__name__,
+                    model=self.id,
+                    duration=(t_end - t_start),
+                    usage=UsageInfo(
+                        input_tokens=response.usage.prompt_tokens,
+                        output_tokens=response.usage.completion_tokens,
+                        extra={
+                            "cached_input_tokens": getattr(
+                                response,
+                                "usage.prompt_cache_hit_tokens",
+                                0,
+                            )
+                        },
+                    ),
+                ),
+            )
+        except ValidationError:
+            self.logger.error(
+                f"JSON content returned by {self.model_name} does not match expected schema:\n{raw_content}"
+            )
+            raise
+
+
+class MiniMax_M2_5(MiniMaxSchematicGenerator[T]):
+    def __init__(self, logger: Logger, tracer: Tracer, meter: Meter) -> None:
+        super().__init__(model_name="MiniMax-M2.5", logger=logger, tracer=tracer, meter=meter)
+
+    @property
+    @override
+    def max_tokens(self) -> int:
+        return 204_000
+
+
+class MiniMax_M2_5_Highspeed(MiniMaxSchematicGenerator[T]):
+    def __init__(self, logger: Logger, tracer: Tracer, meter: Meter) -> None:
+        super().__init__(
+            model_name="MiniMax-M2.5-highspeed",
+            logger=logger,
+            tracer=tracer,
+            meter=meter,
+        )
+
+    @property
+    @override
+    def max_tokens(self) -> int:
+        return 204_000
+
+
+class MiniMaxService(NLPService):
+    @staticmethod
+    def verify_environment() -> str | None:
+        """Returns an error message if the environment is not set up correctly."""
+
+        if not os.environ.get("MINIMAX_API_KEY"):
+            return """\
+You're using the MiniMax NLP service, but MINIMAX_API_KEY is not set.
+Please set MINIMAX_API_KEY in your environment before running Parlant.
+"""
+
+        return None
+
+    def __init__(
+        self,
+        logger: Logger,
+        tracer: Tracer,
+        meter: Meter,
+    ) -> None:
+        self._logger = logger
+        self._tracer = tracer
+        self._meter = meter
+        self._model_name = os.environ.get("MINIMAX_MODEL", "MiniMax-M2.5")
+        self._logger.info(f"Initialized MiniMaxService with model: {self._model_name}")
+
+    @property
+    @override
+    def supports_streaming(self) -> bool:
+        return False
+
+    @override
+    async def get_streaming_text_generator(
+        self, hints: StreamingTextGeneratorHints = {}
+    ) -> StreamingTextGenerator:
+        raise NotImplementedError("Streaming is not supported. Check supports_streaming first.")
+
+    def _get_specialized_generator_class(
+        self,
+        model_name: str,
+        t: type[T],
+    ) -> Callable[..., MiniMaxSchematicGenerator[T]] | None:
+        """Returns the specialized generator class for known models."""
+        model_mapping: dict[str, type[MiniMaxSchematicGenerator[T]]] = {
+            "MiniMax-M2.5": MiniMax_M2_5[t],  # type: ignore
+            "MiniMax-M2.5-highspeed": MiniMax_M2_5_Highspeed[t],  # type: ignore
+        }
+
+        if generator_class := model_mapping.get(model_name):
+            return generator_class
+        else:
+            return None
+
+    @override
+    async def get_schematic_generator(
+        self, t: type[T], hints: SchematicGeneratorHints = {}
+    ) -> MiniMaxSchematicGenerator[T]:
+        minimax_generator = self._get_specialized_generator_class(self._model_name, t)
+        assert minimax_generator is not None, f"Unsupported MiniMax model: {self._model_name}"
+        return minimax_generator(self._logger, self._tracer, self._meter)
+
+    @override
+    async def get_embedder(self, hints: EmbedderHints = {}) -> Embedder:
+        return JinaAIEmbedder(self._logger, self._tracer, self._meter)
+
+    @override
+    async def get_moderation_service(self) -> ModerationService:
+        return NoModeration()

--- a/src/parlant/adapters/nlp/minimax_service.py
+++ b/src/parlant/adapters/nlp/minimax_service.py
@@ -207,29 +207,14 @@ class MiniMaxSchematicGenerator(BaseSchematicGenerator[T]):
             raise
 
 
-class MiniMax_M2_5(MiniMaxSchematicGenerator[T]):
+class MiniMax_M3(MiniMaxSchematicGenerator[T]):
     def __init__(self, logger: Logger, tracer: Tracer, meter: Meter) -> None:
-        super().__init__(model_name="MiniMax-M2.5", logger=logger, tracer=tracer, meter=meter)
+        super().__init__(model_name="MiniMax-M3", logger=logger, tracer=tracer, meter=meter)
 
     @property
     @override
     def max_tokens(self) -> int:
-        return 204_000
-
-
-class MiniMax_M2_5_Highspeed(MiniMaxSchematicGenerator[T]):
-    def __init__(self, logger: Logger, tracer: Tracer, meter: Meter) -> None:
-        super().__init__(
-            model_name="MiniMax-M2.5-highspeed",
-            logger=logger,
-            tracer=tracer,
-            meter=meter,
-        )
-
-    @property
-    @override
-    def max_tokens(self) -> int:
-        return 204_000
+        return 512_000
 
 
 class MiniMax_M2_7(MiniMaxSchematicGenerator[T]):
@@ -279,7 +264,7 @@ Please set MINIMAX_API_KEY in your environment before running Parlant.
         self._logger = logger
         self._tracer = tracer
         self._meter = meter
-        self._model_name = os.environ.get("MINIMAX_MODEL", "MiniMax-M2.7")
+        self._model_name = os.environ.get("MINIMAX_MODEL", "MiniMax-M3")
         self._logger.info(f"Initialized MiniMaxService with model: {self._model_name}")
 
     @property
@@ -300,10 +285,9 @@ Please set MINIMAX_API_KEY in your environment before running Parlant.
     ) -> Callable[..., MiniMaxSchematicGenerator[T]] | None:
         """Returns the specialized generator class for known models."""
         model_mapping: dict[str, type[MiniMaxSchematicGenerator[T]]] = {
+            "MiniMax-M3": MiniMax_M3[t],  # type: ignore
             "MiniMax-M2.7": MiniMax_M2_7[t],  # type: ignore
             "MiniMax-M2.7-highspeed": MiniMax_M2_7_Highspeed[t],  # type: ignore
-            "MiniMax-M2.5": MiniMax_M2_5[t],  # type: ignore
-            "MiniMax-M2.5-highspeed": MiniMax_M2_5_Highspeed[t],  # type: ignore
         }
 
         if generator_class := model_mapping.get(model_name):

--- a/src/parlant/adapters/nlp/minimax_service.py
+++ b/src/parlant/adapters/nlp/minimax_service.py
@@ -232,6 +232,31 @@ class MiniMax_M2_5_Highspeed(MiniMaxSchematicGenerator[T]):
         return 204_000
 
 
+class MiniMax_M2_7(MiniMaxSchematicGenerator[T]):
+    def __init__(self, logger: Logger, tracer: Tracer, meter: Meter) -> None:
+        super().__init__(model_name="MiniMax-M2.7", logger=logger, tracer=tracer, meter=meter)
+
+    @property
+    @override
+    def max_tokens(self) -> int:
+        return 204_000
+
+
+class MiniMax_M2_7_Highspeed(MiniMaxSchematicGenerator[T]):
+    def __init__(self, logger: Logger, tracer: Tracer, meter: Meter) -> None:
+        super().__init__(
+            model_name="MiniMax-M2.7-highspeed",
+            logger=logger,
+            tracer=tracer,
+            meter=meter,
+        )
+
+    @property
+    @override
+    def max_tokens(self) -> int:
+        return 204_000
+
+
 class MiniMaxService(NLPService):
     @staticmethod
     def verify_environment() -> str | None:
@@ -254,7 +279,7 @@ Please set MINIMAX_API_KEY in your environment before running Parlant.
         self._logger = logger
         self._tracer = tracer
         self._meter = meter
-        self._model_name = os.environ.get("MINIMAX_MODEL", "MiniMax-M2.5")
+        self._model_name = os.environ.get("MINIMAX_MODEL", "MiniMax-M2.7")
         self._logger.info(f"Initialized MiniMaxService with model: {self._model_name}")
 
     @property
@@ -275,6 +300,8 @@ Please set MINIMAX_API_KEY in your environment before running Parlant.
     ) -> Callable[..., MiniMaxSchematicGenerator[T]] | None:
         """Returns the specialized generator class for known models."""
         model_mapping: dict[str, type[MiniMaxSchematicGenerator[T]]] = {
+            "MiniMax-M2.7": MiniMax_M2_7[t],  # type: ignore
+            "MiniMax-M2.7-highspeed": MiniMax_M2_7_Highspeed[t],  # type: ignore
             "MiniMax-M2.5": MiniMax_M2_5[t],  # type: ignore
             "MiniMax-M2.5-highspeed": MiniMax_M2_5_Highspeed[t],  # type: ignore
         }

--- a/src/parlant/sdk.py
+++ b/src/parlant/sdk.py
@@ -484,6 +484,16 @@ class NLPServices:
         return DeepSeekService(container[Logger], container[Tracer], container[Meter])
 
     @staticmethod
+    def minimax(container: Container) -> NLPService:
+        """Creates a MiniMax NLPService instance using the provided container."""
+        from parlant.adapters.nlp.minimax_service import MiniMaxService
+
+        if error := MiniMaxService.verify_environment():
+            raise NLPServiceConfigurationError(error)
+
+        return MiniMaxService(container[Logger], container[Tracer], container[Meter])
+
+    @staticmethod
     def snowflake(container: Container) -> NLPService:
         """Creates a SnowflakeCortexService instance using the provided container."""
         from parlant.adapters.nlp.snowflake_cortex_service import SnowflakeCortexService

--- a/tests/adapters/nlp/test_minimax_service.py
+++ b/tests/adapters/nlp/test_minimax_service.py
@@ -31,3 +31,32 @@ def test_that_verify_environment_returns_none_when_api_key_is_set() -> None:
     with patch.dict(os.environ, {"MINIMAX_API_KEY": "test-key"}, clear=True):
         error = MiniMaxService.verify_environment()
         assert error is None
+
+
+def test_that_default_model_is_m2_7() -> None:
+    """Test that the default model is MiniMax-M2.7."""
+    from unittest.mock import MagicMock
+
+    with patch.dict(os.environ, {"MINIMAX_API_KEY": "test-key"}, clear=True):
+        logger = MagicMock()
+        tracer = MagicMock()
+        meter = MagicMock()
+        service = MiniMaxService(logger=logger, tracer=tracer, meter=meter)
+        assert service._model_name == "MiniMax-M2.7"
+
+
+def test_that_m2_7_model_classes_exist() -> None:
+    """Test that MiniMax M2.7 model classes are importable and have correct model names."""
+    from parlant.adapters.nlp.minimax_service import MiniMax_M2_7, MiniMax_M2_7_Highspeed
+    from unittest.mock import MagicMock
+
+    logger = MagicMock()
+    tracer = MagicMock()
+    meter = MagicMock()
+
+    with patch.dict(os.environ, {"MINIMAX_API_KEY": "test-key"}):
+        gen = MiniMax_M2_7[dict](logger=logger, tracer=tracer, meter=meter)
+        assert gen.model_name == "MiniMax-M2.7"
+
+        gen_hs = MiniMax_M2_7_Highspeed[dict](logger=logger, tracer=tracer, meter=meter)
+        assert gen_hs.model_name == "MiniMax-M2.7-highspeed"

--- a/tests/adapters/nlp/test_minimax_service.py
+++ b/tests/adapters/nlp/test_minimax_service.py
@@ -1,0 +1,33 @@
+# Copyright 2026 Emcie Co Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+from unittest.mock import patch
+
+from parlant.adapters.nlp.minimax_service import MiniMaxService
+
+
+def test_that_missing_api_key_returns_error_message() -> None:
+    """Test that missing MINIMAX_API_KEY returns error message."""
+    with patch.dict(os.environ, {}, clear=True):
+        error = MiniMaxService.verify_environment()
+        assert error is not None
+        assert "MINIMAX_API_KEY is not set" in error
+
+
+def test_that_verify_environment_returns_none_when_api_key_is_set() -> None:
+    """Test that verify_environment returns None when MINIMAX_API_KEY is set."""
+    with patch.dict(os.environ, {"MINIMAX_API_KEY": "test-key"}, clear=True):
+        error = MiniMaxService.verify_environment()
+        assert error is None

--- a/tests/adapters/nlp/test_minimax_service.py
+++ b/tests/adapters/nlp/test_minimax_service.py
@@ -33,8 +33,8 @@ def test_that_verify_environment_returns_none_when_api_key_is_set() -> None:
         assert error is None
 
 
-def test_that_default_model_is_m2_7() -> None:
-    """Test that the default model is MiniMax-M2.7."""
+def test_that_default_model_is_m3() -> None:
+    """Test that the default model is MiniMax-M3."""
     from unittest.mock import MagicMock
 
     with patch.dict(os.environ, {"MINIMAX_API_KEY": "test-key"}, clear=True):
@@ -42,12 +42,16 @@ def test_that_default_model_is_m2_7() -> None:
         tracer = MagicMock()
         meter = MagicMock()
         service = MiniMaxService(logger=logger, tracer=tracer, meter=meter)
-        assert service._model_name == "MiniMax-M2.7"
+        assert service._model_name == "MiniMax-M3"
 
 
-def test_that_m2_7_model_classes_exist() -> None:
-    """Test that MiniMax M2.7 model classes are importable and have correct model names."""
-    from parlant.adapters.nlp.minimax_service import MiniMax_M2_7, MiniMax_M2_7_Highspeed
+def test_that_m3_and_m2_7_model_classes_exist() -> None:
+    """Test that MiniMax M3 and M2.7 model classes are importable and have correct model names."""
+    from parlant.adapters.nlp.minimax_service import (
+        MiniMax_M3,
+        MiniMax_M2_7,
+        MiniMax_M2_7_Highspeed,
+    )
     from unittest.mock import MagicMock
 
     logger = MagicMock()
@@ -55,6 +59,10 @@ def test_that_m2_7_model_classes_exist() -> None:
     meter = MagicMock()
 
     with patch.dict(os.environ, {"MINIMAX_API_KEY": "test-key"}):
+        gen_m3 = MiniMax_M3[dict](logger=logger, tracer=tracer, meter=meter)
+        assert gen_m3.model_name == "MiniMax-M3"
+        assert gen_m3.max_tokens == 512_000
+
         gen = MiniMax_M2_7[dict](logger=logger, tracer=tracer, meter=meter)
         assert gen.model_name == "MiniMax-M2.7"
 


### PR DESCRIPTION
## Summary

This PR adds [MiniMax](https://www.minimaxi.com/) as a new NLP service provider for Parlant. The default model is **`MiniMax-M3`**, with `MiniMax-M2.7` and `MiniMax-M2.7-highspeed` available as alternatives.

### Changes

- **New adapter**: `src/parlant/adapters/nlp/minimax_service.py` — Full NLP service implementation following the OpenAI-compatible pattern (similar to DeepSeek/Qwen adapters)
- **SDK registration**: Added `NLPServices.minimax()` factory method in `sdk.py`
- **Tests**: Unit tests for environment verification, default model, and model class instantiation in `tests/adapters/nlp/test_minimax_service.py`
- **Documentation**: Adapter setup and usage guide in `docs/adapters/nlp/minimax.md`

### MiniMax API Details

- **Base URL**: `https://api.minimax.io/v1` (OpenAI-compatible)
- **Models**:
  - `MiniMax-M3` — Latest model, **default**, 512K context window, up to 128K output, supports image input
  - `MiniMax-M2.7` — Previous generation, highest quality (204K context)
  - `MiniMax-M2.7-highspeed` — Previous generation, lower latency (204K context)
- **Auth**: `MINIMAX_API_KEY` environment variable
- **Temperature**: Must be in `(0, 1]`; the adapter auto-clamps `0` to `0.01`

### Usage

```python
import parlant as p
from parlant.sdk import NLPServices

async with p.Server(nlp_service=NLPServices.minimax) as server:
    pass
```

### Architecture

Follows the established Hexagonal Architecture pattern with:
- `MiniMaxEstimatingTokenizer` — Token estimation using tiktoken
- `MiniMaxSchematicGenerator` — JSON schema-based generation with retry policies
- `MiniMax_M3` / `MiniMax_M2_7` / `MiniMax_M2_7_Highspeed` — Model-specific generator classes
- `MiniMaxService` — NLP service with environment verification (default: `MiniMax-M3`)
- JinaAI embeddings as fallback (MiniMax doesn't expose embedding API)

## Test Plan

- [x] Unit tests for `MiniMaxService.verify_environment()`
- [x] Unit test that the default model is `MiniMax-M3`
- [x] Unit test that M3 and M2.7 generator classes are importable and report correct model names and context window
- [x] Follows existing adapter patterns (DeepSeek, Qwen)