### PR TITLE
fix(api): preserve falsy values in session patch

### DIFF
--- a/src/parlant/api/sessions.py
+++ b/src/parlant/api/sessions.py
@@ -1608,28 +1608,28 @@ def create_router(
         async def from_dto(dto: SessionUpdateParamsDTO) -> SessionUpdateParamsModel:
             params: SessionUpdateParamsModel = {}
 
-            if dto.consumption_offsets:
+            if dto.consumption_offsets is not None:
                 session = await app.sessions.read(session_id)
 
-                if dto.consumption_offsets.client:
+                if dto.consumption_offsets.client is not None:
                     params["consumption_offsets"] = {
                         **session.consumption_offsets,
                         "client": dto.consumption_offsets.client,
                     }
 
-            if dto.title:
+            if dto.title is not None:
                 params["title"] = dto.title
 
-            if dto.mode:
+            if dto.mode is not None:
                 params["mode"] = dto.mode.value
 
-            if dto.customer_id:
+            if dto.customer_id is not None:
                 params["customer_id"] = dto.customer_id
 
-            if dto.agent_id:
+            if dto.agent_id is not None:
                 params["agent_id"] = dto.agent_id
 
-            if dto.metadata:
+            if dto.metadata is not None:
                 session = await app.sessions.read(session_id)
                 current_metadata = dict(session.metadata)
 

--- a/tests/api/test_sessions.py
+++ b/tests/api/test_sessions.py
@@ -394,6 +394,68 @@ async def test_that_consumption_offsets_can_be_updated(
     assert session_dto["consumption_offsets"][consumer_id] == 1
 
 
+async def test_that_consumption_offsets_can_be_updated_to_zero(
+    async_client: httpx.AsyncClient,
+    long_session_id: SessionId,
+) -> None:
+    (
+        await async_client.patch(
+            f"/sessions/{long_session_id}",
+            json={
+                "consumption_offsets": {
+                    "client": 1,
+                }
+            },
+        )
+    ).raise_for_status()
+
+    session_dto = (
+        (
+            await async_client.patch(
+                f"/sessions/{long_session_id}",
+                json={
+                    "consumption_offsets": {
+                        "client": 0,
+                    }
+                },
+            )
+        )
+        .raise_for_status()
+        .json()
+    )
+
+    assert session_dto["consumption_offsets"]["client"] == 0
+
+
+async def test_that_omitting_consumption_offsets_does_not_reset_them(
+    async_client: httpx.AsyncClient,
+    long_session_id: SessionId,
+) -> None:
+    (
+        await async_client.patch(
+            f"/sessions/{long_session_id}",
+            json={
+                "consumption_offsets": {
+                    "client": 1,
+                }
+            },
+        )
+    ).raise_for_status()
+
+    session_dto = (
+        (
+            await async_client.patch(
+                f"/sessions/{long_session_id}",
+                json={"title": "updated title"},
+            )
+        )
+        .raise_for_status()
+        .json()
+    )
+
+    assert session_dto["consumption_offsets"]["client"] == 1
+
+
 async def test_that_title_can_be_updated(
     async_client: httpx.AsyncClient,
     session_id: SessionId,
@@ -410,6 +472,24 @@ async def test_that_title_can_be_updated(
     )
 
     assert session_dto["title"] == "new session title"
+
+
+async def test_that_title_can_be_updated_to_an_empty_string(
+    async_client: httpx.AsyncClient,
+    session_id: SessionId,
+) -> None:
+    session_dto = (
+        (
+            await async_client.patch(
+                f"/sessions/{session_id}",
+                json={"title": ""},
+            )
+        )
+        .raise_for_status()
+        .json()
+    )
+
+    assert session_dto["title"] == ""
 
 
 async def test_that_mode_can_be_updated(


### PR DESCRIPTION
Fixes #768

Session PATCH was using truthy checks (`if dto.xxx:`) for optional fields, which silently drops valid falsy values like `client=0`, `title=""`, or empty metadata operations.

Changed all 7 checks to `is not None` so that falsy values are accepted as valid updates. Metadata `set`/`unset` inner guards are kept as truthy checks since empty dict/list operations are already no-ops.

Added tests covering `client=0`, `title=""`, and omitting `consumption_offsets` entirely.

> Replaces #770, which was accidentally corrupted by a shallow-clone force-push. Sorry for the noise.