### PR TITLE
fix(sessions): avoid agent state truncation crash on non-agent traces

### DIFF
--- a/src/parlant/core/app_modules/sessions.py
+++ b/src/parlant/core/app_modules/sessions.py
@@ -517,10 +517,13 @@ class SessionModule:
     ) -> None:
         session = await self._session_store.read_session(session_id)
 
-        events = await self._session_store.list_events(
-            session_id=session_id,
-            min_offset=0,
-            exclude_deleted=True,
+        events = sorted(
+            await self._session_store.list_events(
+                session_id=session_id,
+                min_offset=0,
+                exclude_deleted=True,
+            ),
+            key=lambda event: event.offset,
         )
 
         events_starting_from_min_offset = [e for e in events if e.offset >= min_offset]
@@ -546,10 +549,16 @@ class SessionModule:
             return
 
         state_index_offset = next(
-            i
-            for i, s in enumerate(session.agent_states, start=0)
-            if s.trace_id.startswith(event_at_min_offset.trace_id)
+            (
+                i
+                for i, s in enumerate(session.agent_states, start=0)
+                if s.trace_id.startswith(event_at_min_offset.trace_id)
+            ),
+            None,
         )
+
+        if state_index_offset is None:
+            return
 
         agent_states = session.agent_states[:state_index_offset]
 

--- a/tests/api/test_sessions.py
+++ b/tests/api/test_sessions.py
@@ -1295,8 +1295,7 @@ async def test_that_agent_state_is_deleted_when_deleting_events(
     initial_events = (
         (await async_client.get(f"/sessions/{session_id}/events")).raise_for_status().json()
     )
-
-    event_to_delete = initial_events[2]
+    event_to_delete = next(e for e in initial_events if e["trace_id"] == second_event_trace_id)
 
     (
         await async_client.delete(
@@ -1307,6 +1306,95 @@ async def test_that_agent_state_is_deleted_when_deleting_events(
     session = await session_store.read_session(session_id)
 
     assert len(session.agent_states) == 1
+
+
+async def test_that_deleting_events_from_a_non_agent_trace_keeps_agent_state(
+    async_client: httpx.AsyncClient,
+    container: Container,
+    session_id: SessionId,
+) -> None:
+    session_store = container[SessionStore]
+
+    first_event_trace_id = generate_id()
+    human_event_trace_id = generate_id()
+    third_event_trace_id = generate_id()
+
+    session_events = [
+        make_event_params(
+            EventSource.CUSTOMER,
+            kind=EventKind.MESSAGE,
+            data={"message": "Hello"},
+            trace_id=first_event_trace_id,
+        ),
+        make_event_params(
+            EventSource.AI_AGENT,
+            kind=EventKind.MESSAGE,
+            data={"message": "Hi, how can I assist you?"},
+            trace_id=first_event_trace_id,
+        ),
+        make_event_params(
+            EventSource.HUMAN_AGENT,
+            kind=EventKind.MESSAGE,
+            data={"message": "I'll take it from here."},
+            trace_id=human_event_trace_id,
+        ),
+        make_event_params(
+            EventSource.CUSTOMER,
+            kind=EventKind.MESSAGE,
+            data={"message": "Thanks"},
+            trace_id=third_event_trace_id,
+        ),
+        make_event_params(
+            EventSource.AI_AGENT,
+            kind=EventKind.MESSAGE,
+            data={"message": "You're welcome!"},
+            trace_id=third_event_trace_id,
+        ),
+    ]
+
+    await populate_session_id(container, session_id, session_events)
+    await session_store.update_session(
+        session_id=session_id,
+        params={
+            "agent_states": [
+                AgentState(
+                    trace_id=first_event_trace_id,
+                    journey_paths={},
+                    applied_guideline_ids=[],
+                ),
+                AgentState(
+                    trace_id=third_event_trace_id,
+                    journey_paths={},
+                    applied_guideline_ids=[],
+                ),
+            ]
+        },
+    )
+
+    initial_events = (
+        (await async_client.get(f"/sessions/{session_id}/events")).raise_for_status().json()
+    )
+    human_trace_event = next(e for e in initial_events if e["trace_id"] == human_event_trace_id)
+
+    (
+        await async_client.delete(
+            f"/sessions/{session_id}/events?min_offset={human_trace_event['offset']}"
+        )
+    ).raise_for_status()
+
+    session = await session_store.read_session(session_id)
+    remaining_events = (
+        (await async_client.get(f"/sessions/{session_id}/events")).raise_for_status().json()
+    )
+
+    assert [state.trace_id for state in session.agent_states] == [
+        first_event_trace_id,
+        third_event_trace_id,
+    ]
+    assert [event["trace_id"] for event in remaining_events] == [
+        first_event_trace_id,
+        first_event_trace_id,
+    ]
 
 
 async def test_that_a_custom_event_can_be_read(


### PR DESCRIPTION
Fixes #769

`delete_events()` crashes with `StopIteration` when the cutoff event belongs to a human trace — the `next()` call looking for a matching `agent_state` finds nothing because human traces have no agent state entry.

Fixed by passing a default to `next(..., None)` and returning early when no matching agent state exists. Also added `sorted()` by offset before selecting the cutoff event to avoid issues with non-deterministic event ordering.

Added a human-trace regression test and tightened the existing agent-trace test to select by `trace_id`.