### PR TITLE
Add composite Index for Cosmos DB compatibility

### DIFF
--- a/src/parlant/adapters/db/mongo_db.py
+++ b/src/parlant/adapters/db/mongo_db.py
@@ -64,7 +64,14 @@ class MongoDocumentDatabase(DocumentDatabase):
 
         self._collections[name] = MongoDocumentCollection(self, collection)
         await self._collections[name].ensure_indexes(
-            [CollectionIndex(fields=(("creation_utc", SortDirection.ASC),))]
+            [
+                CollectionIndex(
+                    fields=(
+                        ("creation_utc", SortDirection.ASC),
+                        ("id", SortDirection.ASC),
+                    )
+                )
+            ]
         )
         return self._collections[name]
 
@@ -122,7 +129,14 @@ class MongoDocumentDatabase(DocumentDatabase):
 
         self._collections[name] = MongoDocumentCollection(self, result_collection)
         await self._collections[name].ensure_indexes(
-            [CollectionIndex(fields=(("creation_utc", SortDirection.ASC),))]
+            [
+                CollectionIndex(
+                    fields=(
+                        ("creation_utc", SortDirection.ASC),
+                        ("id", SortDirection.ASC),
+                    )
+                )
+            ]
         )
         return self._collections[name]
 


### PR DESCRIPTION
## Problem
Parlant fails on Azure Cosmos DB Mongo API with 
"pymongo.errors.OperationFailure: Error=2, Details=... The order by query does not have a corresponding composite index that it can be served from"

**Root Cause: ** The find() method in MongoDocumentCollection uses composite sort:
sort_spec = [("creation_utc", sort_order), ("id", sort_order)]

But create_collection and get_collection() only create single field index:
CollectionIndex(fields=(("creation_utc", SortDirection.Asc),))

Cosmos DB's Mongo DB API rrequires explicit composite indexes for composite ORDER BY queries. Regular Mongo DB creates these automatically but Cosmos DB does not.

