### PR TITLE
Add last_modified field to Guideline, Glossary, Journey, and ContextVariable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ All notable changes to Parlant will be documented here.
 - Fix priority and dependency relationships propagating through inactive intermediaries — only direct relationships now affect resolution, consistent with the reinstatement principle from argumentation theory
 - Fix entailment recording only the highest-scoring source when multiple guidelines entail the same target — all entailing relationships are now recorded in resolution details
 - Fix `Variable.get_value()` returning `None` when called from a retriever, caused by retrievers starting before context variables were loaded
+- Fix journey tool-state auto-advancing even when the tool did not run
 
 ## [3.3.0] - 2025-03-15
 

--- a/src/parlant/api/app.py
+++ b/src/parlant/api/app.py
@@ -107,7 +107,7 @@ def _resolve_operation_id(request: Request) -> str | None:
 
 async def create_api_app(
     container: Container,
-    configure: Callable[[FastAPI], Awaitable[None]] | None = None,
+    configure: Callable[[FastAPI], Awaitable[FastAPI | None]] | None = None,
     contextvar_propagation: Mapping[ContextVar[Any], Any] = {},
 ) -> ASGIApplication:
     logger = container[Logger]
@@ -393,7 +393,8 @@ async def create_api_app(
 
     # Call configure_api hook if provided
     if configure:
-        await configure(api_app)
+        if new_app := await configure(api_app):
+            api_app = new_app
 
     # Store FastAPI app in container for access via Server.api property
     container[FastAPI] = api_app

--- a/src/parlant/api/canned_responses.py
+++ b/src/parlant/api/canned_responses.py
@@ -184,6 +184,7 @@ class CannedResponseDTO(
 ):
     id: CannedResponseIdField
     creation_utc: CannedResponseCreationUTCField
+    last_modified: datetime
     value: CannedResponseValueField
     fields: CannedResponseFieldSequenceField
     tags: TagIdSequenceField
@@ -373,6 +374,7 @@ def create_router(
         return CannedResponseDTO(
             id=canrep.id,
             creation_utc=canrep.creation_utc,
+            last_modified=canrep.last_modified,
             value=canrep.value,
             fields=[_canned_response_field_to_dto(s) for s in canrep.fields],
             tags=canrep.tags,
@@ -408,6 +410,7 @@ def create_router(
         return CannedResponseDTO(
             id=canrep.id,
             creation_utc=canrep.creation_utc,
+            last_modified=canrep.last_modified,
             value=canrep.value,
             fields=[_canned_response_field_to_dto(s) for s in canrep.fields],
             tags=canrep.tags,
@@ -440,6 +443,7 @@ def create_router(
             CannedResponseDTO(
                 id=f.id,
                 creation_utc=f.creation_utc,
+                last_modified=f.last_modified,
                 value=f.value,
                 fields=[_canned_response_field_to_dto(s) for s in f.fields],
                 tags=f.tags,
@@ -510,6 +514,7 @@ def create_router(
         return CannedResponseDTO(
             id=canrep.id,
             creation_utc=canrep.creation_utc,
+            last_modified=canrep.last_modified,
             value=canrep.value,
             fields=[_canned_response_field_to_dto(s) for s in canrep.fields],
             tags=canrep.tags,

--- a/src/parlant/api/canned_responses.py
+++ b/src/parlant/api/canned_responses.py
@@ -30,7 +30,13 @@ from parlant.core.canned_responses import (
     CannedResponseField,
 )
 from parlant.core.tags import TagId
-from parlant.api.common import ExampleJson, JSONSerializableDTO, apigen_config, example_json_content
+from parlant.api.common import (
+    ExampleJson,
+    JSONSerializableDTO,
+    LastModifiedField,
+    apigen_config,
+    example_json_content,
+)
 
 
 API_GROUP = "canned_responses"
@@ -184,7 +190,7 @@ class CannedResponseDTO(
 ):
     id: CannedResponseIdField
     creation_utc: CannedResponseCreationUTCField
-    last_modified: datetime
+    last_modified: LastModifiedField
     value: CannedResponseValueField
     fields: CannedResponseFieldSequenceField
     tags: TagIdSequenceField

--- a/src/parlant/api/common.py
+++ b/src/parlant/api/common.py
@@ -345,6 +345,7 @@ class GuidelineDTO(
     track: bool = True
     labels: GuidelineLabelsField = set()
     priority: int = 0
+    last_modified: datetime
 
 
 EnumValueTypeDTO: TypeAlias = str | int

--- a/src/parlant/api/common.py
+++ b/src/parlant/api/common.py
@@ -284,6 +284,13 @@ def example_json_content(json_example: ExampleJson) -> ExtraSchema:
     return {"application/json": {"example": json_example}}
 
 
+LastModifiedField: TypeAlias = Annotated[
+    datetime,
+    Field(
+        description="Timestamp of the last modification",
+    ),
+]
+
 GuidelineMetadataField: TypeAlias = Annotated[
     Mapping[str, JSONSerializableDTO],
     Field(description="Metadata for the guideline"),
@@ -345,7 +352,7 @@ class GuidelineDTO(
     track: bool = True
     labels: GuidelineLabelsField = set()
     priority: int = 0
-    last_modified: datetime
+    last_modified: LastModifiedField
 
 
 EnumValueTypeDTO: TypeAlias = str | int

--- a/src/parlant/api/context_variables.py
+++ b/src/parlant/api/context_variables.py
@@ -225,6 +225,7 @@ class ContextVariableDTO(
     tool_id: ToolIdDTO | None = None
     freshness_rules: FreshnessRulesField | None = None
     tags: ContextVariableTagsField | None = None
+    last_modified: datetime
 
 
 context_variable_tags_update_params_example: ExampleJson = {
@@ -412,6 +413,7 @@ def create_router(
             else None,
             freshness_rules=variable.freshness_rules,
             tags=variable.tags,
+            last_modified=variable.last_modified,
         )
 
     @router.patch(
@@ -473,6 +475,7 @@ def create_router(
             else None,
             freshness_rules=updated_variable.freshness_rules,
             tags=updated_variable.tags,
+            last_modified=updated_variable.last_modified,
         )
 
     @router.get(
@@ -509,6 +512,7 @@ def create_router(
                 else None,
                 freshness_rules=v.freshness_rules,
                 tags=v.tags,
+                last_modified=v.last_modified,
             )
             for v in variables
         ]
@@ -554,6 +558,7 @@ def create_router(
             else None,
             freshness_rules=variable.freshness_rules,
             tags=variable.tags,
+            last_modified=variable.last_modified,
         )
 
         if not include_values:

--- a/src/parlant/api/context_variables.py
+++ b/src/parlant/api/context_variables.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 from pydantic import Field, field_validator
-from datetime import datetime
 from croniter import croniter
 from fastapi import HTTPException, Path, Query, Request, status
 from typing import Annotated, Sequence, TypeAlias, cast
@@ -22,6 +21,7 @@ from fastapi import APIRouter
 from parlant.api import common
 from parlant.api.authorization import AuthorizationPolicy, Operation
 from parlant.api.common import (
+    LastModifiedField,
     ToolIdDTO,
     JSONSerializableDTO,
     apigen_config,
@@ -95,14 +95,6 @@ ValueIdField: TypeAlias = Annotated[
         examples=["val_789abc"],
     ),
 ]
-
-LastModifiedField: TypeAlias = Annotated[
-    datetime,
-    Field(
-        description="Timestamp of the last modification",
-    ),
-]
-
 
 DataField: TypeAlias = Annotated[
     JSONSerializableDTO,
@@ -225,7 +217,7 @@ class ContextVariableDTO(
     tool_id: ToolIdDTO | None = None
     freshness_rules: FreshnessRulesField | None = None
     tags: ContextVariableTagsField | None = None
-    last_modified: datetime
+    last_modified: LastModifiedField
 
 
 context_variable_tags_update_params_example: ExampleJson = {

--- a/src/parlant/api/glossary.py
+++ b/src/parlant/api/glossary.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from datetime import datetime
+
 from fastapi import APIRouter, HTTPException, Path, Query, Request, status
 from typing import Annotated, Sequence, TypeAlias
 from pydantic import Field
@@ -151,6 +153,7 @@ class TermDTO(
     description: TermDescriptionField
     synonyms: TermSynonymsField = []
     tags: TermTagsField
+    last_modified: datetime
 
 
 TermTagsUpdateAddField: TypeAlias = Annotated[
@@ -264,6 +267,7 @@ def create_router(
             description=term.description,
             synonyms=term.synonyms,
             tags=term.tags,
+            last_modified=term.last_modified,
         )
 
     @router.get(
@@ -298,6 +302,7 @@ def create_router(
             description=term.description,
             synonyms=term.synonyms,
             tags=term.tags,
+            last_modified=term.last_modified,
         )
 
     @router.get(
@@ -333,6 +338,7 @@ def create_router(
                 description=term.description,
                 synonyms=term.synonyms,
                 tags=term.tags,
+                last_modified=term.last_modified,
             )
             for term in terms
         ]
@@ -387,6 +393,7 @@ def create_router(
             description=term.description,
             synonyms=term.synonyms,
             tags=term.tags,
+            last_modified=term.last_modified,
         )
 
     @router.delete(

--- a/src/parlant/api/glossary.py
+++ b/src/parlant/api/glossary.py
@@ -12,15 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from datetime import datetime
-
 from fastapi import APIRouter, HTTPException, Path, Query, Request, status
 from typing import Annotated, Sequence, TypeAlias
 from pydantic import Field
 
 from parlant.api import common
 from parlant.api.authorization import Operation, AuthorizationPolicy
-from parlant.api.common import apigen_config, ExampleJson
+from parlant.api.common import LastModifiedField, apigen_config, ExampleJson
 from parlant.core.app_modules.glossary import TermTagsUpdateParamsModel
 from parlant.core.agents import AgentId
 from parlant.core.application import Application
@@ -153,7 +151,7 @@ class TermDTO(
     description: TermDescriptionField
     synonyms: TermSynonymsField = []
     tags: TermTagsField
-    last_modified: datetime
+    last_modified: LastModifiedField
 
 
 TermTagsUpdateAddField: TypeAlias = Annotated[

--- a/src/parlant/api/guidelines.py
+++ b/src/parlant/api/guidelines.py
@@ -447,6 +447,7 @@ def _guideline_relationship_to_dto(
             track=rel_source_guideline.track,
             labels=rel_source_guideline.labels,
             priority=rel_source_guideline.priority,
+            last_modified=rel_source_guideline.last_modified,
         )
         if relationship.source_type == RelationshipEntityKind.GUIDELINE
         else None,
@@ -475,6 +476,7 @@ def _guideline_relationship_to_dto(
             track=rel_target_guideline.track,
             labels=rel_target_guideline.labels,
             priority=rel_target_guideline.priority,
+            last_modified=rel_target_guideline.last_modified,
         )
         if relationship.target_type == RelationshipEntityKind.GUIDELINE
         else None,
@@ -566,6 +568,7 @@ def create_router(
             track=guideline.track,
             labels=guideline.labels,
             priority=guideline.priority,
+            last_modified=guideline.last_modified,
         )
 
     @router.get(
@@ -613,6 +616,7 @@ def create_router(
                 track=guideline.track,
                 labels=guideline.labels,
                 priority=guideline.priority,
+                last_modified=guideline.last_modified,
             )
             for guideline in guidelines
         ]
@@ -677,6 +681,7 @@ def create_router(
                 track=guideline.track,
                 labels=guideline.labels,
                 priority=guideline.priority,
+                last_modified=guideline.last_modified,
             ),
             relationships=[
                 _guideline_relationship_to_dto(relationship, indirect)
@@ -799,6 +804,7 @@ def create_router(
                 track=updated_guideline.track,
                 labels=updated_guideline.labels,
                 priority=updated_guideline.priority,
+                last_modified=updated_guideline.last_modified,
             ),
             relationships=[
                 _guideline_relationship_to_dto(relationship, indirect)

--- a/src/parlant/api/journeys.py
+++ b/src/parlant/api/journeys.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 from collections import defaultdict
-from datetime import datetime
 
 from fastapi import APIRouter, Path, Query, Request, status
 from fastapi.responses import PlainTextResponse
@@ -25,6 +24,7 @@ from parlant.api.authorization import Operation, AuthorizationPolicy
 from parlant.api.common import (
     CompositionModeDTO,
     ExampleJson,
+    LastModifiedField,
     apigen_config,
     composition_mode_dto_to_composition_mode,
     composition_mode_to_composition_mode_dto,
@@ -178,7 +178,7 @@ class JourneyDTO(
     composition_mode: CompositionModeDTO | None = None
     labels: JourneyLabelsField = set()
     priority: int = 0
-    last_modified: datetime
+    last_modified: LastModifiedField
 
 
 class JourneyGraphDTO(JourneyDTO):

--- a/src/parlant/api/journeys.py
+++ b/src/parlant/api/journeys.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 from collections import defaultdict
+from datetime import datetime
+
 from fastapi import APIRouter, Path, Query, Request, status
 from fastapi.responses import PlainTextResponse
 from html import escape
@@ -176,6 +178,7 @@ class JourneyDTO(
     composition_mode: CompositionModeDTO | None = None
     labels: JourneyLabelsField = set()
     priority: int = 0
+    last_modified: datetime
 
 
 class JourneyGraphDTO(JourneyDTO):
@@ -518,6 +521,7 @@ def create_router(
             else None,
             labels=journey.labels,
             priority=journey.priority,
+            last_modified=journey.last_modified,
         )
 
     @router.get(
@@ -559,6 +563,7 @@ def create_router(
                     else None,
                     labels=journey.labels,
                     priority=journey.priority,
+                    last_modified=journey.last_modified,
                 )
             )
 
@@ -624,6 +629,7 @@ def create_router(
             else None,
             labels=model.journey.labels,
             priority=model.journey.priority,
+            last_modified=model.journey.last_modified,
             nodes=[node_to_dto(n) for n in model.nodes],
             edges=[edge_to_dto(e) for e in model.edges],
         )
@@ -720,6 +726,7 @@ def create_router(
             else None,
             labels=journey.labels,
             priority=journey.priority,
+            last_modified=journey.last_modified,
         )
 
     @router.delete(

--- a/src/parlant/api/relationships.py
+++ b/src/parlant/api/relationships.py
@@ -178,6 +178,7 @@ def create_router(
                 tags=model.source_guideline.tags,
                 metadata=model.source_guideline.metadata,
                 priority=model.source_guideline.priority,
+                last_modified=model.source_guideline.last_modified,
             )
             if model.source_guideline
             else None,
@@ -195,6 +196,7 @@ def create_router(
                 tags=model.target_guideline.tags,
                 metadata=model.target_guideline.metadata,
                 priority=model.target_guideline.priority,
+                last_modified=model.target_guideline.last_modified,
             )
             if model.target_guideline
             else None,

--- a/src/parlant/bin/server.py
+++ b/src/parlant/bin/server.py
@@ -328,7 +328,7 @@ class StartupParameters:
     migrate: bool
     configure: Callable[[Container], Awaitable[Container]] | None = None
     initialize: Callable[[Container], Awaitable[None]] | None = None
-    configure_api: Callable[[FastAPI], Awaitable[None]] | None = None
+    configure_api: Callable[[FastAPI], Awaitable[FastAPI | None]] | None = None
     contextvar_propagation: Mapping[ContextVar[Any], Any] = field(default_factory=dict)
 
 

--- a/src/parlant/core/canned_responses.py
+++ b/src/parlant/core/canned_responses.py
@@ -79,6 +79,7 @@ class CannedResponse:
             value=value,
             fields=[],
             creation_utc=datetime.now(),
+            last_modified=datetime.now(),
             tags=[],
             signals=[],
             metadata={},
@@ -90,6 +91,7 @@ class CannedResponse:
 
     id: CannedResponseId
     creation_utc: datetime
+    last_modified: datetime
     value: str
     fields: Sequence[CannedResponseField]
     signals: Sequence[str]
@@ -232,10 +234,22 @@ class CannedResponseDocument_v0_5_0(TypedDict, total=False):
     metadata: Mapping[str, JSONSerializable]
 
 
+class CannedResponseDocument_v0_6_0(TypedDict, total=False):
+    id: ObjectId
+    version: Version.String
+    creation_utc: str
+    value: str
+    fields: str
+    signals: Sequence[str]
+    metadata: Mapping[str, JSONSerializable]
+    field_dependencies: Sequence[str]
+
+
 class CannedResponseDocument(TypedDict, total=False):
     id: ObjectId
     version: Version.String
     creation_utc: str
+    last_modified: str
     value: str
     fields: str
     signals: Sequence[str]
@@ -268,7 +282,7 @@ class CannedResponseTagAssociationDocument(TypedDict, total=False):
 
 
 class CannedResponseVectorStore(CannedResponseStore):
-    VERSION = Version.from_string("0.6.0")
+    VERSION = Version.from_string("0.7.0")
 
     def __init__(
         self,
@@ -327,6 +341,17 @@ class CannedResponseVectorStore(CannedResponseStore):
                 checksum=doc["checksum"],
             )
 
+        async def v0_6_0_to_v0_7_0(doc: VectorDocument) -> Optional[VectorDocument]:
+            doc = cast(CannedResponseVectorDocument, doc)
+
+            return CannedResponseVectorDocument(
+                id=doc["id"],
+                canned_response_id=doc["canned_response_id"],
+                version=Version.String("0.7.0"),
+                content=doc["content"],
+                checksum=doc["checksum"],
+            )
+
         return await VectorDocumentMigrationHelper[CannedResponseVectorDocument](
             self,
             {
@@ -335,6 +360,7 @@ class CannedResponseVectorStore(CannedResponseStore):
                 "0.3.0": v0_1_0_to_v0_4_0,
                 "0.4.0": v0_4_0_to_v0_5_0,
                 "0.5.0": v0_5_0_to_v0_6_0,
+                "0.6.0": v0_6_0_to_v0_7_0,
             },
         ).migrate(doc)
 
@@ -360,7 +386,7 @@ class CannedResponseVectorStore(CannedResponseStore):
         async def v0_5_0_to_v0_6_0(doc: BaseDocument) -> Optional[BaseDocument]:
             doc = cast(CannedResponseDocument_v0_5_0, doc)
 
-            return CannedResponseDocument(
+            return CannedResponseDocument_v0_6_0(
                 id=doc["id"],
                 version=Version.String("0.6.0"),
                 creation_utc=doc["creation_utc"],
@@ -371,6 +397,21 @@ class CannedResponseVectorStore(CannedResponseStore):
                 field_dependencies=[],
             )
 
+        async def v0_6_0_to_v0_7_0(doc: BaseDocument) -> Optional[BaseDocument]:
+            d = cast(CannedResponseDocument_v0_6_0, doc)
+
+            return CannedResponseDocument(
+                id=d["id"],
+                version=Version.String("0.7.0"),
+                creation_utc=d["creation_utc"],
+                last_modified=d["creation_utc"],  # Default to creation_utc for existing responses
+                value=d["value"],
+                fields=d["fields"],
+                signals=d["signals"],
+                metadata=d.get("metadata", {}),
+                field_dependencies=d.get("field_dependencies", []),
+            )
+
         return await DocumentMigrationHelper[CannedResponseDocument](
             self,
             {
@@ -379,6 +420,7 @@ class CannedResponseVectorStore(CannedResponseStore):
                 "0.3.0": v0_1_0_to_v0_4_0,
                 "0.4.0": v0_4_0_to_v0_5_0,
                 "0.5.0": v0_5_0_to_v0_6_0,
+                "0.6.0": v0_6_0_to_v0_7_0,
             },
         ).migrate(doc)
 
@@ -434,6 +476,17 @@ class CannedResponseVectorStore(CannedResponseStore):
                 tag_id=TagId(doc["tag_id"]),
             )
 
+        async def v0_6_0_to_v0_7_0(doc: BaseDocument) -> Optional[BaseDocument]:
+            doc = cast(CannedResponseTagAssociationDocument, doc)
+
+            return CannedResponseTagAssociationDocument(
+                id=doc["id"],
+                version=Version.String("0.7.0"),
+                creation_utc=doc["creation_utc"],
+                canned_response_id=CannedResponseId(doc["canned_response_id"]),
+                tag_id=TagId(doc["tag_id"]),
+            )
+
         return await DocumentMigrationHelper[CannedResponseTagAssociationDocument](
             self,
             {
@@ -442,6 +495,7 @@ class CannedResponseVectorStore(CannedResponseStore):
                 "0.3.0": v0_3_0_to_v0_4_0,
                 "0.4.0": v0_4_0_to_v0_5_0,
                 "0.5.0": v0_5_0_to_v0_6_0,
+                "0.6.0": v0_6_0_to_v0_7_0,
             },
         ).migrate(doc)
 
@@ -504,6 +558,7 @@ class CannedResponseVectorStore(CannedResponseStore):
             id=ObjectId(canned_response_id.id),
             version=self.VERSION.to_string(),
             creation_utc=canned_response_id.creation_utc.isoformat(),
+            last_modified=canned_response_id.last_modified.isoformat(),
             value=canned_response_id.value,
             fields=json.dumps(
                 [
@@ -529,6 +584,7 @@ class CannedResponseVectorStore(CannedResponseStore):
         return CannedResponse(
             id=CannedResponseId(canned_response_document["id"]),
             creation_utc=datetime.fromisoformat(canned_response_document["creation_utc"]),
+            last_modified=datetime.fromisoformat(canned_response_document["last_modified"]),
             value=canned_response_document["value"],
             fields=[
                 CannedResponseField(
@@ -593,6 +649,7 @@ class CannedResponseVectorStore(CannedResponseStore):
                 value=value,
                 fields=fields or [],
                 creation_utc=creation_utc,
+                last_modified=creation_utc,
                 metadata=metadata,
                 tags=tags or [],
                 signals=signals or [],
@@ -670,6 +727,7 @@ class CannedResponseVectorStore(CannedResponseStore):
             canrep = CannedResponse(
                 id=CannedResponseId(canned_response_id),
                 creation_utc=datetime.fromisoformat(doc["creation_utc"]),
+                last_modified=datetime.now(timezone.utc),
                 value=params.get("value", existing_value.value),
                 fields=params.get("fields", existing_value.fields),
                 signals=params.get("signals", existing_value.signals),

--- a/src/parlant/core/context_variables.py
+++ b/src/parlant/core/context_variables.py
@@ -53,6 +53,7 @@ class ContextVariable:
     name: str
     description: Optional[str]
     creation_utc: datetime
+    last_modified: datetime
     tool_id: Optional[ToolId]
     freshness_rules: Optional[str]
     tags: Sequence[TagId]
@@ -178,9 +179,20 @@ class _ContextVariableDocument_v0_2_0(TypedDict, total=False):
     freshness_rules: Optional[str]
 
 
+class _ContextVariableDocument_v0_3_0(TypedDict, total=False):
+    id: ObjectId
+    creation_utc: str
+    version: Version.String
+    name: str
+    description: Optional[str]
+    tool_id: Optional[str]
+    freshness_rules: Optional[str]
+
+
 class _ContextVariableDocument(TypedDict, total=False):
     id: ObjectId
     creation_utc: str
+    last_modified: str
     version: Version.String
     name: str
     description: Optional[str]
@@ -227,7 +239,7 @@ class ContextVariableTagAssociationDocument(TypedDict, total=False):
 
 
 class ContextVariableDocumentStore(ContextVariableStore):
-    VERSION = Version.from_string("0.3.0")
+    VERSION = Version.from_string("0.4.0")
 
     def __init__(
         self,
@@ -260,10 +272,24 @@ class ContextVariableDocumentStore(ContextVariableStore):
         async def v0_2_0_to_v0_3_0(doc: BaseDocument) -> Optional[BaseDocument]:
             d = cast(_ContextVariableDocument_v0_2_0, doc)
 
-            return _ContextVariableDocument(
+            return _ContextVariableDocument_v0_3_0(
                 id=d["id"],
                 creation_utc=datetime.now(timezone.utc).isoformat(),
                 version=Version.String("0.3.0"),
+                name=d["name"],
+                description=d.get("description"),
+                tool_id=d.get("tool_id"),
+                freshness_rules=d.get("freshness_rules"),
+            )
+
+        async def v0_3_0_to_v0_4_0(doc: BaseDocument) -> Optional[BaseDocument]:
+            d = cast(_ContextVariableDocument_v0_3_0, doc)
+
+            return _ContextVariableDocument(
+                id=d["id"],
+                creation_utc=d["creation_utc"],
+                last_modified=d["creation_utc"],  # Default to creation_utc for existing variables
+                version=Version.String("0.4.0"),
                 name=d["name"],
                 description=d.get("description"),
                 tool_id=d.get("tool_id"),
@@ -275,6 +301,7 @@ class ContextVariableDocumentStore(ContextVariableStore):
             {
                 "0.1.0": v0_1_0_to_v0_2_0,
                 "0.2.0": v0_2_0_to_v0_3_0,
+                "0.3.0": v0_3_0_to_v0_4_0,
             },
         ).migrate(doc)
 
@@ -305,11 +332,17 @@ class ContextVariableDocumentStore(ContextVariableStore):
                 data=d["data"],
             )
 
+        async def value_v0_3_0_to_v0_4_0(doc: BaseDocument) -> Optional[BaseDocument]:
+            d = cast(_ContextVariableValueDocument, doc)
+            d["version"] = Version.String("0.4.0")
+            return d
+
         return await DocumentMigrationHelper[_ContextVariableValueDocument](
             self,
             {
                 "0.1.0": v0_1_0_to_v0_2_0,
                 "0.2.0": v0_2_0_to_v0_3_0,
+                "0.3.0": value_v0_3_0_to_v0_4_0,
             },
         ).migrate(doc)
 
@@ -338,11 +371,17 @@ class ContextVariableDocumentStore(ContextVariableStore):
                 tag_id=d["tag_id"],
             )
 
+        async def tag_v0_3_0_to_v0_4_0(doc: BaseDocument) -> Optional[BaseDocument]:
+            d = cast(ContextVariableTagAssociationDocument, doc)
+            d["version"] = Version.String("0.4.0")
+            return d
+
         return await DocumentMigrationHelper[ContextVariableTagAssociationDocument](
             self,
             {
                 "0.1.0": v0_1_0_to_v0_2_0,
                 "0.2.0": v0_2_0_to_v0_3_0,
+                "0.3.0": tag_v0_3_0_to_v0_4_0,
             },
         ).migrate(doc)
 
@@ -396,6 +435,7 @@ class ContextVariableDocumentStore(ContextVariableStore):
             name=context_variable.name,
             description=context_variable.description,
             creation_utc=context_variable.creation_utc.isoformat(),
+            last_modified=context_variable.last_modified.isoformat(),
             tool_id=context_variable.tool_id.to_string() if context_variable.tool_id else None,
             freshness_rules=context_variable.freshness_rules,
         )
@@ -434,6 +474,7 @@ class ContextVariableDocumentStore(ContextVariableStore):
             name=context_variable_document["name"],
             description=context_variable_document.get("description"),
             creation_utc=datetime.fromisoformat(context_variable_document["creation_utc"]),
+            last_modified=datetime.fromisoformat(context_variable_document["last_modified"]),
             tool_id=ToolId.from_string(context_variable_document["tool_id"])
             if context_variable_document["tool_id"]
             else None,
@@ -472,6 +513,7 @@ class ContextVariableDocumentStore(ContextVariableStore):
                 name=name,
                 description=description,
                 creation_utc=creation_utc,
+                last_modified=creation_utc,
                 tool_id=tool_id,
                 freshness_rules=freshness_rules,
                 tags=tags or [],
@@ -515,6 +557,7 @@ class ContextVariableDocumentStore(ContextVariableStore):
                 )
 
             update_params = {
+                "last_modified": datetime.now(timezone.utc).isoformat(),
                 **({"name": params["name"]} if "name" in params else {}),
                 **({"description": params["description"]} if "description" in params else {}),
                 **(

--- a/src/parlant/core/engines/alpha/engine.py
+++ b/src/parlant/core/engines/alpha/engine.py
@@ -92,7 +92,7 @@ from parlant.core.engines.alpha.tool_event_generator import (
 from parlant.core.engines.alpha.utils import context_variables_to_json
 from parlant.core.engines.types import Context, Engine, UtteranceRationale, UtteranceRequest
 from parlant.core.emissions import EventEmitter, EmittedEvent
-from parlant.core.tracer import Tracer
+from parlant.core.tracer import AttributeValue, Tracer
 from parlant.core.loggers import Logger
 from parlant.core.entity_cq import EntityQueries, EntityCommands
 from parlant.core.tools import ToolContext, ToolId
@@ -1058,9 +1058,15 @@ class AlphaEngine(Engine):
                 )
             )
 
-            event_data["matched_guidelines"] = [{"id": m.guideline.id} for m in all_matches]
+            event_data["matched_guidelines"] = [
+                {"id": m.guideline.id, "last_modified": m.guideline.last_modified.isoformat()}
+                for m in all_matches
+            ]
 
-            event_data["matched_journeys"] = [{"id": j.id} for j in context.state.journeys]
+            event_data["matched_journeys"] = [
+                {"id": j.id, "last_modified": j.last_modified.isoformat()}
+                for j in context.state.journeys
+            ]
 
             # Extract journey states from guideline matches with journey_node metadata
             event_data["matched_journey_states"] = [
@@ -1160,45 +1166,36 @@ class AlphaEngine(Engine):
 
     def _add_match_events_to_tracer(
         self,
-        matched_guidelines: Sequence[GuidelineMatch],
-        skipped_guidelines: Sequence[GuidelineMatch],
+        matches: Sequence[GuidelineMatch],
+        journeys: Optional[Mapping[JourneyId, Journey]] = None,
     ) -> None:
         for match in matched_guidelines:
             if match.guideline.metadata.get("journey_node"):
-                edge_id = extract_edge_id_from_journey_node_guideline_id(match.guideline.id)
+                journey_node_meta = cast(
+                    dict[str, JSONSerializable],
+                    match.guideline.metadata["journey_node"],
+                )
+                journey_id = cast(str, journey_node_meta["journey_id"])
+
+                attributes: dict[str, AttributeValue] = {
+                    "node_id": extract_node_id_from_journey_node_guideline_id(match.guideline.id),
+                    "condition": match.guideline.content.condition,
+                    "action": match.guideline.content.action or "",
+                    "rationale": match.rationale,
+                    "journey_id": journey_id,
+                }
+
+                if "sub_journey_id" in journey_node_meta:
+                    attributes["sub_journey_id"] = cast(str, journey_node_meta["sub_journey_id"])
+
+                if journeys and JourneyId(journey_id) in journeys:
+                    attributes["last_modified"] = journeys[
+                        JourneyId(journey_id)
+                    ].last_modified.isoformat()
 
                 self._tracer.add_event(
                     "journey.state.activate",
-                    attributes={
-                        **({"edge_id": edge_id} if edge_id else {}),
-                        "node_id": extract_node_id_from_journey_node_guideline_id(
-                            match.guideline.id
-                        ),
-                        "journey_path": json.dumps(
-                            match.metadata.get("journey_path_guideline_ids", [])
-                        ),
-                        "condition": match.guideline.content.condition,
-                        "action": match.guideline.content.action or "",
-                        "rationale": match.rationale,
-                        "journey_id": cast(str, match.metadata.get("step_selection_journey_id")),
-                        **(
-                            {
-                                "sub_journey_id": cast(
-                                    str,
-                                    cast(
-                                        dict[str, JSONSerializable],
-                                        match.guideline.metadata["journey_node"],
-                                    )["sub_journey_id"],
-                                )
-                            }
-                            if "sub_journey_id"
-                            in cast(
-                                dict[str, JSONSerializable],
-                                match.guideline.metadata["journey_node"],
-                            )
-                            else {}
-                        ),
-                    },
+                    attributes=attributes,
                 )
 
             else:
@@ -1206,6 +1203,7 @@ class AlphaEngine(Engine):
                     "gm.activate",
                     attributes={
                         "guideline_id": match.guideline.id,
+                        "last_modified": match.guideline.last_modified.isoformat(),
                         "condition": match.guideline.content.condition,
                         "action": match.guideline.content.action or "",
                         "rationale": match.rationale,
@@ -1308,6 +1306,10 @@ class AlphaEngine(Engine):
                 guidelines=relevant_guidelines,
             )
 
+        journeys_by_id = {j.id: j for j in available_journeys}
+
+        self._add_match_events_to_tracer(matching_result.matches, journeys=journeys_by_id)
+
         # Step 5: Filter the journeys that are activated by the matched guidelines.
         activated_journeys = self._filter_activated_journeys(
             context, matching_result.matched_guidelines, available_journeys
@@ -1343,6 +1345,8 @@ class AlphaEngine(Engine):
                     )
                 ),
             )
+
+            self._add_match_events_to_tracer(second_match_result.matches, journeys=journeys_by_id)
 
         # Step 7: Build the set of matched guidelines:
         matched_guidelines = list(
@@ -1415,6 +1419,10 @@ class AlphaEngine(Engine):
                 guidelines=guidelines_to_reevaluate,
             )
 
+        reeval_journeys_by_id = {j.id: j for j in all_journeys}
+
+        self._add_match_events_to_tracer(matching_result.matches, journeys=reeval_journeys_by_id)
+
         # Step 5: Filter out the journeys activated by the matched guidelines.
         # If a journey was already active in a previous guideline-matching iteration, we still retrieve it
         # so we can exclude it from the next guideline-matching iteration.
@@ -1452,6 +1460,9 @@ class AlphaEngine(Engine):
                         [matching_result.skipped_guidelines, second_match_result.skipped_guidelines]
                     )
                 ),
+            )
+            self._add_match_events_to_tracer(
+                second_match_result.matches, journeys=reeval_journeys_by_id
             )
 
         # Step 7: Build the final set of matched guidelines:

--- a/src/parlant/core/engines/alpha/engine.py
+++ b/src/parlant/core/engines/alpha/engine.py
@@ -2017,6 +2017,7 @@ class AlphaEngine(Engine):
                 guideline=Guideline(
                     id=GuidelineId(f"<canrep-request-{i}>"),
                     creation_utc=datetime.now(timezone.utc),
+                    last_modified=datetime.now(timezone.utc),
                     content=GuidelineContent(
                         condition="",  # FIXME: Change this to None when we support `str | None` conditions
                         action=utterance_request.action,
@@ -2090,6 +2091,7 @@ class AlphaEngine(Engine):
                             guideline=Guideline(
                                 id=GuidelineId(f"<tool-guideline-{guideline_index}>"),
                                 creation_utc=datetime.now(timezone.utc),
+                                last_modified=datetime.now(timezone.utc),
                                 content=GuidelineContent(
                                     condition=guideline_data.get("condition", ""),
                                     action=guideline_data["action"],

--- a/src/parlant/core/engines/alpha/engine.py
+++ b/src/parlant/core/engines/alpha/engine.py
@@ -1166,7 +1166,8 @@ class AlphaEngine(Engine):
 
     def _add_match_events_to_tracer(
         self,
-        matches: Sequence[GuidelineMatch],
+        matched_guidelines: Sequence[GuidelineMatch],
+        skipped_guidelines: Sequence[GuidelineMatch] = (),
         journeys: Optional[Mapping[JourneyId, Journey]] = None,
     ) -> None:
         for match in matched_guidelines:
@@ -1308,7 +1309,11 @@ class AlphaEngine(Engine):
 
         journeys_by_id = {j.id: j for j in available_journeys}
 
-        self._add_match_events_to_tracer(matching_result.matches, journeys=journeys_by_id)
+        self._add_match_events_to_tracer(
+            matched_guidelines=matching_result.matched_guidelines,
+            skipped_guidelines=matching_result.skipped_guidelines,
+            journeys=journeys_by_id,
+        )
 
         # Step 5: Filter the journeys that are activated by the matched guidelines.
         activated_journeys = self._filter_activated_journeys(
@@ -1346,7 +1351,11 @@ class AlphaEngine(Engine):
                 ),
             )
 
-            self._add_match_events_to_tracer(second_match_result.matches, journeys=journeys_by_id)
+            self._add_match_events_to_tracer(
+                matched_guidelines=second_match_result.matched_guidelines,
+                skipped_guidelines=second_match_result.skipped_guidelines,
+                journeys=journeys_by_id,
+            )
 
         # Step 7: Build the set of matched guidelines:
         matched_guidelines = list(
@@ -1369,14 +1378,15 @@ class AlphaEngine(Engine):
         )
 
         self._add_match_events_to_tracer(
-            resolver_result.matches,
-            list(
+            matched_guidelines=resolver_result.matches,
+            skipped_guidelines=list(
                 set(matching_result.skipped_guidelines).union(
                     set(
                         second_match_result.skipped_guidelines if second_match_result else []
                     ).difference(resolver_result.matches)
                 )
             ),
+            journeys=journeys_by_id,
         )
 
         return _GuidelineAndJourneyMatchingResult(
@@ -1421,7 +1431,11 @@ class AlphaEngine(Engine):
 
         reeval_journeys_by_id = {j.id: j for j in all_journeys}
 
-        self._add_match_events_to_tracer(matching_result.matches, journeys=reeval_journeys_by_id)
+        self._add_match_events_to_tracer(
+            matched_guidelines=matching_result.matched_guidelines,
+            skipped_guidelines=matching_result.skipped_guidelines,
+            journeys=reeval_journeys_by_id,
+        )
 
         # Step 5: Filter out the journeys activated by the matched guidelines.
         # If a journey was already active in a previous guideline-matching iteration, we still retrieve it
@@ -1462,7 +1476,9 @@ class AlphaEngine(Engine):
                 ),
             )
             self._add_match_events_to_tracer(
-                second_match_result.matches, journeys=reeval_journeys_by_id
+                matched_guidelines=second_match_result.matched_guidelines,
+                skipped_guidelines=second_match_result.skipped_guidelines,
+                journeys=reeval_journeys_by_id,
             )
 
         # Step 7: Build the final set of matched guidelines:
@@ -1488,14 +1504,15 @@ class AlphaEngine(Engine):
         )
 
         self._add_match_events_to_tracer(
-            resolver_result.matches,
-            list(
+            matched_guidelines=resolver_result.matches,
+            skipped_guidelines=list(
                 set(matching_result.skipped_guidelines).union(
                     set(
                         second_match_result.skipped_guidelines if second_match_result else []
                     ).difference(resolver_result.matches)
                 )
             ),
+            journeys=reeval_journeys_by_id,
         )
 
         return _GuidelineAndJourneyMatchingResult(

--- a/src/parlant/core/engines/alpha/guideline_matching/generic/generic_guideline_matching_strategy.py
+++ b/src/parlant/core/engines/alpha/guideline_matching/generic/generic_guideline_matching_strategy.py
@@ -317,6 +317,7 @@ class GenericGuidelineMatchingStrategy(GuidelineMatchingStrategy):
                         guideline=Guideline(
                             id=cast(GuidelineId, f"<transient_{generate_id()}>"),
                             creation_utc=datetime.now(),
+                            last_modified=datetime.now(),
                             content=GuidelineContent(
                                 condition=internal_representation(m.guideline).condition,
                                 action=cast(

--- a/src/parlant/core/engines/alpha/guideline_matching/generic/journey/journey_backtrack_check.py
+++ b/src/parlant/core/engines/alpha/guideline_matching/generic/journey/journey_backtrack_check.py
@@ -522,6 +522,7 @@ OUTPUT FORMAT
                     Guideline(
                         id=GuidelineId(f"c-{i}"),
                         creation_utc=datetime.now(timezone.utc),
+                        last_modified=datetime.now(timezone.utc),
                         metadata={"journey_node": {"journey_id": "journey"}},
                         content=GuidelineContent(
                             condition=c,

--- a/src/parlant/core/engines/alpha/guideline_matching/generic/journey/journey_backtrack_node_selection.py
+++ b/src/parlant/core/engines/alpha/guideline_matching/generic/journey/journey_backtrack_node_selection.py
@@ -575,6 +575,7 @@ class JourneyBacktrackNodeSelection:
                     Guideline(
                         id=GuidelineId(f"c-{i}"),
                         creation_utc=datetime.now(timezone.utc),
+                        last_modified=datetime.now(timezone.utc),
                         metadata={"journey_node": {"journey_id": "journey"}},
                         content=GuidelineContent(
                             condition=c,

--- a/src/parlant/core/engines/alpha/guideline_matching/generic/journey/journey_next_step_selection.py
+++ b/src/parlant/core/engines/alpha/guideline_matching/generic/journey/journey_next_step_selection.py
@@ -528,6 +528,7 @@ OUTPUT FORMAT
                 Guideline(
                     id=GuidelineId(f"c-{i}"),
                     creation_utc=datetime.now(timezone.utc),
+                    last_modified=datetime.now(timezone.utc),
                     metadata={"journey_node": {"journey_id": "journey"}},
                     content=GuidelineContent(
                         condition=c,

--- a/src/parlant/core/engines/alpha/guideline_matching/generic/journey/journey_node_selection_batch.py
+++ b/src/parlant/core/engines/alpha/guideline_matching/generic/journey/journey_node_selection_batch.py
@@ -38,6 +38,7 @@ from parlant.core.meter import Meter
 from parlant.core.nlp.generation import SchematicGenerator
 from parlant.core.nlp.generation_info import GenerationInfo, UsageInfo
 from parlant.core.sessions import EventKind, ToolEventData
+from parlant.core.store_provider import StoreProvider, StoreProviderHints
 from parlant.core.tools import ToolId
 
 

--- a/src/parlant/core/engines/alpha/guideline_matching/generic/journey/journey_node_selection_batch.py
+++ b/src/parlant/core/engines/alpha/guideline_matching/generic/journey/journey_node_selection_batch.py
@@ -30,13 +30,15 @@ from parlant.core.engines.alpha.guideline_matching.guideline_matching_context im
     GuidelineMatchingContext,
 )
 from parlant.core.engines.alpha.optimization_policy import OptimizationPolicy
+from parlant.core.emissions import EmittedEvent
 from parlant.core.guidelines import Guideline, GuidelineId, GuidelineStore
 from parlant.core.journeys import Journey
 from parlant.core.loggers import Logger
 from parlant.core.meter import Meter
 from parlant.core.nlp.generation import SchematicGenerator
 from parlant.core.nlp.generation_info import GenerationInfo, UsageInfo
-from parlant.core.store_provider import StoreProvider, StoreProviderHints
+from parlant.core.sessions import EventKind, ToolEventData
+from parlant.core.tools import ToolId
 
 
 PRE_ROOT_INDEX = "0"
@@ -132,6 +134,24 @@ class GenericJourneyNodeSelectionBatch(GuidelineMatchingBatch):
         kind_str = cast(dict[str, Any], guideline.metadata.get("journey_node", {})).get("kind")
         return JourneyNodeKind(kind_str) if kind_str else None
 
+    @staticmethod
+    def _get_tool_ids(guideline: Guideline) -> Sequence[ToolId]:
+        return cast(
+            dict[str, Sequence[ToolId]],
+            guideline.metadata.get("journey_node", {}),
+        ).get("tool_ids", [])
+
+    @staticmethod
+    def _extract_tool_ids_from_staged_events(
+        staged_events: Sequence[EmittedEvent],
+    ) -> set[ToolId]:
+        return {
+            ToolId.from_string(tc["tool_id"])
+            for e in staged_events
+            if e.kind == EventKind.TOOL
+            for tc in cast(ToolEventData, e.data)["tool_calls"]
+        }
+
     def auto_return_match(self) -> GuidelineMatchingBatchResult | None:
         node_index_to_guideline: dict[str, Guideline] = {
             self._get_guideline_node_index(g): g for g in self._node_guidelines
@@ -152,7 +172,14 @@ class GenericJourneyNodeSelectionBatch(GuidelineMatchingBatch):
             kind = self._get_kind(last_visited_guideline)
             outgoing_edges = self._get_follow_ups(last_visited_guideline)
 
-            if kind == JourneyNodeKind.TOOL and len(outgoing_edges) == 1:
+            if (
+                kind == JourneyNodeKind.TOOL
+                and len(outgoing_edges) == 1
+                and (
+                    set(self._get_tool_ids(last_visited_guideline))
+                    & self._extract_tool_ids_from_staged_events(self._context.staged_events)
+                )
+            ):
                 current_node: GuidelineId = outgoing_edges[0]
                 journey_path = list(self._previous_path) + [
                     self._get_guideline_node_index(guideline_id_to_guideline[current_node])

--- a/src/parlant/core/engines/alpha/relational_resolver.py
+++ b/src/parlant/core/engines/alpha/relational_resolver.py
@@ -1381,6 +1381,7 @@ class RelationalResolver:
                     "gm.activate",
                     attributes={
                         "guideline_id": match.guideline.id,
+                        "last_modified": match.guideline.last_modified.isoformat(),
                         "condition": match.guideline.content.condition,
                         "action": match.guideline.content.action or "",
                         "rationale": "Activated via entailment",
@@ -1397,6 +1398,7 @@ class RelationalResolver:
                 "gm.deactivate",
                 attributes={
                     "guideline_id": gid,
+                    "last_modified": m.guideline.last_modified.isoformat(),
                     "condition": m.guideline.content.condition,
                     "action": m.guideline.content.action or "",
                     "rationale": rationale,

--- a/src/parlant/core/glossary.py
+++ b/src/parlant/core/glossary.py
@@ -57,6 +57,7 @@ TermId = NewType("TermId", str)
 class Term:
     id: TermId
     creation_utc: datetime
+    last_modified: datetime
     name: str
     description: str
     synonyms: list[str]
@@ -151,12 +152,24 @@ class TermDocument_v0_1_0(TypedDict, total=False):
     synonyms: Optional[str]
 
 
+class _TermDocument_v0_2_0(TypedDict, total=False):
+    id: ObjectId
+    version: Version.String
+    content: str
+    checksum: Required[str]
+    creation_utc: str
+    name: str
+    description: str
+    synonyms: Optional[str]
+
+
 class _TermDocument(TypedDict, total=False):
     id: ObjectId
     version: Version.String
     content: str
     checksum: Required[str]
     creation_utc: str
+    last_modified: str
     name: str
     description: str
     synonyms: Optional[str]
@@ -171,7 +184,7 @@ class TermTagAssociationDocument(TypedDict, total=False):
 
 
 class GlossaryVectorStore(GlossaryStore):
-    VERSION = Version.from_string("0.2.0")
+    VERSION = Version.from_string("0.3.0")
 
     def __init__(
         self,
@@ -206,10 +219,27 @@ class GlossaryVectorStore(GlossaryStore):
                 "This code should not be reached! Please run the 'parlant-prepare-migration' script."
             )
 
+        async def v0_2_0_to_v0_3_0(
+            document: VectorBaseDocument,
+        ) -> Optional[VectorBaseDocument]:
+            d = cast(_TermDocument_v0_2_0, document)
+            return _TermDocument(
+                id=d["id"],
+                version=Version.String("0.3.0"),
+                content=d["content"],
+                checksum=d["checksum"],
+                creation_utc=d["creation_utc"],
+                last_modified=d["creation_utc"],  # Default to creation_utc for existing terms
+                name=d["name"],
+                description=d["description"],
+                synonyms=d.get("synonyms"),
+            )
+
         return await VectorDocumentMigrationHelper[_TermDocument](
             self,
             {
                 "0.1.0": v0_1_0_to_v0_2_0,
+                "0.2.0": v0_2_0_to_v0_3_0,
             },
         ).migrate(document)
 
@@ -273,6 +303,7 @@ class GlossaryVectorStore(GlossaryStore):
             content=content,
             checksum=checksum,
             creation_utc=term.creation_utc.isoformat(),
+            last_modified=term.last_modified.isoformat(),
             name=term.name,
             description=term.description,
             synonyms=(", ").join(term.synonyms) if term.synonyms is not None else "",
@@ -286,6 +317,7 @@ class GlossaryVectorStore(GlossaryStore):
         return Term(
             id=TermId(term_document["id"]),
             creation_utc=datetime.fromisoformat(term_document["creation_utc"]),
+            last_modified=datetime.fromisoformat(term_document["last_modified"]),
             name=term_document["name"],
             description=term_document["description"],
             synonyms=term_document["synonyms"].split(", ") if term_document["synonyms"] else [],
@@ -324,6 +356,7 @@ class GlossaryVectorStore(GlossaryStore):
             term = Term(
                 id=term_id,
                 creation_utc=creation_utc,
+                last_modified=creation_utc,
                 name=name,
                 description=description,
                 synonyms=list(synonyms) if synonyms else [],
@@ -399,6 +432,7 @@ class GlossaryVectorStore(GlossaryStore):
                     "description": description,
                     "synonyms": ", ".join(synonyms) if synonyms else "",
                     "checksum": md5_checksum(content),
+                    "last_modified": datetime.now(timezone.utc).isoformat(),
                 },
             )
 

--- a/src/parlant/core/guidelines.py
+++ b/src/parlant/core/guidelines.py
@@ -57,6 +57,7 @@ class GuidelineContent:
 class Guideline:
     id: GuidelineId
     creation_utc: datetime
+    last_modified: datetime
     content: GuidelineContent
     enabled: bool
     tags: Sequence[TagId]
@@ -296,10 +297,27 @@ class GuidelineDocument_v0_9_0(TypedDict, total=False):
     labels: Sequence[str]
 
 
+class GuidelineDocument_v0_10_0(TypedDict, total=False):
+    id: ObjectId
+    version: Version.String
+    creation_utc: str
+    condition: str
+    action: Optional[str]
+    description: Optional[str]
+    criticality: str
+    enabled: bool
+    metadata: Mapping[str, JSONSerializable]
+    composition_mode: Optional[str]
+    track: bool
+    labels: Sequence[str]
+    priority: int
+
+
 class GuidelineDocument(TypedDict, total=False):
     id: ObjectId
     version: Version.String
     creation_utc: str
+    last_modified: str
     condition: str
     action: Optional[str]
     description: Optional[str]
@@ -334,7 +352,7 @@ async def guideline_document_converter_0_1_0_to_0_2_0(doc: BaseDocument) -> Opti
 
 
 class GuidelineDocumentStore(GuidelineStore):
-    VERSION = Version.from_string("0.10.0")
+    VERSION = Version.from_string("0.11.0")
 
     def __init__(
         self,
@@ -354,9 +372,28 @@ class GuidelineDocumentStore(GuidelineStore):
         self._lock = ReaderWriterLock()
 
     async def _document_loader(self, doc: BaseDocument) -> Optional[GuidelineDocument]:
+        async def v0_10_0_to_v0_11_0(doc: BaseDocument) -> Optional[BaseDocument]:
+            d = cast(GuidelineDocument_v0_10_0, doc)
+            return GuidelineDocument(
+                id=d["id"],
+                version=Version.String("0.11.0"),
+                creation_utc=d["creation_utc"],
+                last_modified=d["creation_utc"],  # Default to creation_utc for existing guidelines
+                condition=d["condition"],
+                action=d["action"],
+                description=d.get("description", None),
+                criticality=d["criticality"],
+                enabled=d["enabled"],
+                metadata=d["metadata"],
+                composition_mode=d.get("composition_mode"),
+                track=d.get("track", True),
+                labels=d.get("labels", []),
+                priority=d.get("priority", 0),
+            )
+
         async def v0_9_0_to_v0_10_0(doc: BaseDocument) -> Optional[BaseDocument]:
             d = cast(GuidelineDocument_v0_9_0, doc)
-            return GuidelineDocument(
+            return GuidelineDocument_v0_10_0(
                 id=d["id"],
                 version=Version.String("0.10.0"),
                 creation_utc=d["creation_utc"],
@@ -476,6 +513,7 @@ class GuidelineDocumentStore(GuidelineStore):
                 "0.7.0": v0_7_0_to_v0_8_0,
                 "0.8.0": v0_8_0_to_v0_9_0,
                 "0.9.0": v0_9_0_to_v0_10_0,
+                "0.10.0": v0_10_0_to_v0_11_0,
             },
         ).migrate(doc)
 
@@ -548,6 +586,7 @@ class GuidelineDocumentStore(GuidelineStore):
             id=ObjectId(guideline.id),
             version=self.VERSION.to_string(),
             creation_utc=guideline.creation_utc.isoformat(),
+            last_modified=guideline.last_modified.isoformat(),
             condition=guideline.content.condition,
             action=guideline.content.action,
             description=guideline.content.description,
@@ -579,6 +618,7 @@ class GuidelineDocumentStore(GuidelineStore):
         return Guideline(
             id=GuidelineId(guideline_document["id"]),
             creation_utc=datetime.fromisoformat(guideline_document["creation_utc"]),
+            last_modified=datetime.fromisoformat(guideline_document["last_modified"]),
             content=GuidelineContent(
                 condition=guideline_document["condition"],
                 action=guideline_document["action"],
@@ -630,6 +670,7 @@ class GuidelineDocumentStore(GuidelineStore):
             guideline = Guideline(
                 id=guideline_id,
                 creation_utc=creation_utc,
+                last_modified=creation_utc,
                 content=GuidelineContent(
                     condition=condition,
                     action=action,
@@ -759,6 +800,7 @@ class GuidelineDocumentStore(GuidelineStore):
         async with self._lock.writer_lock:
             guideline_document = GuidelineDocument(
                 {
+                    "last_modified": datetime.now(timezone.utc).isoformat(),
                     **({"condition": params["condition"]} if "condition" in params else {}),
                     **({"action": params["action"]} if "action" in params else {}),
                     **({"description": params["description"]} if "description" in params else {}),
@@ -892,6 +934,7 @@ class GuidelineDocumentStore(GuidelineStore):
                 filters={"id": {"$eq": guideline_id}},
                 params={
                     "metadata": updated_metadata,
+                    "last_modified": datetime.now(timezone.utc).isoformat(),
                 },
             )
 
@@ -917,6 +960,7 @@ class GuidelineDocumentStore(GuidelineStore):
                 filters={"id": {"$eq": guideline_id}},
                 params={
                     "metadata": updated_metadata,
+                    "last_modified": datetime.now(timezone.utc).isoformat(),
                 },
             )
 
@@ -943,6 +987,7 @@ class GuidelineDocumentStore(GuidelineStore):
                 filters={"id": {"$eq": guideline_id}},
                 params={
                     "labels": updated_labels,
+                    "last_modified": datetime.now(timezone.utc).isoformat(),
                 },
             )
 
@@ -969,6 +1014,7 @@ class GuidelineDocumentStore(GuidelineStore):
                 filters={"id": {"$eq": guideline_id}},
                 params={
                     "labels": updated_labels,
+                    "last_modified": datetime.now(timezone.utc).isoformat(),
                 },
             )
 

--- a/src/parlant/core/journey_guideline_projection.py
+++ b/src/parlant/core/journey_guideline_projection.py
@@ -485,6 +485,7 @@ class JourneyGuidelineProjection:
                 ),
                 criticality=Criticality.HIGH,
                 creation_utc=datetime.now(timezone.utc),
+                last_modified=datetime.now(timezone.utc),
                 enabled=True,
                 tags=list(journey.tags),
                 metadata=metadata,

--- a/src/parlant/core/journey_guideline_projection.py
+++ b/src/parlant/core/journey_guideline_projection.py
@@ -449,6 +449,7 @@ class JourneyGuidelineProjection:
                 "index": str(node_indexes[node.id]),
                 "journey_id": journey_id,
                 "labels": list(node.labels),
+                "tool_ids": list(node.tools),
             }
 
             base_journey_node["kind"] = node.kind.value

--- a/src/parlant/core/journeys.py
+++ b/src/parlant/core/journeys.py
@@ -120,6 +120,7 @@ class JourneyLink:
 class Journey:
     id: JourneyId
     creation_utc: datetime
+    last_modified: datetime
     description: str
     conditions: Sequence[GuidelineId]
     title: str
@@ -491,6 +492,7 @@ class JourneyDocument(TypedDict, total=False):
     id: ObjectId
     version: Version.String
     creation_utc: str
+    last_modified: str
     title: str
     description: str
     root_id: JourneyNodeId
@@ -690,6 +692,7 @@ class JourneyVectorStore(JourneyStore):
                 id=d["id"],
                 version=Version.String("0.7.0"),
                 creation_utc=d["creation_utc"],
+                last_modified=d["creation_utc"],  # Default to creation_utc for existing journeys
                 title=d["title"],
                 description=d["description"],
                 root_id=d["root_id"],
@@ -931,6 +934,7 @@ class JourneyVectorStore(JourneyStore):
             id=ObjectId(journey.id),
             version=self.VERSION.to_string(),
             creation_utc=journey.creation_utc.isoformat(),
+            last_modified=journey.last_modified.isoformat(),
             title=journey.title,
             description=journey.description,
             root_id=journey.root_id,
@@ -960,6 +964,7 @@ class JourneyVectorStore(JourneyStore):
         return Journey(
             id=JourneyId(doc["id"]),
             creation_utc=datetime.fromisoformat(doc["creation_utc"]),
+            last_modified=datetime.fromisoformat(doc["last_modified"]),
             conditions=conditions,
             title=doc["title"],
             description=doc["description"],
@@ -1121,6 +1126,7 @@ class JourneyVectorStore(JourneyStore):
             journey = Journey(
                 id=journey_id,
                 creation_utc=creation_utc,
+                last_modified=creation_utc,
                 conditions=conditions,
                 title=title,
                 description=description,
@@ -1203,7 +1209,7 @@ class JourneyVectorStore(JourneyStore):
             nodes = await self.list_nodes(journey_id=journey_id)
             edges = await self.list_edges(journey_id=journey_id)
 
-            updated = {**doc, **params}
+            updated = {**doc, **params, "last_modified": datetime.now(timezone.utc).isoformat()}
 
             content = self.assemble_content(
                 title=cast(str, updated["title"]),
@@ -1901,7 +1907,10 @@ class JourneyVectorStore(JourneyStore):
 
             result = await self._collection.update_one(
                 filters={"id": {"$eq": journey_id}},
-                params={"labels": updated_labels},
+                params={
+                    "labels": updated_labels,
+                    "last_modified": datetime.now(timezone.utc).isoformat(),
+                },
             )
 
         assert result.updated_document
@@ -1925,7 +1934,10 @@ class JourneyVectorStore(JourneyStore):
 
             result = await self._collection.update_one(
                 filters={"id": {"$eq": journey_id}},
-                params={"labels": updated_labels},
+                params={
+                    "labels": updated_labels,
+                    "last_modified": datetime.now(timezone.utc).isoformat(),
+                },
             )
 
         assert result.updated_document

--- a/src/parlant/sdk.py
+++ b/src/parlant/sdk.py
@@ -5384,7 +5384,7 @@ class Server:
                 latest_container[EngineHooks] = hooks
 
             if env_based_module := get_env_based_module():
-                if configure_module := getattr(env_based_module, "configure_module", None):
+                if configure_module := getattr(env_based_module, "configure_container", None):
                     latest_container = await configure_module(latest_container.clone())
 
             return latest_container
@@ -5430,7 +5430,7 @@ class Server:
                 await self._initialize(c)
 
             if env_based_module := get_env_based_module():
-                if initialize_module := getattr(env_based_module, "initialize_module", None):
+                if initialize_module := getattr(env_based_module, "initialize_container", None):
                     await initialize_module(c.clone())
 
         return StartupParameters(

--- a/src/parlant/sdk.py
+++ b/src/parlant/sdk.py
@@ -5384,8 +5384,8 @@ class Server:
                 latest_container[EngineHooks] = hooks
 
             if env_based_module := get_env_based_module():
-                if configure_module := getattr(env_based_module, "configure_container", None):
-                    latest_container = await configure_module(latest_container.clone())
+                if module_func := getattr(env_based_module, "configure_container", None):
+                    latest_container = await module_func(latest_container.clone())
 
             return latest_container
 
@@ -5430,8 +5430,19 @@ class Server:
                 await self._initialize(c)
 
             if env_based_module := get_env_based_module():
-                if initialize_module := getattr(env_based_module, "initialize_container", None):
-                    await initialize_module(c.clone())
+                if module_func := getattr(env_based_module, "initialize_container", None):
+                    await module_func(c.clone())
+
+        async def configure_api(app: FastAPI) -> FastAPI:
+            if self._configure_api:
+                await self._configure_api(app)
+
+            if env_based_module := get_env_based_module():
+                if module_func := getattr(env_based_module, "configure_api", None):
+                    if new_app := await module_func(app):
+                        app = new_app
+
+            return app
 
         return StartupParameters(
             host=self.host,
@@ -5442,7 +5453,7 @@ class Server:
             migrate=self._migrate,
             configure=configure,
             initialize=initialize,
-            configure_api=self._configure_api,
+            configure_api=configure_api,
             contextvar_propagation={
                 self._current_server_var: self,
             },

--- a/tests/api/test_canned_responses.py
+++ b/tests/api/test_canned_responses.py
@@ -49,6 +49,7 @@ async def test_that_a_canned_response_can_be_created(
 
     assert "id" in canned_response
     assert "creation_utc" in canned_response
+    assert "last_modified" in canned_response
 
 
 async def test_that_a_canned_response_can_be_created_with_tags(
@@ -236,6 +237,7 @@ async def test_that_a_canned_response_can_be_updated(
     updated_canned_response = response.json()
     assert updated_canned_response["value"] == update_payload["value"]
     assert updated_canned_response["fields"] == update_payload["fields"]
+    assert updated_canned_response["last_modified"] > canned_response.last_modified.isoformat()
 
 
 async def test_that_a_canned_response_can_be_deleted(

--- a/tests/api/test_context_variables.py
+++ b/tests/api/test_context_variables.py
@@ -63,6 +63,7 @@ async def test_that_a_context_variable_can_be_created(
     assert context_variable["description"] == "test of context variable"
     assert context_variable["freshness_rules"] == freshness_rules
     assert context_variable["tags"] == []
+    assert "last_modified" in context_variable
 
 
 async def test_that_a_context_variable_can_be_created_with_tags(
@@ -249,6 +250,7 @@ async def test_that_a_context_variable_can_be_updated_with_new_values(
     assert data["description"] == updated_description
     assert data["freshness_rules"] == freshness_rules
     assert set(data["tags"]) == set(tags_to_add)
+    assert data["last_modified"] > variable.last_modified.isoformat()
 
 
 async def test_that_tags_can_be_removed_from_a_context_variable(

--- a/tests/api/test_glossary.py
+++ b/tests/api/test_glossary.py
@@ -44,6 +44,7 @@ async def test_that_a_term_can_be_created(
     assert data["description"] == description
     assert data["synonyms"] == synonyms
     assert data["tags"] == []
+    assert "last_modified" in data
 
 
 async def test_that_a_term_can_be_created_with_tags(
@@ -242,6 +243,7 @@ async def test_that_a_term_can_be_updated_with_new_values(
     assert data["description"] == updated_description
     assert data["synonyms"] == updated_synonyms
     assert set(data["tags"]) == set(tags_to_add)
+    assert data["last_modified"] > term["last_modified"]
 
 
 async def test_that_tags_can_be_removed_from_a_term(

--- a/tests/api/test_guidelines.py
+++ b/tests/api/test_guidelines.py
@@ -85,6 +85,7 @@ async def test_that_a_guideline_can_be_created(
     assert guideline["enabled"] is True
     assert guideline["tags"] == []
     assert guideline["metadata"] == {"key1": "value1", "key2": "value2"}
+    assert "last_modified" in guideline
 
 
 async def test_that_a_guideline_can_be_created_without_an_action(
@@ -321,6 +322,7 @@ async def test_that_a_guideline_condition_can_be_updated(
     assert updated_guideline["id"] == guideline.id
     assert updated_guideline["condition"] == "the customer inquires about weather"
     assert updated_guideline["action"] == guideline.content.action
+    assert updated_guideline["last_modified"] > guideline.last_modified.isoformat()
 
 
 async def test_that_a_guideline_action_can_be_updated(

--- a/tests/api/test_journeys.py
+++ b/tests/api/test_journeys.py
@@ -53,6 +53,8 @@ async def test_that_a_journey_can_be_created(
     guideline_after_update = await guideline_store.read_guideline(guideline.id)
     assert guideline_after_update.tags == [Tag.for_journey_id(journey["id"]).id]
 
+    assert "last_modified" in journey
+
 
 async def test_that_a_journey_can_be_created_with_multiple_conditions(
     async_client: httpx.AsyncClient,
@@ -278,6 +280,7 @@ async def test_that_a_journey_can_be_updated(
 
     assert updated_journey["title"] == expected_title
     assert updated_journey["description"] == expected_description
+    assert updated_journey["last_modified"] > journey["last_modified"]
 
 
 async def test_that_tags_can_be_added_to_a_journey(

--- a/tests/core/stable/engines/alpha/test_disambiguation_batch.py
+++ b/tests/core/stable/engines/alpha/test_disambiguation_batch.py
@@ -181,6 +181,7 @@ def create_term(
     return Term(
         id=TermId("-"),
         creation_utc=datetime.now(timezone.utc),
+        last_modified=datetime.now(timezone.utc),
         name=name,
         description=description,
         synonyms=synonyms,

--- a/tests/core/stable/engines/alpha/test_disambiguation_batch.py
+++ b/tests/core/stable/engines/alpha/test_disambiguation_batch.py
@@ -238,6 +238,7 @@ async def create_guideline(
     guideline = Guideline(
         id=GuidelineId(generate_id()),
         creation_utc=datetime.now(timezone.utc),
+        last_modified=datetime.now(timezone.utc),
         content=GuidelineContent(
             condition=condition,
             action=action,

--- a/tests/core/stable/engines/alpha/test_disambiguation_batch.py
+++ b/tests/core/stable/engines/alpha/test_disambiguation_batch.py
@@ -197,6 +197,7 @@ def create_context_variable(
     return ContextVariable(
         id=ContextVariableId("-"),
         creation_utc=datetime.now(timezone.utc),
+        last_modified=datetime.now(timezone.utc),
         name=name,
         description="",
         tool_id=None,

--- a/tests/core/stable/engines/alpha/test_generic_response_analysis.py
+++ b/tests/core/stable/engines/alpha/test_generic_response_analysis.py
@@ -138,6 +138,7 @@ def create_guideline(
     guideline = Guideline(
         id=GuidelineId(generate_id()),
         creation_utc=datetime.now(timezone.utc),
+        last_modified=datetime.now(timezone.utc),
         content=GuidelineContent(
             condition=condition,
             action=action,
@@ -163,6 +164,7 @@ def create_guideline_with_tools(
     guideline = Guideline(
         id=GuidelineId(generate_id()),
         creation_utc=datetime.now(timezone.utc),
+        last_modified=datetime.now(timezone.utc),
         content=GuidelineContent(
             condition=condition,
             action=action,

--- a/tests/core/stable/engines/alpha/test_guideline_actionable_batch.py
+++ b/tests/core/stable/engines/alpha/test_guideline_actionable_batch.py
@@ -152,6 +152,7 @@ def create_guideline(
     guideline = Guideline(
         id=GuidelineId(generate_id()),
         creation_utc=datetime.now(timezone.utc),
+        last_modified=datetime.now(timezone.utc),
         content=GuidelineContent(
             condition=condition,
             action=action,

--- a/tests/core/stable/engines/alpha/test_guideline_low_criticality_batch.py
+++ b/tests/core/stable/engines/alpha/test_guideline_low_criticality_batch.py
@@ -182,6 +182,7 @@ def create_guideline(
     guideline = Guideline(
         id=GuidelineId(generate_id()),
         creation_utc=datetime.now(timezone.utc),
+        last_modified=datetime.now(timezone.utc),
         content=GuidelineContent(
             condition=condition,
             action=action,

--- a/tests/core/stable/engines/alpha/test_guideline_matcher.py
+++ b/tests/core/stable/engines/alpha/test_guideline_matcher.py
@@ -511,6 +511,7 @@ def create_term(
     return Term(
         id=TermId("-"),
         creation_utc=datetime.now(timezone.utc),
+        last_modified=datetime.now(timezone.utc),
         name=name,
         description=description,
         synonyms=synonyms,

--- a/tests/core/stable/engines/alpha/test_guideline_matcher.py
+++ b/tests/core/stable/engines/alpha/test_guideline_matcher.py
@@ -454,6 +454,7 @@ async def create_guideline(
     guideline = Guideline(
         id=GuidelineId(generate_id()),
         creation_utc=datetime.now(timezone.utc),
+        last_modified=datetime.now(timezone.utc),
         content=GuidelineContent(
             condition=condition,
             action=action,
@@ -475,6 +476,7 @@ async def create_disambiguation_guideline(
     guideline = Guideline(
         id=GuidelineId(generate_id()),
         creation_utc=datetime.now(timezone.utc),
+        last_modified=datetime.now(timezone.utc),
         content=GuidelineContent(
             condition=condition,
             action=None,

--- a/tests/core/stable/engines/alpha/test_guideline_matcher.py
+++ b/tests/core/stable/engines/alpha/test_guideline_matcher.py
@@ -527,6 +527,7 @@ def create_context_variable(
     return ContextVariable(
         id=ContextVariableId("-"),
         creation_utc=datetime.now(timezone.utc),
+        last_modified=datetime.now(timezone.utc),
         name=name,
         description="",
         tool_id=None,

--- a/tests/core/stable/engines/alpha/test_journey_node_selection.py
+++ b/tests/core/stable/engines/alpha/test_journey_node_selection.py
@@ -1018,6 +1018,7 @@ async def create_journey(
     root_guideline = Guideline(
         id=GuidelineId("root"),
         creation_utc=datetime.now(timezone.utc),
+        last_modified=datetime.now(timezone.utc),
         content=GuidelineContent(condition="", action=None),
         criticality=Criticality.MEDIUM,
         enabled=True,
@@ -1035,6 +1036,7 @@ async def create_journey(
         Guideline(
             id=GuidelineId(node.id),
             creation_utc=datetime.now(timezone.utc),
+            last_modified=datetime.now(timezone.utc),
             content=GuidelineContent(
                 condition=node.condition or "",
                 action=node.action,

--- a/tests/core/stable/engines/alpha/test_journey_node_selection.py
+++ b/tests/core/stable/engines/alpha/test_journey_node_selection.py
@@ -985,6 +985,7 @@ def create_context_variable(
     return ContextVariable(
         id=ContextVariableId("-"),
         creation_utc=datetime.now(timezone.utc),
+        last_modified=datetime.now(timezone.utc),
         name=name,
         description="",
         tool_id=None,

--- a/tests/core/stable/engines/alpha/test_journey_node_selection.py
+++ b/tests/core/stable/engines/alpha/test_journey_node_selection.py
@@ -1076,6 +1076,7 @@ async def create_journey(
         id=journey_id,
         root_id=JourneyNodeId(root_guideline.id),
         creation_utc=datetime.now(timezone.utc),
+        last_modified=datetime.now(timezone.utc),
         description=description,
         conditions=condition_ids,
         title=title,

--- a/tests/core/stable/engines/alpha/test_journey_node_selection.py
+++ b/tests/core/stable/engines/alpha/test_journey_node_selection.py
@@ -969,6 +969,7 @@ def create_term(
     return Term(
         id=TermId("-"),
         creation_utc=datetime.now(timezone.utc),
+        last_modified=datetime.now(timezone.utc),
         name=name,
         description=description,
         synonyms=synonyms,

--- a/tests/core/stable/engines/alpha/test_previously_applied_actionable_batch.py
+++ b/tests/core/stable/engines/alpha/test_previously_applied_actionable_batch.py
@@ -130,6 +130,7 @@ def create_guideline(
     guideline = Guideline(
         id=GuidelineId(generate_id()),
         creation_utc=datetime.now(timezone.utc),
+        last_modified=datetime.now(timezone.utc),
         content=GuidelineContent(
             condition=condition,
             action=action,

--- a/tests/core/stable/engines/alpha/test_previously_applied_actionable_customer_dependent_batch.py
+++ b/tests/core/stable/engines/alpha/test_previously_applied_actionable_customer_dependent_batch.py
@@ -119,6 +119,7 @@ def create_guideline(
     guideline = Guideline(
         id=GuidelineId(generate_id()),
         creation_utc=datetime.now(timezone.utc),
+        last_modified=datetime.now(timezone.utc),
         content=GuidelineContent(
             condition=condition,
             action=action,

--- a/tests/core/stable/engines/alpha/test_tool_caller.py
+++ b/tests/core/stable/engines/alpha/test_tool_caller.py
@@ -119,6 +119,7 @@ def create_guideline_match(
     guideline = Guideline(
         id=GuidelineId(generate_id()),
         creation_utc=datetime.now(timezone.utc),
+        last_modified=datetime.now(timezone.utc),
         content=GuidelineContent(
             condition=condition,
             action=action,

--- a/tests/core/stable/services/indexing/test_agent_intention_proposer.py
+++ b/tests/core/stable/services/indexing/test_agent_intention_proposer.py
@@ -186,6 +186,7 @@ def create_guideline(
     guideline = Guideline(
         id=GuidelineId(generate_id()),
         creation_utc=datetime.now(timezone.utc),
+        last_modified=datetime.now(timezone.utc),
         content=GuidelineContent(
             condition=condition,
             action=action,

--- a/tests/core/stable/services/indexing/test_journey_reachable_nodes_evaluation.py
+++ b/tests/core/stable/services/indexing/test_journey_reachable_nodes_evaluation.py
@@ -67,6 +67,7 @@ def _make_guideline(
     return Guideline(
         id=GuidelineId(id),
         creation_utc=datetime.now(timezone.utc),
+        last_modified=datetime.now(timezone.utc),
         content=GuidelineContent(condition=condition, action=action),
         criticality=Criticality.MEDIUM,
         enabled=True,

--- a/tests/core/stable/services/indexing/test_relative_action_step_proposer.py
+++ b/tests/core/stable/services/indexing/test_relative_action_step_proposer.py
@@ -130,6 +130,7 @@ def create_journey(
         id=journey_id,
         root_id=JourneyNodeId(root_guideline.id),
         creation_utc=datetime.now(timezone.utc),
+        last_modified=datetime.now(timezone.utc),
         description="",
         conditions=[g.id for g in condition_guidelines],
         title=title,

--- a/tests/core/stable/services/indexing/test_relative_action_step_proposer.py
+++ b/tests/core/stable/services/indexing/test_relative_action_step_proposer.py
@@ -68,6 +68,7 @@ def create_journey(
         Guideline(
             id=GuidelineId(f"c-{i}"),
             creation_utc=datetime.now(timezone.utc),
+            last_modified=datetime.now(timezone.utc),
             content=GuidelineContent(condition=condition, action=None),
             criticality=Criticality.MEDIUM,
             enabled=False,
@@ -80,6 +81,7 @@ def create_journey(
     root_guideline = Guideline(
         id=GuidelineId("root"),
         creation_utc=datetime.now(timezone.utc),
+        last_modified=datetime.now(timezone.utc),
         content=GuidelineContent(condition="", action=None),
         criticality=Criticality.MEDIUM,
         enabled=True,
@@ -97,6 +99,7 @@ def create_journey(
         Guideline(
             id=GuidelineId(step.id),
             creation_utc=datetime.now(timezone.utc),
+            last_modified=datetime.now(timezone.utc),
             content=GuidelineContent(
                 condition=step.condition or "",
                 action=step.action,

--- a/tests/core/unstable/engines/alpha/test_agent_intention_proposer.py
+++ b/tests/core/unstable/engines/alpha/test_agent_intention_proposer.py
@@ -186,6 +186,7 @@ def create_guideline(
     guideline = Guideline(
         id=GuidelineId(generate_id()),
         creation_utc=datetime.now(timezone.utc),
+        last_modified=datetime.now(timezone.utc),
         content=GuidelineContent(
             condition=condition,
             action=action,

--- a/tests/core/unstable/engines/alpha/test_disambiguation_batch.py
+++ b/tests/core/unstable/engines/alpha/test_disambiguation_batch.py
@@ -191,6 +191,7 @@ def create_context_variable(
     return ContextVariable(
         id=ContextVariableId("-"),
         creation_utc=datetime.now(timezone.utc),
+        last_modified=datetime.now(timezone.utc),
         name=name,
         description="",
         tool_id=None,

--- a/tests/core/unstable/engines/alpha/test_disambiguation_batch.py
+++ b/tests/core/unstable/engines/alpha/test_disambiguation_batch.py
@@ -232,6 +232,7 @@ async def create_guideline(
     guideline = Guideline(
         id=GuidelineId(generate_id()),
         creation_utc=datetime.now(timezone.utc),
+        last_modified=datetime.now(timezone.utc),
         content=GuidelineContent(
             condition=condition,
             action=action,

--- a/tests/core/unstable/engines/alpha/test_disambiguation_batch.py
+++ b/tests/core/unstable/engines/alpha/test_disambiguation_batch.py
@@ -175,6 +175,7 @@ def create_term(
     return Term(
         id=TermId("-"),
         creation_utc=datetime.now(timezone.utc),
+        last_modified=datetime.now(timezone.utc),
         name=name,
         description=description,
         synonyms=synonyms,

--- a/tests/core/unstable/engines/alpha/test_guideline_matcher.py
+++ b/tests/core/unstable/engines/alpha/test_guideline_matcher.py
@@ -400,6 +400,7 @@ def create_context_variable(
     return ContextVariable(
         id=ContextVariableId("-"),
         creation_utc=datetime.now(timezone.utc),
+        last_modified=datetime.now(timezone.utc),
         name=name,
         description="",
         tool_id=None,

--- a/tests/core/unstable/engines/alpha/test_guideline_matcher.py
+++ b/tests/core/unstable/engines/alpha/test_guideline_matcher.py
@@ -362,6 +362,7 @@ async def create_guideline(
     guideline = Guideline(
         id=GuidelineId(generate_id()),
         creation_utc=datetime.now(timezone.utc),
+        last_modified=datetime.now(timezone.utc),
         content=GuidelineContent(
             condition=condition,
             action=action,

--- a/tests/core/unstable/engines/alpha/test_guideline_matcher.py
+++ b/tests/core/unstable/engines/alpha/test_guideline_matcher.py
@@ -384,6 +384,7 @@ def create_term(
     return Term(
         id=TermId("-"),
         creation_utc=datetime.now(timezone.utc),
+        last_modified=datetime.now(timezone.utc),
         name=name,
         description=description,
         synonyms=synonyms,

--- a/tests/sdk/test_journeys.py
+++ b/tests/sdk/test_journeys.py
@@ -2474,6 +2474,7 @@ class Test_that_link_with_condition_to_sub_journey_with_conditional_root_preserv
         )
         assert response4 == "Welcome back! How can I assist you today?"
 
+
 class Test_that_tool_state_runs_again_after_missing_data(SDKTest):
     STARTUP_TIMEOUT = 500
 

--- a/tests/sdk/test_journeys.py
+++ b/tests/sdk/test_journeys.py
@@ -2473,3 +2473,85 @@ class Test_that_link_with_condition_to_sub_journey_with_conditional_root_preserv
             reuse_session=True,
         )
         assert response4 == "Welcome back! How can I assist you today?"
+
+class Test_that_tool_state_runs_again_after_missing_data(SDKTest):
+    STARTUP_TIMEOUT = 500
+
+    async def setup(self, server: p.Server) -> None:
+        @tool
+        def find_user_id_by_name(
+            context: ToolContext, first_name: str, last_name: str
+        ) -> ToolResult:
+            return ToolResult(data={"user_id": f"{first_name.lower()}_{last_name.lower()}_8831"})
+
+        @tool
+        def find_user_id_by_email(context: ToolContext, email: str) -> ToolResult:
+            return ToolResult(data={"user_id": f"{email}_8831"})
+
+        self.agent = await server.create_agent(
+            name="Retail Agent",
+            description="You are a customer-service agent for an online retail store.",
+            max_engine_iterations=3,
+        )
+
+        self.journey = await self.agent.create_journey(
+            title="Meet & Greet",
+            description=(
+                "Start the conversation with a friendly greeting and ask for their "
+                "full name or email address to look up their account first."
+            ),
+            conditions=[await self.agent.create_observation(matcher=p.MATCH_ALWAYS)],
+        )
+
+        t0 = await self.journey.initial_state.transition_to(
+            chat_state=(
+                "Greet the customer and ask for their full name or email address "
+                "to look up their account"
+            ),
+        )
+        t1 = await t0.target.transition_to(
+            condition="The customer provides their full name",
+            tool_instruction="Look up the customer's account using the provided information",
+            tool_state=find_user_id_by_name,
+        )
+        t2 = await t0.target.transition_to(
+            condition="The customer provides their email",
+            tool_instruction="Look up the customer's account using the provided information",
+            tool_state=find_user_id_by_email,
+        )
+        t3_via_t1 = await t1.target.transition_to(
+            condition="The customer's account is successfully found using the provided information",
+            chat_state="Tell them their exact user ID for reference, and offer them a Pepsi",
+        )
+        _ = await t2.target.transition_to(
+            condition="The customer's account is successfully found using the provided information",
+            state=t3_via_t1.target,
+        )
+
+    async def run(self, ctx: Context) -> None:
+        first_response = await ctx.send_and_receive_message(
+            "I’d like to know exactly how many t-shirt options are available in your online store right now.",
+            recipient=self.agent,
+            reuse_session=True,
+        )
+
+        assert await nlp_test(first_response, "It asks for their full name or email address")
+
+        second_response = await ctx.send_and_receive_message(
+            "My name is John",
+            recipient=self.agent,
+            reuse_session=True,
+        )
+
+        assert await nlp_test(
+            second_response,
+            "It asks for the last name",
+        )
+
+        third_response = await ctx.send_and_receive_message(
+            "Smith",
+            recipient=self.agent,
+            reuse_session=True,
+        )
+
+        assert "john_smith_8831" in third_response.lower()


### PR DESCRIPTION
## Summary
- Add `last_modified: datetime` field to **Guideline**, **Term** (Glossary), **Journey**, **ContextVariable**, and **CannedResponse** entities
- Bump store versions: Guideline 0.10.0→0.11.0, Glossary 0.2.0→0.3.0, Journey 0.6.0→0.7.0, ContextVariable 0.3.0→0.4.0, CannedResponse 0.6.0→0.7.0
- Migration sets `last_modified = creation_utc` for all existing documents
- All mutation methods (update, set/unset metadata, upsert/remove labels) now update `last_modified` to current UTC time
- Added `last_modified` to API DTOs and all response constructions

## Notes
- Journey version 0.7.0 is intentionally aligned with `feature/emcie-platform` branch which also bumps to 0.7.0
- One commit per entity for clean review