### PR TITLE
Add last_modified field to all core entities

### DIFF
--- a/src/parlant/api/canned_responses.py
+++ b/src/parlant/api/canned_responses.py
@@ -30,7 +30,13 @@ from parlant.core.canned_responses import (
     CannedResponseField,
 )
 from parlant.core.tags import TagId
-from parlant.api.common import ExampleJson, JSONSerializableDTO, apigen_config, example_json_content
+from parlant.api.common import (
+    ExampleJson,
+    JSONSerializableDTO,
+    LastModifiedField,
+    apigen_config,
+    example_json_content,
+)
 
 
 API_GROUP = "canned_responses"
@@ -184,6 +190,7 @@ class CannedResponseDTO(
 ):
     id: CannedResponseIdField
     creation_utc: CannedResponseCreationUTCField
+    last_modified: LastModifiedField
     value: CannedResponseValueField
     fields: CannedResponseFieldSequenceField
     tags: TagIdSequenceField
@@ -373,6 +380,7 @@ def create_router(
         return CannedResponseDTO(
             id=canrep.id,
             creation_utc=canrep.creation_utc,
+            last_modified=canrep.last_modified,
             value=canrep.value,
             fields=[_canned_response_field_to_dto(s) for s in canrep.fields],
             tags=canrep.tags,
@@ -408,6 +416,7 @@ def create_router(
         return CannedResponseDTO(
             id=canrep.id,
             creation_utc=canrep.creation_utc,
+            last_modified=canrep.last_modified,
             value=canrep.value,
             fields=[_canned_response_field_to_dto(s) for s in canrep.fields],
             tags=canrep.tags,
@@ -440,6 +449,7 @@ def create_router(
             CannedResponseDTO(
                 id=f.id,
                 creation_utc=f.creation_utc,
+                last_modified=f.last_modified,
                 value=f.value,
                 fields=[_canned_response_field_to_dto(s) for s in f.fields],
                 tags=f.tags,
@@ -510,6 +520,7 @@ def create_router(
         return CannedResponseDTO(
             id=canrep.id,
             creation_utc=canrep.creation_utc,
+            last_modified=canrep.last_modified,
             value=canrep.value,
             fields=[_canned_response_field_to_dto(s) for s in canrep.fields],
             tags=canrep.tags,

--- a/src/parlant/api/canned_responses.py
+++ b/src/parlant/api/canned_responses.py
@@ -33,7 +33,6 @@ from parlant.core.tags import TagId
 from parlant.api.common import (
     ExampleJson,
     JSONSerializableDTO,
-    LastModifiedField,
     apigen_config,
     example_json_content,
 )
@@ -163,6 +162,13 @@ CannedResponseCreationUTCField: TypeAlias = Annotated[
     ),
 ]
 
+CannedResponseLastModifiedField: TypeAlias = Annotated[
+    datetime,
+    Field(
+        description="UTC timestamp of the last modification to the canned response",
+    ),
+]
+
 CannedResponseValueField: TypeAlias = Annotated[
     str,
     Field(
@@ -190,7 +196,7 @@ class CannedResponseDTO(
 ):
     id: CannedResponseIdField
     creation_utc: CannedResponseCreationUTCField
-    last_modified: LastModifiedField
+    last_modified: CannedResponseLastModifiedField
     value: CannedResponseValueField
     fields: CannedResponseFieldSequenceField
     tags: TagIdSequenceField

--- a/src/parlant/api/common.py
+++ b/src/parlant/api/common.py
@@ -137,14 +137,6 @@ JSONSerializableDTO: TypeAlias = Annotated[
 ]
 
 
-LastModifiedField: TypeAlias = Annotated[
-    datetime,
-    Field(
-        description="Timestamp of the last modification",
-    ),
-]
-
-
 class EvaluationStatusDTO(Enum):
     """
     Current state of an evaluation task
@@ -292,6 +284,13 @@ def example_json_content(json_example: ExampleJson) -> ExtraSchema:
     return {"application/json": {"example": json_example}}
 
 
+GuidelineLastModifiedField: TypeAlias = Annotated[
+    datetime,
+    Field(
+        description="UTC timestamp of the last modification to the guideline",
+    ),
+]
+
 GuidelineMetadataField: TypeAlias = Annotated[
     Mapping[str, JSONSerializableDTO],
     Field(description="Metadata for the guideline"),
@@ -349,7 +348,7 @@ class GuidelineDTO(
     enabled: GuidelineEnabledField = True
     tags: GuidelineTagsField
     metadata: GuidelineMetadataField
-    last_modified: LastModifiedField
+    last_modified: GuidelineLastModifiedField
     composition_mode: CompositionModeDTO | None = None
     track: bool = True
     labels: GuidelineLabelsField = set()

--- a/src/parlant/api/common.py
+++ b/src/parlant/api/common.py
@@ -137,6 +137,14 @@ JSONSerializableDTO: TypeAlias = Annotated[
 ]
 
 
+LastModifiedField: TypeAlias = Annotated[
+    datetime,
+    Field(
+        description="Timestamp of the last modification",
+    ),
+]
+
+
 class EvaluationStatusDTO(Enum):
     """
     Current state of an evaluation task
@@ -341,6 +349,7 @@ class GuidelineDTO(
     enabled: GuidelineEnabledField = True
     tags: GuidelineTagsField
     metadata: GuidelineMetadataField
+    last_modified: LastModifiedField
     composition_mode: CompositionModeDTO | None = None
     track: bool = True
     labels: GuidelineLabelsField = set()

--- a/src/parlant/api/context_variables.py
+++ b/src/parlant/api/context_variables.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 from pydantic import Field, field_validator
-from datetime import datetime
 from croniter import croniter
 from fastapi import HTTPException, Path, Query, Request, status
 from typing import Annotated, Sequence, TypeAlias, cast
@@ -22,6 +21,7 @@ from fastapi import APIRouter
 from parlant.api import common
 from parlant.api.authorization import AuthorizationPolicy, Operation
 from parlant.api.common import (
+    LastModifiedField,
     ToolIdDTO,
     JSONSerializableDTO,
     apigen_config,
@@ -93,13 +93,6 @@ ValueIdField: TypeAlias = Annotated[
     Field(
         description="Unique identifier for the variable value",
         examples=["val_789abc"],
-    ),
-]
-
-LastModifiedField: TypeAlias = Annotated[
-    datetime,
-    Field(
-        description="Timestamp of the last modification",
     ),
 ]
 
@@ -225,6 +218,7 @@ class ContextVariableDTO(
     tool_id: ToolIdDTO | None = None
     freshness_rules: FreshnessRulesField | None = None
     tags: ContextVariableTagsField | None = None
+    last_modified: LastModifiedField
 
 
 context_variable_tags_update_params_example: ExampleJson = {
@@ -412,6 +406,7 @@ def create_router(
             else None,
             freshness_rules=variable.freshness_rules,
             tags=variable.tags,
+            last_modified=variable.last_modified,
         )
 
     @router.patch(
@@ -473,6 +468,7 @@ def create_router(
             else None,
             freshness_rules=updated_variable.freshness_rules,
             tags=updated_variable.tags,
+            last_modified=updated_variable.last_modified,
         )
 
     @router.get(
@@ -509,6 +505,7 @@ def create_router(
                 else None,
                 freshness_rules=v.freshness_rules,
                 tags=v.tags,
+                last_modified=v.last_modified,
             )
             for v in variables
         ]
@@ -554,6 +551,7 @@ def create_router(
             else None,
             freshness_rules=variable.freshness_rules,
             tags=variable.tags,
+            last_modified=variable.last_modified,
         )
 
         if not include_values:

--- a/src/parlant/api/context_variables.py
+++ b/src/parlant/api/context_variables.py
@@ -20,8 +20,8 @@ from typing import Annotated, Sequence, TypeAlias, cast
 from fastapi import APIRouter
 from parlant.api import common
 from parlant.api.authorization import AuthorizationPolicy, Operation
+from datetime import datetime
 from parlant.api.common import (
-    LastModifiedField,
     ToolIdDTO,
     JSONSerializableDTO,
     apigen_config,
@@ -101,6 +101,20 @@ DataField: TypeAlias = Annotated[
     JSONSerializableDTO,
     Field(
         description="The actual data stored in the variable",
+    ),
+]
+
+LastModifiedField: TypeAlias = Annotated[
+    datetime,
+    Field(
+        description="Timestamp of the last modification",
+    ),
+]
+
+ContextVariableLastModifiedField: TypeAlias = Annotated[
+    datetime,
+    Field(
+        description="UTC timestamp of the last modification to the context variable",
     ),
 ]
 
@@ -218,7 +232,7 @@ class ContextVariableDTO(
     tool_id: ToolIdDTO | None = None
     freshness_rules: FreshnessRulesField | None = None
     tags: ContextVariableTagsField | None = None
-    last_modified: LastModifiedField
+    last_modified: ContextVariableLastModifiedField
 
 
 context_variable_tags_update_params_example: ExampleJson = {

--- a/src/parlant/api/glossary.py
+++ b/src/parlant/api/glossary.py
@@ -18,7 +18,8 @@ from pydantic import Field
 
 from parlant.api import common
 from parlant.api.authorization import Operation, AuthorizationPolicy
-from parlant.api.common import LastModifiedField, apigen_config, ExampleJson
+from datetime import datetime
+from parlant.api.common import apigen_config, ExampleJson
 from parlant.core.app_modules.glossary import TermTagsUpdateParamsModel
 from parlant.core.agents import AgentId
 from parlant.core.application import Application
@@ -88,6 +89,13 @@ TermTagsField: TypeAlias = Annotated[
     ),
 ]
 
+TermLastModifiedField: TypeAlias = Annotated[
+    datetime,
+    Field(
+        description="UTC timestamp of the last modification to the term",
+    ),
+]
+
 
 class TermCreationParamsDTO(
     DefaultBaseModel,
@@ -151,7 +159,7 @@ class TermDTO(
     description: TermDescriptionField
     synonyms: TermSynonymsField = []
     tags: TermTagsField
-    last_modified: LastModifiedField
+    last_modified: TermLastModifiedField
 
 
 TermTagsUpdateAddField: TypeAlias = Annotated[

--- a/src/parlant/api/glossary.py
+++ b/src/parlant/api/glossary.py
@@ -18,7 +18,7 @@ from pydantic import Field
 
 from parlant.api import common
 from parlant.api.authorization import Operation, AuthorizationPolicy
-from parlant.api.common import apigen_config, ExampleJson
+from parlant.api.common import LastModifiedField, apigen_config, ExampleJson
 from parlant.core.app_modules.glossary import TermTagsUpdateParamsModel
 from parlant.core.agents import AgentId
 from parlant.core.application import Application
@@ -151,6 +151,7 @@ class TermDTO(
     description: TermDescriptionField
     synonyms: TermSynonymsField = []
     tags: TermTagsField
+    last_modified: LastModifiedField
 
 
 TermTagsUpdateAddField: TypeAlias = Annotated[
@@ -264,6 +265,7 @@ def create_router(
             description=term.description,
             synonyms=term.synonyms,
             tags=term.tags,
+            last_modified=term.last_modified,
         )
 
     @router.get(
@@ -298,6 +300,7 @@ def create_router(
             description=term.description,
             synonyms=term.synonyms,
             tags=term.tags,
+            last_modified=term.last_modified,
         )
 
     @router.get(
@@ -333,6 +336,7 @@ def create_router(
                 description=term.description,
                 synonyms=term.synonyms,
                 tags=term.tags,
+                last_modified=term.last_modified,
             )
             for term in terms
         ]
@@ -387,6 +391,7 @@ def create_router(
             description=term.description,
             synonyms=term.synonyms,
             tags=term.tags,
+            last_modified=term.last_modified,
         )
 
     @router.delete(

--- a/src/parlant/api/guidelines.py
+++ b/src/parlant/api/guidelines.py
@@ -439,6 +439,7 @@ def _guideline_relationship_to_dto(
             enabled=rel_source_guideline.enabled,
             tags=rel_source_guideline.tags,
             metadata=rel_source_guideline.metadata,
+            last_modified=rel_source_guideline.last_modified,
             composition_mode=composition_mode_to_composition_mode_dto(
                 rel_source_guideline.composition_mode
             )
@@ -467,6 +468,7 @@ def _guideline_relationship_to_dto(
             enabled=rel_target_guideline.enabled,
             tags=rel_target_guideline.tags,
             metadata=rel_target_guideline.metadata,
+            last_modified=rel_target_guideline.last_modified,
             composition_mode=composition_mode_to_composition_mode_dto(
                 rel_target_guideline.composition_mode
             )
@@ -558,6 +560,7 @@ def create_router(
             description=guideline.content.description,
             criticality=_criticality_to_dto(guideline.criticality),
             metadata=guideline.metadata,
+            last_modified=guideline.last_modified,
             enabled=guideline.enabled,
             tags=guideline.tags,
             composition_mode=composition_mode_to_composition_mode_dto(guideline.composition_mode)
@@ -603,6 +606,7 @@ def create_router(
                 description=guideline.content.description,
                 criticality=_criticality_to_dto(guideline.criticality),
                 metadata=guideline.metadata,
+                last_modified=guideline.last_modified,
                 enabled=guideline.enabled,
                 tags=guideline.tags,
                 composition_mode=composition_mode_to_composition_mode_dto(
@@ -667,6 +671,7 @@ def create_router(
                 description=guideline.content.description,
                 criticality=_criticality_to_dto(guideline.criticality),
                 metadata=guideline.metadata,
+                last_modified=guideline.last_modified,
                 enabled=guideline.enabled,
                 tags=guideline.tags,
                 composition_mode=composition_mode_to_composition_mode_dto(
@@ -789,6 +794,7 @@ def create_router(
                 description=updated_guideline.content.description,
                 criticality=_criticality_to_dto(updated_guideline.criticality),
                 metadata=updated_guideline.metadata,
+                last_modified=updated_guideline.last_modified,
                 enabled=updated_guideline.enabled,
                 tags=updated_guideline.tags,
                 composition_mode=composition_mode_to_composition_mode_dto(

--- a/src/parlant/api/journeys.py
+++ b/src/parlant/api/journeys.py
@@ -23,7 +23,6 @@ from parlant.api.authorization import Operation, AuthorizationPolicy
 from parlant.api.common import (
     CompositionModeDTO,
     ExampleJson,
-    LastModifiedField,
     apigen_config,
     composition_mode_dto_to_composition_mode,
     composition_mode_to_composition_mode_dto,
@@ -108,6 +107,13 @@ JourneyLabelsField: TypeAlias = Annotated[
     ),
 ]
 
+JourneyLastModifiedField: TypeAlias = Annotated[
+    datetime,
+    Field(
+        description="UTC timestamp of the last modification to the journey",
+    ),
+]
+
 journey_example: ExampleJson = {
     "id": "IUCGT-lvpS",
     "title": "Customer Onboarding",
@@ -177,7 +183,7 @@ class JourneyDTO(
     composition_mode: CompositionModeDTO | None = None
     labels: JourneyLabelsField = set()
     priority: int = 0
-    last_modified: LastModifiedField
+    last_modified: JourneyLastModifiedField
 
 
 class JourneyGraphDTO(JourneyDTO):

--- a/src/parlant/api/journeys.py
+++ b/src/parlant/api/journeys.py
@@ -23,6 +23,7 @@ from parlant.api.authorization import Operation, AuthorizationPolicy
 from parlant.api.common import (
     CompositionModeDTO,
     ExampleJson,
+    LastModifiedField,
     apigen_config,
     composition_mode_dto_to_composition_mode,
     composition_mode_to_composition_mode_dto,
@@ -176,6 +177,7 @@ class JourneyDTO(
     composition_mode: CompositionModeDTO | None = None
     labels: JourneyLabelsField = set()
     priority: int = 0
+    last_modified: LastModifiedField
 
 
 class JourneyGraphDTO(JourneyDTO):
@@ -518,6 +520,7 @@ def create_router(
             else None,
             labels=journey.labels,
             priority=journey.priority,
+            last_modified=journey.last_modified,
         )
 
     @router.get(
@@ -559,6 +562,7 @@ def create_router(
                     else None,
                     labels=journey.labels,
                     priority=journey.priority,
+                    last_modified=journey.last_modified,
                 )
             )
 
@@ -624,6 +628,7 @@ def create_router(
             else None,
             labels=model.journey.labels,
             priority=model.journey.priority,
+            last_modified=model.journey.last_modified,
             nodes=[node_to_dto(n) for n in model.nodes],
             edges=[edge_to_dto(e) for e in model.edges],
         )
@@ -720,6 +725,7 @@ def create_router(
             else None,
             labels=journey.labels,
             priority=journey.priority,
+            last_modified=journey.last_modified,
         )
 
     @router.delete(

--- a/src/parlant/api/relationships.py
+++ b/src/parlant/api/relationships.py
@@ -177,6 +177,7 @@ def create_router(
                 enabled=model.source_guideline.enabled,
                 tags=model.source_guideline.tags,
                 metadata=model.source_guideline.metadata,
+                last_modified=model.source_guideline.last_modified,
                 priority=model.source_guideline.priority,
             )
             if model.source_guideline
@@ -194,6 +195,7 @@ def create_router(
                 enabled=model.target_guideline.enabled,
                 tags=model.target_guideline.tags,
                 metadata=model.target_guideline.metadata,
+                last_modified=model.target_guideline.last_modified,
                 priority=model.target_guideline.priority,
             )
             if model.target_guideline

--- a/src/parlant/core/canned_responses.py
+++ b/src/parlant/core/canned_responses.py
@@ -74,11 +74,13 @@ class CannedResponse:
     def create_transient(
         value: str,
     ) -> CannedResponse:
+        now = datetime.now()
         return CannedResponse(
             id=CannedResponse.TRANSIENT_ID,
             value=value,
             fields=[],
-            creation_utc=datetime.now(),
+            creation_utc=now,
+            last_modified=now,
             tags=[],
             signals=[],
             metadata={},
@@ -90,6 +92,7 @@ class CannedResponse:
 
     id: CannedResponseId
     creation_utc: datetime
+    last_modified: datetime
     value: str
     fields: Sequence[CannedResponseField]
     signals: Sequence[str]
@@ -232,10 +235,22 @@ class CannedResponseDocument_v0_5_0(TypedDict, total=False):
     metadata: Mapping[str, JSONSerializable]
 
 
+class CannedResponseDocument_v0_6_0(TypedDict, total=False):
+    id: ObjectId
+    version: Version.String
+    creation_utc: str
+    value: str
+    fields: str
+    signals: Sequence[str]
+    metadata: Mapping[str, JSONSerializable]
+    field_dependencies: Sequence[str]
+
+
 class CannedResponseDocument(TypedDict, total=False):
     id: ObjectId
     version: Version.String
     creation_utc: str
+    last_modified: str
     value: str
     fields: str
     signals: Sequence[str]
@@ -268,7 +283,7 @@ class CannedResponseTagAssociationDocument(TypedDict, total=False):
 
 
 class CannedResponseVectorStore(CannedResponseStore):
-    VERSION = Version.from_string("0.6.0")
+    VERSION = Version.from_string("0.7.0")
 
     def __init__(
         self,
@@ -327,6 +342,17 @@ class CannedResponseVectorStore(CannedResponseStore):
                 checksum=doc["checksum"],
             )
 
+        async def v0_6_0_to_v0_7_0(doc: VectorDocument) -> Optional[VectorDocument]:
+            doc = cast(CannedResponseVectorDocument, doc)
+
+            return CannedResponseVectorDocument(
+                id=doc["id"],
+                canned_response_id=doc["canned_response_id"],
+                version=Version.String("0.7.0"),
+                content=doc["content"],
+                checksum=doc["checksum"],
+            )
+
         return await VectorDocumentMigrationHelper[CannedResponseVectorDocument](
             self,
             {
@@ -335,6 +361,7 @@ class CannedResponseVectorStore(CannedResponseStore):
                 "0.3.0": v0_1_0_to_v0_4_0,
                 "0.4.0": v0_4_0_to_v0_5_0,
                 "0.5.0": v0_5_0_to_v0_6_0,
+                "0.6.0": v0_6_0_to_v0_7_0,
             },
         ).migrate(doc)
 
@@ -360,7 +387,7 @@ class CannedResponseVectorStore(CannedResponseStore):
         async def v0_5_0_to_v0_6_0(doc: BaseDocument) -> Optional[BaseDocument]:
             doc = cast(CannedResponseDocument_v0_5_0, doc)
 
-            return CannedResponseDocument(
+            return CannedResponseDocument_v0_6_0(
                 id=doc["id"],
                 version=Version.String("0.6.0"),
                 creation_utc=doc["creation_utc"],
@@ -371,6 +398,21 @@ class CannedResponseVectorStore(CannedResponseStore):
                 field_dependencies=[],
             )
 
+        async def v0_6_0_to_v0_7_0(doc: BaseDocument) -> Optional[BaseDocument]:
+            d = cast(CannedResponseDocument_v0_6_0, doc)
+
+            return CannedResponseDocument(
+                id=d["id"],
+                version=Version.String("0.7.0"),
+                creation_utc=d["creation_utc"],
+                last_modified=d["creation_utc"],
+                value=d["value"],
+                fields=d["fields"],
+                signals=d["signals"],
+                metadata=d.get("metadata", {}),
+                field_dependencies=d.get("field_dependencies", []),
+            )
+
         return await DocumentMigrationHelper[CannedResponseDocument](
             self,
             {
@@ -379,6 +421,7 @@ class CannedResponseVectorStore(CannedResponseStore):
                 "0.3.0": v0_1_0_to_v0_4_0,
                 "0.4.0": v0_4_0_to_v0_5_0,
                 "0.5.0": v0_5_0_to_v0_6_0,
+                "0.6.0": v0_6_0_to_v0_7_0,
             },
         ).migrate(doc)
 
@@ -434,6 +477,17 @@ class CannedResponseVectorStore(CannedResponseStore):
                 tag_id=TagId(doc["tag_id"]),
             )
 
+        async def v0_6_0_to_v0_7_0(doc: BaseDocument) -> Optional[BaseDocument]:
+            doc = cast(CannedResponseTagAssociationDocument, doc)
+
+            return CannedResponseTagAssociationDocument(
+                id=doc["id"],
+                version=Version.String("0.7.0"),
+                creation_utc=doc["creation_utc"],
+                canned_response_id=CannedResponseId(doc["canned_response_id"]),
+                tag_id=TagId(doc["tag_id"]),
+            )
+
         return await DocumentMigrationHelper[CannedResponseTagAssociationDocument](
             self,
             {
@@ -442,6 +496,7 @@ class CannedResponseVectorStore(CannedResponseStore):
                 "0.3.0": v0_3_0_to_v0_4_0,
                 "0.4.0": v0_4_0_to_v0_5_0,
                 "0.5.0": v0_5_0_to_v0_6_0,
+                "0.6.0": v0_6_0_to_v0_7_0,
             },
         ).migrate(doc)
 
@@ -504,6 +559,7 @@ class CannedResponseVectorStore(CannedResponseStore):
             id=ObjectId(canned_response_id.id),
             version=self.VERSION.to_string(),
             creation_utc=canned_response_id.creation_utc.isoformat(),
+            last_modified=canned_response_id.last_modified.isoformat(),
             value=canned_response_id.value,
             fields=json.dumps(
                 [
@@ -529,6 +585,11 @@ class CannedResponseVectorStore(CannedResponseStore):
         return CannedResponse(
             id=CannedResponseId(canned_response_document["id"]),
             creation_utc=datetime.fromisoformat(canned_response_document["creation_utc"]),
+            last_modified=datetime.fromisoformat(
+                canned_response_document.get(
+                    "last_modified", canned_response_document["creation_utc"]
+                )
+            ),
             value=canned_response_document["value"],
             fields=[
                 CannedResponseField(
@@ -593,6 +654,7 @@ class CannedResponseVectorStore(CannedResponseStore):
                 value=value,
                 fields=fields or [],
                 creation_utc=creation_utc,
+                last_modified=creation_utc,
                 metadata=metadata,
                 tags=tags or [],
                 signals=signals or [],
@@ -670,6 +732,7 @@ class CannedResponseVectorStore(CannedResponseStore):
             canrep = CannedResponse(
                 id=CannedResponseId(canned_response_id),
                 creation_utc=datetime.fromisoformat(doc["creation_utc"]),
+                last_modified=datetime.now(timezone.utc),
                 value=params.get("value", existing_value.value),
                 fields=params.get("fields", existing_value.fields),
                 signals=params.get("signals", existing_value.signals),

--- a/src/parlant/core/context_variables.py
+++ b/src/parlant/core/context_variables.py
@@ -53,6 +53,7 @@ class ContextVariable:
     name: str
     description: Optional[str]
     creation_utc: datetime
+    last_modified: datetime
     tool_id: Optional[ToolId]
     freshness_rules: Optional[str]
     tags: Sequence[TagId]
@@ -178,9 +179,20 @@ class _ContextVariableDocument_v0_2_0(TypedDict, total=False):
     freshness_rules: Optional[str]
 
 
+class _ContextVariableDocument_v0_3_0(TypedDict, total=False):
+    id: ObjectId
+    creation_utc: str
+    version: Version.String
+    name: str
+    description: Optional[str]
+    tool_id: Optional[str]
+    freshness_rules: Optional[str]
+
+
 class _ContextVariableDocument(TypedDict, total=False):
     id: ObjectId
     creation_utc: str
+    last_modified: str
     version: Version.String
     name: str
     description: Optional[str]
@@ -227,7 +239,7 @@ class ContextVariableTagAssociationDocument(TypedDict, total=False):
 
 
 class ContextVariableDocumentStore(ContextVariableStore):
-    VERSION = Version.from_string("0.3.0")
+    VERSION = Version.from_string("0.4.0")
 
     def __init__(
         self,
@@ -260,10 +272,24 @@ class ContextVariableDocumentStore(ContextVariableStore):
         async def v0_2_0_to_v0_3_0(doc: BaseDocument) -> Optional[BaseDocument]:
             d = cast(_ContextVariableDocument_v0_2_0, doc)
 
-            return _ContextVariableDocument(
+            return _ContextVariableDocument_v0_3_0(
                 id=d["id"],
                 creation_utc=datetime.now(timezone.utc).isoformat(),
                 version=Version.String("0.3.0"),
+                name=d["name"],
+                description=d.get("description"),
+                tool_id=d.get("tool_id"),
+                freshness_rules=d.get("freshness_rules"),
+            )
+
+        async def v0_3_0_to_v0_4_0(doc: BaseDocument) -> Optional[BaseDocument]:
+            d = cast(_ContextVariableDocument_v0_3_0, doc)
+
+            return _ContextVariableDocument(
+                id=d["id"],
+                creation_utc=d["creation_utc"],
+                last_modified=d["creation_utc"],
+                version=Version.String("0.4.0"),
                 name=d["name"],
                 description=d.get("description"),
                 tool_id=d.get("tool_id"),
@@ -275,6 +301,7 @@ class ContextVariableDocumentStore(ContextVariableStore):
             {
                 "0.1.0": v0_1_0_to_v0_2_0,
                 "0.2.0": v0_2_0_to_v0_3_0,
+                "0.3.0": v0_3_0_to_v0_4_0,
             },
         ).migrate(doc)
 
@@ -305,11 +332,24 @@ class ContextVariableDocumentStore(ContextVariableStore):
                 data=d["data"],
             )
 
+        async def v0_3_0_to_v0_4_0(doc: BaseDocument) -> Optional[BaseDocument]:
+            d = cast(_ContextVariableValueDocument, doc)
+            return _ContextVariableValueDocument(
+                id=d["id"],
+                creation_utc=d.get("creation_utc", datetime.now(timezone.utc).isoformat()),
+                version=Version.String("0.4.0"),
+                last_modified=d["last_modified"],
+                variable_id=d["variable_id"],
+                key=d["key"],
+                data=d["data"],
+            )
+
         return await DocumentMigrationHelper[_ContextVariableValueDocument](
             self,
             {
                 "0.1.0": v0_1_0_to_v0_2_0,
                 "0.2.0": v0_2_0_to_v0_3_0,
+                "0.3.0": v0_3_0_to_v0_4_0,
             },
         ).migrate(doc)
 
@@ -338,11 +378,22 @@ class ContextVariableDocumentStore(ContextVariableStore):
                 tag_id=d["tag_id"],
             )
 
+        async def v0_3_0_to_v0_4_0(doc: BaseDocument) -> Optional[BaseDocument]:
+            d = cast(ContextVariableTagAssociationDocument, doc)
+            return ContextVariableTagAssociationDocument(
+                id=d["id"],
+                creation_utc=d["creation_utc"],
+                version=Version.String("0.4.0"),
+                variable_id=d["variable_id"],
+                tag_id=d["tag_id"],
+            )
+
         return await DocumentMigrationHelper[ContextVariableTagAssociationDocument](
             self,
             {
                 "0.1.0": v0_1_0_to_v0_2_0,
                 "0.2.0": v0_2_0_to_v0_3_0,
+                "0.3.0": v0_3_0_to_v0_4_0,
             },
         ).migrate(doc)
 
@@ -396,6 +447,7 @@ class ContextVariableDocumentStore(ContextVariableStore):
             name=context_variable.name,
             description=context_variable.description,
             creation_utc=context_variable.creation_utc.isoformat(),
+            last_modified=context_variable.last_modified.isoformat(),
             tool_id=context_variable.tool_id.to_string() if context_variable.tool_id else None,
             freshness_rules=context_variable.freshness_rules,
         )
@@ -434,6 +486,7 @@ class ContextVariableDocumentStore(ContextVariableStore):
             name=context_variable_document["name"],
             description=context_variable_document.get("description"),
             creation_utc=datetime.fromisoformat(context_variable_document["creation_utc"]),
+            last_modified=datetime.fromisoformat(context_variable_document["last_modified"]),
             tool_id=ToolId.from_string(context_variable_document["tool_id"])
             if context_variable_document["tool_id"]
             else None,
@@ -472,6 +525,7 @@ class ContextVariableDocumentStore(ContextVariableStore):
                 name=name,
                 description=description,
                 creation_utc=creation_utc,
+                last_modified=creation_utc,
                 tool_id=tool_id,
                 freshness_rules=freshness_rules,
                 tags=tags or [],
@@ -529,6 +583,7 @@ class ContextVariableDocumentStore(ContextVariableStore):
                         else None
                     }
                 ),
+                "last_modified": datetime.now(timezone.utc).isoformat(),
             }
 
             result = await self._variable_collection.update_one(

--- a/src/parlant/core/engines/alpha/engine.py
+++ b/src/parlant/core/engines/alpha/engine.py
@@ -1190,8 +1190,6 @@ class AlphaEngine(Engine):
                         "journey_path": json.dumps(
                             match.metadata.get("journey_path_guideline_ids", [])
                         ),
-                        "condition": match.guideline.content.condition,
-                        "action": match.guideline.content.action or "",
                         "rationale": match.rationale,
                         "journey_id": journey_id,
                         **(
@@ -1225,8 +1223,6 @@ class AlphaEngine(Engine):
                     attributes={
                         "guideline_id": match.guideline.id,
                         "last_modified": match.guideline.last_modified.isoformat(),
-                        "condition": match.guideline.content.condition,
-                        "action": match.guideline.content.action or "",
                         "rationale": match.rationale,
                     },
                 )
@@ -1242,8 +1238,6 @@ class AlphaEngine(Engine):
                         "node_id": extract_node_id_from_journey_node_guideline_id(
                             skip.guideline.id
                         ),
-                        "condition": skip.guideline.content.condition,
-                        "action": skip.guideline.content.action or "",
                         "rationale": skip.rationale,
                         "journey_path": json.dumps(
                             skip.guideline.metadata.get("journey_path_guideline_ids", [])
@@ -1274,8 +1268,6 @@ class AlphaEngine(Engine):
                     "gm.skipped",
                     attributes={
                         "guideline_id": skip.guideline.id,
-                        "condition": skip.guideline.content.condition,
-                        "action": skip.guideline.content.action or "",
                         "rationale": skip.rationale,
                     },
                 )

--- a/src/parlant/core/engines/alpha/engine.py
+++ b/src/parlant/core/engines/alpha/engine.py
@@ -1058,7 +1058,10 @@ class AlphaEngine(Engine):
                 )
             )
 
-            event_data["matched_guidelines"] = [{"id": m.guideline.id} for m in all_matches]
+            event_data["matched_guidelines"] = [
+                {"id": m.guideline.id, "last_modified": m.guideline.last_modified.isoformat()}
+                for m in all_matches
+            ]
 
             event_data["matched_journeys"] = [{"id": j.id} for j in context.state.journeys]
 
@@ -1206,6 +1209,7 @@ class AlphaEngine(Engine):
                     "gm.activate",
                     attributes={
                         "guideline_id": match.guideline.id,
+                        "last_modified": match.guideline.last_modified.isoformat(),
                         "condition": match.guideline.content.condition,
                         "action": match.guideline.content.action or "",
                         "rationale": match.rationale,
@@ -2017,6 +2021,7 @@ class AlphaEngine(Engine):
                 guideline=Guideline(
                     id=GuidelineId(f"<canrep-request-{i}>"),
                     creation_utc=datetime.now(timezone.utc),
+                    last_modified=datetime.now(timezone.utc),
                     content=GuidelineContent(
                         condition="",  # FIXME: Change this to None when we support `str | None` conditions
                         action=utterance_request.action,
@@ -2090,6 +2095,7 @@ class AlphaEngine(Engine):
                             guideline=Guideline(
                                 id=GuidelineId(f"<tool-guideline-{guideline_index}>"),
                                 creation_utc=datetime.now(timezone.utc),
+                                last_modified=datetime.now(timezone.utc),
                                 content=GuidelineContent(
                                     condition=guideline_data.get("condition", ""),
                                     action=guideline_data["action"],

--- a/src/parlant/core/engines/alpha/engine.py
+++ b/src/parlant/core/engines/alpha/engine.py
@@ -1063,7 +1063,10 @@ class AlphaEngine(Engine):
                 for m in all_matches
             ]
 
-            event_data["matched_journeys"] = [{"id": j.id} for j in context.state.journeys]
+            event_data["matched_journeys"] = [
+                {"id": j.id, "last_modified": j.last_modified.isoformat()}
+                for j in context.state.journeys
+            ]
 
             # Extract journey states from guideline matches with journey_node metadata
             event_data["matched_journey_states"] = [

--- a/src/parlant/core/engines/alpha/engine.py
+++ b/src/parlant/core/engines/alpha/engine.py
@@ -1168,10 +1168,17 @@ class AlphaEngine(Engine):
         self,
         matched_guidelines: Sequence[GuidelineMatch],
         skipped_guidelines: Sequence[GuidelineMatch],
+        journeys: Optional[Mapping[JourneyId, Journey]] = None,
     ) -> None:
         for match in matched_guidelines:
             if match.guideline.metadata.get("journey_node"):
                 edge_id = extract_edge_id_from_journey_node_guideline_id(match.guideline.id)
+                journey_id = cast(str, match.metadata.get("step_selection_journey_id"))
+                journey_last_modified = ""
+                if journeys and journey_id:
+                    j = journeys.get(JourneyId(journey_id))
+                    if j:
+                        journey_last_modified = j.last_modified.isoformat()
 
                 self._tracer.add_event(
                     "journey.state.activate",
@@ -1186,7 +1193,12 @@ class AlphaEngine(Engine):
                         "condition": match.guideline.content.condition,
                         "action": match.guideline.content.action or "",
                         "rationale": match.rationale,
-                        "journey_id": cast(str, match.metadata.get("step_selection_journey_id")),
+                        "journey_id": journey_id,
+                        **(
+                            {"last_modified": journey_last_modified}
+                            if journey_last_modified
+                            else {}
+                        ),
                         **(
                             {
                                 "sub_journey_id": cast(
@@ -1380,6 +1392,7 @@ class AlphaEngine(Engine):
                     ).difference(resolver_result.matches)
                 )
             ),
+            journeys={j.id: j for j in activated_journeys},
         )
 
         return _GuidelineAndJourneyMatchingResult(
@@ -1492,6 +1505,7 @@ class AlphaEngine(Engine):
                     ).difference(resolver_result.matches)
                 )
             ),
+            journeys={j.id: j for j in all_activated_journeys},
         )
 
         return _GuidelineAndJourneyMatchingResult(

--- a/src/parlant/core/engines/alpha/guideline_matching/generic/generic_guideline_matching_strategy.py
+++ b/src/parlant/core/engines/alpha/guideline_matching/generic/generic_guideline_matching_strategy.py
@@ -317,6 +317,7 @@ class GenericGuidelineMatchingStrategy(GuidelineMatchingStrategy):
                         guideline=Guideline(
                             id=cast(GuidelineId, f"<transient_{generate_id()}>"),
                             creation_utc=datetime.now(),
+                            last_modified=datetime.now(),
                             content=GuidelineContent(
                                 condition=internal_representation(m.guideline).condition,
                                 action=cast(

--- a/src/parlant/core/engines/alpha/guideline_matching/generic/journey/journey_backtrack_check.py
+++ b/src/parlant/core/engines/alpha/guideline_matching/generic/journey/journey_backtrack_check.py
@@ -522,6 +522,7 @@ OUTPUT FORMAT
                     Guideline(
                         id=GuidelineId(f"c-{i}"),
                         creation_utc=datetime.now(timezone.utc),
+                        last_modified=datetime.now(timezone.utc),
                         metadata={"journey_node": {"journey_id": "journey"}},
                         content=GuidelineContent(
                             condition=c,

--- a/src/parlant/core/engines/alpha/guideline_matching/generic/journey/journey_backtrack_node_selection.py
+++ b/src/parlant/core/engines/alpha/guideline_matching/generic/journey/journey_backtrack_node_selection.py
@@ -575,6 +575,7 @@ class JourneyBacktrackNodeSelection:
                     Guideline(
                         id=GuidelineId(f"c-{i}"),
                         creation_utc=datetime.now(timezone.utc),
+                        last_modified=datetime.now(timezone.utc),
                         metadata={"journey_node": {"journey_id": "journey"}},
                         content=GuidelineContent(
                             condition=c,

--- a/src/parlant/core/engines/alpha/guideline_matching/generic/journey/journey_next_step_selection.py
+++ b/src/parlant/core/engines/alpha/guideline_matching/generic/journey/journey_next_step_selection.py
@@ -528,6 +528,7 @@ OUTPUT FORMAT
                 Guideline(
                     id=GuidelineId(f"c-{i}"),
                     creation_utc=datetime.now(timezone.utc),
+                    last_modified=datetime.now(timezone.utc),
                     metadata={"journey_node": {"journey_id": "journey"}},
                     content=GuidelineContent(
                         condition=c,

--- a/src/parlant/core/engines/alpha/relational_resolver.py
+++ b/src/parlant/core/engines/alpha/relational_resolver.py
@@ -1382,8 +1382,6 @@ class RelationalResolver:
                     attributes={
                         "guideline_id": match.guideline.id,
                         "last_modified": match.guideline.last_modified.isoformat(),
-                        "condition": match.guideline.content.condition,
-                        "action": match.guideline.content.action or "",
                         "rationale": "Activated via entailment",
                     },
                 )
@@ -1399,8 +1397,6 @@ class RelationalResolver:
                 attributes={
                     "guideline_id": gid,
                     "last_modified": m.guideline.last_modified.isoformat(),
-                    "condition": m.guideline.content.condition,
-                    "action": m.guideline.content.action or "",
                     "rationale": rationale,
                 },
             )

--- a/src/parlant/core/engines/alpha/relational_resolver.py
+++ b/src/parlant/core/engines/alpha/relational_resolver.py
@@ -1381,6 +1381,7 @@ class RelationalResolver:
                     "gm.activate",
                     attributes={
                         "guideline_id": match.guideline.id,
+                        "last_modified": match.guideline.last_modified.isoformat(),
                         "condition": match.guideline.content.condition,
                         "action": match.guideline.content.action or "",
                         "rationale": "Activated via entailment",
@@ -1397,6 +1398,7 @@ class RelationalResolver:
                 "gm.deactivate",
                 attributes={
                     "guideline_id": gid,
+                    "last_modified": m.guideline.last_modified.isoformat(),
                     "condition": m.guideline.content.condition,
                     "action": m.guideline.content.action or "",
                     "rationale": rationale,

--- a/src/parlant/core/glossary.py
+++ b/src/parlant/core/glossary.py
@@ -57,6 +57,7 @@ TermId = NewType("TermId", str)
 class Term:
     id: TermId
     creation_utc: datetime
+    last_modified: datetime
     name: str
     description: str
     synonyms: list[str]
@@ -151,12 +152,24 @@ class TermDocument_v0_1_0(TypedDict, total=False):
     synonyms: Optional[str]
 
 
+class _TermDocument_v0_2_0(TypedDict, total=False):
+    id: ObjectId
+    version: Version.String
+    content: str
+    checksum: Required[str]
+    creation_utc: str
+    name: str
+    description: str
+    synonyms: Optional[str]
+
+
 class _TermDocument(TypedDict, total=False):
     id: ObjectId
     version: Version.String
     content: str
     checksum: Required[str]
     creation_utc: str
+    last_modified: str
     name: str
     description: str
     synonyms: Optional[str]
@@ -171,7 +184,7 @@ class TermTagAssociationDocument(TypedDict, total=False):
 
 
 class GlossaryVectorStore(GlossaryStore):
-    VERSION = Version.from_string("0.2.0")
+    VERSION = Version.from_string("0.3.0")
 
     def __init__(
         self,
@@ -206,10 +219,25 @@ class GlossaryVectorStore(GlossaryStore):
                 "This code should not be reached! Please run the 'parlant-prepare-migration' script."
             )
 
+        async def v0_2_0_to_v0_3_0(document: VectorBaseDocument) -> Optional[VectorBaseDocument]:
+            d = cast(_TermDocument_v0_2_0, document)
+            return _TermDocument(
+                id=d["id"],
+                version=Version.String("0.3.0"),
+                content=d["content"],
+                checksum=d["checksum"],
+                creation_utc=d["creation_utc"],
+                last_modified=d["creation_utc"],
+                name=d["name"],
+                description=d["description"],
+                synonyms=d.get("synonyms"),
+            )
+
         return await VectorDocumentMigrationHelper[_TermDocument](
             self,
             {
                 "0.1.0": v0_1_0_to_v0_2_0,
+                "0.2.0": v0_2_0_to_v0_3_0,
             },
         ).migrate(document)
 
@@ -273,6 +301,7 @@ class GlossaryVectorStore(GlossaryStore):
             content=content,
             checksum=checksum,
             creation_utc=term.creation_utc.isoformat(),
+            last_modified=term.last_modified.isoformat(),
             name=term.name,
             description=term.description,
             synonyms=(", ").join(term.synonyms) if term.synonyms is not None else "",
@@ -286,6 +315,7 @@ class GlossaryVectorStore(GlossaryStore):
         return Term(
             id=TermId(term_document["id"]),
             creation_utc=datetime.fromisoformat(term_document["creation_utc"]),
+            last_modified=datetime.fromisoformat(term_document["last_modified"]),
             name=term_document["name"],
             description=term_document["description"],
             synonyms=term_document["synonyms"].split(", ") if term_document["synonyms"] else [],
@@ -324,6 +354,7 @@ class GlossaryVectorStore(GlossaryStore):
             term = Term(
                 id=term_id,
                 creation_utc=creation_utc,
+                last_modified=creation_utc,
                 name=name,
                 description=description,
                 synonyms=list(synonyms) if synonyms else [],
@@ -399,6 +430,7 @@ class GlossaryVectorStore(GlossaryStore):
                     "description": description,
                     "synonyms": ", ".join(synonyms) if synonyms else "",
                     "checksum": md5_checksum(content),
+                    "last_modified": datetime.now(timezone.utc).isoformat(),
                 },
             )
 

--- a/src/parlant/core/guidelines.py
+++ b/src/parlant/core/guidelines.py
@@ -57,6 +57,7 @@ class GuidelineContent:
 class Guideline:
     id: GuidelineId
     creation_utc: datetime
+    last_modified: datetime
     content: GuidelineContent
     enabled: bool
     tags: Sequence[TagId]
@@ -296,10 +297,27 @@ class GuidelineDocument_v0_9_0(TypedDict, total=False):
     labels: Sequence[str]
 
 
+class GuidelineDocument_v0_10_0(TypedDict, total=False):
+    id: ObjectId
+    version: Version.String
+    creation_utc: str
+    condition: str
+    action: Optional[str]
+    description: Optional[str]
+    criticality: str
+    enabled: bool
+    metadata: Mapping[str, JSONSerializable]
+    composition_mode: Optional[str]
+    track: bool
+    labels: Sequence[str]
+    priority: int
+
+
 class GuidelineDocument(TypedDict, total=False):
     id: ObjectId
     version: Version.String
     creation_utc: str
+    last_modified: str
     condition: str
     action: Optional[str]
     description: Optional[str]
@@ -334,7 +352,7 @@ async def guideline_document_converter_0_1_0_to_0_2_0(doc: BaseDocument) -> Opti
 
 
 class GuidelineDocumentStore(GuidelineStore):
-    VERSION = Version.from_string("0.10.0")
+    VERSION = Version.from_string("0.11.0")
 
     def __init__(
         self,
@@ -354,9 +372,28 @@ class GuidelineDocumentStore(GuidelineStore):
         self._lock = ReaderWriterLock()
 
     async def _document_loader(self, doc: BaseDocument) -> Optional[GuidelineDocument]:
+        async def v0_10_0_to_v0_11_0(doc: BaseDocument) -> Optional[BaseDocument]:
+            d = cast(GuidelineDocument_v0_10_0, doc)
+            return GuidelineDocument(
+                id=d["id"],
+                version=Version.String("0.11.0"),
+                creation_utc=d["creation_utc"],
+                last_modified=d["creation_utc"],
+                condition=d["condition"],
+                action=d["action"],
+                description=d.get("description", None),
+                criticality=d["criticality"],
+                enabled=d["enabled"],
+                metadata=d["metadata"],
+                composition_mode=d.get("composition_mode"),
+                track=d.get("track", True),
+                labels=d.get("labels", []),
+                priority=d.get("priority", 0),
+            )
+
         async def v0_9_0_to_v0_10_0(doc: BaseDocument) -> Optional[BaseDocument]:
             d = cast(GuidelineDocument_v0_9_0, doc)
-            return GuidelineDocument(
+            return GuidelineDocument_v0_10_0(
                 id=d["id"],
                 version=Version.String("0.10.0"),
                 creation_utc=d["creation_utc"],
@@ -476,6 +513,7 @@ class GuidelineDocumentStore(GuidelineStore):
                 "0.7.0": v0_7_0_to_v0_8_0,
                 "0.8.0": v0_8_0_to_v0_9_0,
                 "0.9.0": v0_9_0_to_v0_10_0,
+                "0.10.0": v0_10_0_to_v0_11_0,
             },
         ).migrate(doc)
 
@@ -548,6 +586,7 @@ class GuidelineDocumentStore(GuidelineStore):
             id=ObjectId(guideline.id),
             version=self.VERSION.to_string(),
             creation_utc=guideline.creation_utc.isoformat(),
+            last_modified=guideline.last_modified.isoformat(),
             condition=guideline.content.condition,
             action=guideline.content.action,
             description=guideline.content.description,
@@ -579,6 +618,7 @@ class GuidelineDocumentStore(GuidelineStore):
         return Guideline(
             id=GuidelineId(guideline_document["id"]),
             creation_utc=datetime.fromisoformat(guideline_document["creation_utc"]),
+            last_modified=datetime.fromisoformat(guideline_document["last_modified"]),
             content=GuidelineContent(
                 condition=guideline_document["condition"],
                 action=guideline_document["action"],
@@ -630,6 +670,7 @@ class GuidelineDocumentStore(GuidelineStore):
             guideline = Guideline(
                 id=guideline_id,
                 creation_utc=creation_utc,
+                last_modified=creation_utc,
                 content=GuidelineContent(
                     condition=condition,
                     action=action,
@@ -781,6 +822,7 @@ class GuidelineDocumentStore(GuidelineStore):
                         else {}
                     ),
                     **({"priority": params["priority"]} if "priority" in params else {}),
+                    "last_modified": datetime.now(timezone.utc).isoformat(),
                 }
             )
 
@@ -892,6 +934,7 @@ class GuidelineDocumentStore(GuidelineStore):
                 filters={"id": {"$eq": guideline_id}},
                 params={
                     "metadata": updated_metadata,
+                    "last_modified": datetime.now(timezone.utc).isoformat(),
                 },
             )
 
@@ -917,6 +960,7 @@ class GuidelineDocumentStore(GuidelineStore):
                 filters={"id": {"$eq": guideline_id}},
                 params={
                     "metadata": updated_metadata,
+                    "last_modified": datetime.now(timezone.utc).isoformat(),
                 },
             )
 

--- a/src/parlant/core/journey_guideline_projection.py
+++ b/src/parlant/core/journey_guideline_projection.py
@@ -484,6 +484,7 @@ class JourneyGuidelineProjection:
                 ),
                 criticality=Criticality.HIGH,
                 creation_utc=datetime.now(timezone.utc),
+                last_modified=datetime.now(timezone.utc),
                 enabled=True,
                 tags=list(journey.tags),
                 metadata=metadata,

--- a/src/parlant/core/journeys.py
+++ b/src/parlant/core/journeys.py
@@ -1069,7 +1069,7 @@ class JourneyVectorStore(JourneyStore):
             merge_node_id=JourneyNodeId(doc["merge_node_id"]),
         )
 
-    async def _touch_journey_last_modified(self, journey_id: JourneyId) -> None:
+    async def _update_journey_last_modified(self, journey_id: JourneyId) -> None:
         """Update the journey's last_modified timestamp."""
         await self._collection.update_one(
             filters={"id": {"$eq": journey_id}},
@@ -1526,7 +1526,7 @@ class JourneyVectorStore(JourneyStore):
                 document=self._serialize_node(node, journey_id)
             )
 
-            await self._touch_journey_last_modified(journey_id)
+            await self._update_journey_last_modified(journey_id)
 
         return node
 
@@ -1575,7 +1575,7 @@ class JourneyVectorStore(JourneyStore):
                 params=cast(JourneyNodeAssociationDocument, to_json_dict(updated)),
             )
 
-            await self._touch_journey_last_modified(doc["journey_id"])
+            await self._update_journey_last_modified(doc["journey_id"])
 
         assert result.updated_document
 
@@ -1605,7 +1605,7 @@ class JourneyVectorStore(JourneyStore):
                 filters={"node_id": {"$eq": node_id}}
             )
 
-            await self._touch_journey_last_modified(journey_id)
+            await self._update_journey_last_modified(journey_id)
 
         if result.deleted_count == 0:
             raise ItemNotFoundError(item_id=UniqueId(node_id))
@@ -1789,7 +1789,7 @@ class JourneyVectorStore(JourneyStore):
                 document=self._serialize_edge(edge, journey_id)
             )
 
-            await self._touch_journey_last_modified(journey_id)
+            await self._update_journey_last_modified(journey_id)
 
         return edge
 
@@ -1825,7 +1825,7 @@ class JourneyVectorStore(JourneyStore):
                 params=cast(JourneyEdgeAssociationDocument, to_json_dict(updated)),
             )
 
-            await self._touch_journey_last_modified(doc["journey_id"])
+            await self._update_journey_last_modified(doc["journey_id"])
 
         assert result.updated_document
 
@@ -1871,7 +1871,7 @@ class JourneyVectorStore(JourneyStore):
             )
 
             if result.deleted_count > 0 and edge_doc:
-                await self._touch_journey_last_modified(edge_doc["journey_id"])
+                await self._update_journey_last_modified(edge_doc["journey_id"])
 
         if result.deleted_count == 0:
             raise ItemNotFoundError(item_id=UniqueId(edge_id))
@@ -2066,7 +2066,7 @@ class JourneyVectorStore(JourneyStore):
 
         async with self._lock.writer_lock:
             await self._link_association_collection.insert_one(document=self._serialize_link(link))
-            await self._touch_journey_last_modified(journey_id)
+            await self._update_journey_last_modified(journey_id)
 
         return link
 

--- a/src/parlant/core/journeys.py
+++ b/src/parlant/core/journeys.py
@@ -1069,6 +1069,13 @@ class JourneyVectorStore(JourneyStore):
             merge_node_id=JourneyNodeId(doc["merge_node_id"]),
         )
 
+    async def _touch_journey_last_modified(self, journey_id: JourneyId) -> None:
+        """Update the journey's last_modified timestamp."""
+        await self._collection.update_one(
+            filters={"id": {"$eq": journey_id}},
+            params={"last_modified": datetime.now(timezone.utc).isoformat()},
+        )
+
     @staticmethod
     def assemble_content(
         title: str,
@@ -1519,6 +1526,8 @@ class JourneyVectorStore(JourneyStore):
                 document=self._serialize_node(node, journey_id)
             )
 
+            await self._touch_journey_last_modified(journey_id)
+
         return node
 
     @override
@@ -1566,6 +1575,8 @@ class JourneyVectorStore(JourneyStore):
                 params=cast(JourneyNodeAssociationDocument, to_json_dict(updated)),
             )
 
+            await self._touch_journey_last_modified(doc["journey_id"])
+
         assert result.updated_document
 
         return self._deserialize_node(result.updated_document)
@@ -1583,7 +1594,9 @@ class JourneyVectorStore(JourneyStore):
             if not node_doc:
                 raise ItemNotFoundError(item_id=UniqueId(node_id))
 
-            edges = await self.list_edges(journey_id=node_doc["journey_id"], node_id=node_id)
+            journey_id = node_doc["journey_id"]
+
+            edges = await self.list_edges(journey_id=journey_id, node_id=node_id)
 
             for edge in edges:
                 await self.delete_edge(edge.id)
@@ -1591,6 +1604,8 @@ class JourneyVectorStore(JourneyStore):
             result = await self._node_association_collection.delete_one(
                 filters={"node_id": {"$eq": node_id}}
             )
+
+            await self._touch_journey_last_modified(journey_id)
 
         if result.deleted_count == 0:
             raise ItemNotFoundError(item_id=UniqueId(node_id))
@@ -1690,7 +1705,10 @@ class JourneyVectorStore(JourneyStore):
 
             result = await self._collection.update_one(
                 filters={"id": {"$eq": journey_id}},
-                params={"metadata": updated_metadata},
+                params={
+                    "metadata": updated_metadata,
+                    "last_modified": datetime.now(timezone.utc).isoformat(),
+                },
             )
 
         assert result.updated_document
@@ -1713,7 +1731,10 @@ class JourneyVectorStore(JourneyStore):
 
             result = await self._collection.update_one(
                 filters={"id": {"$eq": journey_id}},
-                params={"metadata": updated_metadata},
+                params={
+                    "metadata": updated_metadata,
+                    "last_modified": datetime.now(timezone.utc).isoformat(),
+                },
             )
 
         assert result.updated_document
@@ -1734,7 +1755,10 @@ class JourneyVectorStore(JourneyStore):
 
             result = await self._collection.update_one(
                 filters={"id": {"$eq": journey_id}},
-                params={"node_properties": node_properties},
+                params={
+                    "node_properties": node_properties,
+                    "last_modified": datetime.now(timezone.utc).isoformat(),
+                },
             )
 
         assert result.updated_document
@@ -1764,6 +1788,8 @@ class JourneyVectorStore(JourneyStore):
             await self._edge_association_collection.insert_one(
                 document=self._serialize_edge(edge, journey_id)
             )
+
+            await self._touch_journey_last_modified(journey_id)
 
         return edge
 
@@ -1798,6 +1824,8 @@ class JourneyVectorStore(JourneyStore):
                 filters={"id": {"$eq": edge_id}},
                 params=cast(JourneyEdgeAssociationDocument, to_json_dict(updated)),
             )
+
+            await self._touch_journey_last_modified(doc["journey_id"])
 
         assert result.updated_document
 
@@ -1836,9 +1864,14 @@ class JourneyVectorStore(JourneyStore):
         edge_id: JourneyEdgeId,
     ) -> None:
         async with self._lock.writer_lock:
+            edge_doc = await self._edge_association_collection.find_one({"id": {"$eq": edge_id}})
+
             result = await self._edge_association_collection.delete_one(
                 filters={"id": {"$eq": edge_id}}
             )
+
+            if result.deleted_count > 0 and edge_doc:
+                await self._touch_journey_last_modified(edge_doc["journey_id"])
 
         if result.deleted_count == 0:
             raise ItemNotFoundError(item_id=UniqueId(edge_id))
@@ -2033,6 +2066,7 @@ class JourneyVectorStore(JourneyStore):
 
         async with self._lock.writer_lock:
             await self._link_association_collection.insert_one(document=self._serialize_link(link))
+            await self._touch_journey_last_modified(journey_id)
 
         return link
 
@@ -2074,7 +2108,7 @@ class JourneyVectorStore(JourneyStore):
 
         link = self._deserialize_link(link_doc)
 
-        # Delete the merge fork node
+        # Delete the merge fork node (also touches last_modified via delete_node)
         await self.delete_node(link.merge_node_id)
 
         async with self._lock.writer_lock:

--- a/src/parlant/core/journeys.py
+++ b/src/parlant/core/journeys.py
@@ -120,6 +120,7 @@ class JourneyLink:
 class Journey:
     id: JourneyId
     creation_utc: datetime
+    last_modified: datetime
     description: str
     conditions: Sequence[GuidelineId]
     title: str
@@ -491,6 +492,7 @@ class JourneyDocument(TypedDict, total=False):
     id: ObjectId
     version: Version.String
     creation_utc: str
+    last_modified: str
     title: str
     description: str
     root_id: JourneyNodeId
@@ -690,6 +692,7 @@ class JourneyVectorStore(JourneyStore):
                 id=d["id"],
                 version=Version.String("0.7.0"),
                 creation_utc=d["creation_utc"],
+                last_modified=d["creation_utc"],
                 title=d["title"],
                 description=d["description"],
                 root_id=d["root_id"],
@@ -931,6 +934,7 @@ class JourneyVectorStore(JourneyStore):
             id=ObjectId(journey.id),
             version=self.VERSION.to_string(),
             creation_utc=journey.creation_utc.isoformat(),
+            last_modified=journey.last_modified.isoformat(),
             title=journey.title,
             description=journey.description,
             root_id=journey.root_id,
@@ -960,6 +964,7 @@ class JourneyVectorStore(JourneyStore):
         return Journey(
             id=JourneyId(doc["id"]),
             creation_utc=datetime.fromisoformat(doc["creation_utc"]),
+            last_modified=datetime.fromisoformat(doc.get("last_modified", doc["creation_utc"])),
             conditions=conditions,
             title=doc["title"],
             description=doc["description"],
@@ -1121,6 +1126,7 @@ class JourneyVectorStore(JourneyStore):
             journey = Journey(
                 id=journey_id,
                 creation_utc=creation_utc,
+                last_modified=creation_utc,
                 conditions=conditions,
                 title=title,
                 description=description,
@@ -1203,7 +1209,11 @@ class JourneyVectorStore(JourneyStore):
             nodes = await self.list_nodes(journey_id=journey_id)
             edges = await self.list_edges(journey_id=journey_id)
 
-            updated = {**doc, **params}
+            updated = {
+                **doc,
+                **params,
+                "last_modified": datetime.now(timezone.utc).isoformat(),
+            }
 
             content = self.assemble_content(
                 title=cast(str, updated["title"]),

--- a/tests/api/test_canned_responses.py
+++ b/tests/api/test_canned_responses.py
@@ -49,6 +49,7 @@ async def test_that_a_canned_response_can_be_created(
 
     assert "id" in canned_response
     assert "creation_utc" in canned_response
+    assert "last_modified" in canned_response
 
 
 async def test_that_a_canned_response_can_be_created_with_tags(
@@ -236,6 +237,7 @@ async def test_that_a_canned_response_can_be_updated(
     updated_canned_response = response.json()
     assert updated_canned_response["value"] == update_payload["value"]
     assert updated_canned_response["fields"] == update_payload["fields"]
+    assert updated_canned_response["last_modified"] != canned_response.creation_utc.isoformat()
 
 
 async def test_that_a_canned_response_can_be_deleted(

--- a/tests/api/test_context_variables.py
+++ b/tests/api/test_context_variables.py
@@ -63,6 +63,7 @@ async def test_that_a_context_variable_can_be_created(
     assert context_variable["description"] == "test of context variable"
     assert context_variable["freshness_rules"] == freshness_rules
     assert context_variable["tags"] == []
+    assert "last_modified" in context_variable
 
 
 async def test_that_a_context_variable_can_be_created_with_tags(
@@ -249,6 +250,7 @@ async def test_that_a_context_variable_can_be_updated_with_new_values(
     assert data["description"] == updated_description
     assert data["freshness_rules"] == freshness_rules
     assert set(data["tags"]) == set(tags_to_add)
+    assert data["last_modified"] != variable.creation_utc.isoformat()
 
 
 async def test_that_tags_can_be_removed_from_a_context_variable(

--- a/tests/api/test_glossary.py
+++ b/tests/api/test_glossary.py
@@ -44,6 +44,7 @@ async def test_that_a_term_can_be_created(
     assert data["description"] == description
     assert data["synonyms"] == synonyms
     assert data["tags"] == []
+    assert "last_modified" in data
 
 
 async def test_that_a_term_can_be_created_with_tags(
@@ -242,6 +243,7 @@ async def test_that_a_term_can_be_updated_with_new_values(
     assert data["description"] == updated_description
     assert data["synonyms"] == updated_synonyms
     assert set(data["tags"]) == set(tags_to_add)
+    assert data["last_modified"] != term["last_modified"]
 
 
 async def test_that_tags_can_be_removed_from_a_term(

--- a/tests/api/test_guidelines.py
+++ b/tests/api/test_guidelines.py
@@ -85,6 +85,7 @@ async def test_that_a_guideline_can_be_created(
     assert guideline["enabled"] is True
     assert guideline["tags"] == []
     assert guideline["metadata"] == {"key1": "value1", "key2": "value2"}
+    assert "last_modified" in guideline
 
 
 async def test_that_a_guideline_can_be_created_without_an_action(
@@ -321,6 +322,7 @@ async def test_that_a_guideline_condition_can_be_updated(
     assert updated_guideline["id"] == guideline.id
     assert updated_guideline["condition"] == "the customer inquires about weather"
     assert updated_guideline["action"] == guideline.content.action
+    assert updated_guideline["last_modified"] != guideline.creation_utc.isoformat()
 
 
 async def test_that_a_guideline_action_can_be_updated(

--- a/tests/api/test_journeys.py
+++ b/tests/api/test_journeys.py
@@ -45,6 +45,7 @@ async def test_that_a_journey_can_be_created(
     assert journey["title"] == payload["title"]
     assert journey["description"] == payload["description"]
     assert journey["tags"] == []
+    assert "last_modified" in journey
 
     assert len(journey["conditions"]) == 1
     guideline = await guideline_store.read_guideline(guideline_id=journey["conditions"][0])
@@ -278,6 +279,7 @@ async def test_that_a_journey_can_be_updated(
 
     assert updated_journey["title"] == expected_title
     assert updated_journey["description"] == expected_description
+    assert updated_journey["last_modified"] != journey["last_modified"]
 
 
 async def test_that_tags_can_be_added_to_a_journey(

--- a/tests/core/stable/engines/alpha/test_disambiguation_batch.py
+++ b/tests/core/stable/engines/alpha/test_disambiguation_batch.py
@@ -181,6 +181,7 @@ def create_term(
     return Term(
         id=TermId("-"),
         creation_utc=datetime.now(timezone.utc),
+        last_modified=datetime.now(timezone.utc),
         name=name,
         description=description,
         synonyms=synonyms,

--- a/tests/core/stable/engines/alpha/test_disambiguation_batch.py
+++ b/tests/core/stable/engines/alpha/test_disambiguation_batch.py
@@ -238,6 +238,7 @@ async def create_guideline(
     guideline = Guideline(
         id=GuidelineId(generate_id()),
         creation_utc=datetime.now(timezone.utc),
+        last_modified=datetime.now(timezone.utc),
         content=GuidelineContent(
             condition=condition,
             action=action,

--- a/tests/core/stable/engines/alpha/test_disambiguation_batch.py
+++ b/tests/core/stable/engines/alpha/test_disambiguation_batch.py
@@ -197,6 +197,7 @@ def create_context_variable(
     return ContextVariable(
         id=ContextVariableId("-"),
         creation_utc=datetime.now(timezone.utc),
+        last_modified=datetime.now(timezone.utc),
         name=name,
         description="",
         tool_id=None,

--- a/tests/core/stable/engines/alpha/test_generic_response_analysis.py
+++ b/tests/core/stable/engines/alpha/test_generic_response_analysis.py
@@ -138,6 +138,7 @@ def create_guideline(
     guideline = Guideline(
         id=GuidelineId(generate_id()),
         creation_utc=datetime.now(timezone.utc),
+        last_modified=datetime.now(timezone.utc),
         content=GuidelineContent(
             condition=condition,
             action=action,
@@ -163,6 +164,7 @@ def create_guideline_with_tools(
     guideline = Guideline(
         id=GuidelineId(generate_id()),
         creation_utc=datetime.now(timezone.utc),
+        last_modified=datetime.now(timezone.utc),
         content=GuidelineContent(
             condition=condition,
             action=action,

--- a/tests/core/stable/engines/alpha/test_guideline_actionable_batch.py
+++ b/tests/core/stable/engines/alpha/test_guideline_actionable_batch.py
@@ -152,6 +152,7 @@ def create_guideline(
     guideline = Guideline(
         id=GuidelineId(generate_id()),
         creation_utc=datetime.now(timezone.utc),
+        last_modified=datetime.now(timezone.utc),
         content=GuidelineContent(
             condition=condition,
             action=action,

--- a/tests/core/stable/engines/alpha/test_guideline_low_criticality_batch.py
+++ b/tests/core/stable/engines/alpha/test_guideline_low_criticality_batch.py
@@ -182,6 +182,7 @@ def create_guideline(
     guideline = Guideline(
         id=GuidelineId(generate_id()),
         creation_utc=datetime.now(timezone.utc),
+        last_modified=datetime.now(timezone.utc),
         content=GuidelineContent(
             condition=condition,
             action=action,

--- a/tests/core/stable/engines/alpha/test_guideline_matcher.py
+++ b/tests/core/stable/engines/alpha/test_guideline_matcher.py
@@ -511,6 +511,7 @@ def create_term(
     return Term(
         id=TermId("-"),
         creation_utc=datetime.now(timezone.utc),
+        last_modified=datetime.now(timezone.utc),
         name=name,
         description=description,
         synonyms=synonyms,

--- a/tests/core/stable/engines/alpha/test_guideline_matcher.py
+++ b/tests/core/stable/engines/alpha/test_guideline_matcher.py
@@ -454,6 +454,7 @@ async def create_guideline(
     guideline = Guideline(
         id=GuidelineId(generate_id()),
         creation_utc=datetime.now(timezone.utc),
+        last_modified=datetime.now(timezone.utc),
         content=GuidelineContent(
             condition=condition,
             action=action,
@@ -475,6 +476,7 @@ async def create_disambiguation_guideline(
     guideline = Guideline(
         id=GuidelineId(generate_id()),
         creation_utc=datetime.now(timezone.utc),
+        last_modified=datetime.now(timezone.utc),
         content=GuidelineContent(
             condition=condition,
             action=None,

--- a/tests/core/stable/engines/alpha/test_guideline_matcher.py
+++ b/tests/core/stable/engines/alpha/test_guideline_matcher.py
@@ -527,6 +527,7 @@ def create_context_variable(
     return ContextVariable(
         id=ContextVariableId("-"),
         creation_utc=datetime.now(timezone.utc),
+        last_modified=datetime.now(timezone.utc),
         name=name,
         description="",
         tool_id=None,

--- a/tests/core/stable/engines/alpha/test_journey_node_selection.py
+++ b/tests/core/stable/engines/alpha/test_journey_node_selection.py
@@ -1018,6 +1018,7 @@ async def create_journey(
     root_guideline = Guideline(
         id=GuidelineId("root"),
         creation_utc=datetime.now(timezone.utc),
+        last_modified=datetime.now(timezone.utc),
         content=GuidelineContent(condition="", action=None),
         criticality=Criticality.MEDIUM,
         enabled=True,
@@ -1035,6 +1036,7 @@ async def create_journey(
         Guideline(
             id=GuidelineId(node.id),
             creation_utc=datetime.now(timezone.utc),
+            last_modified=datetime.now(timezone.utc),
             content=GuidelineContent(
                 condition=node.condition or "",
                 action=node.action,

--- a/tests/core/stable/engines/alpha/test_journey_node_selection.py
+++ b/tests/core/stable/engines/alpha/test_journey_node_selection.py
@@ -985,6 +985,7 @@ def create_context_variable(
     return ContextVariable(
         id=ContextVariableId("-"),
         creation_utc=datetime.now(timezone.utc),
+        last_modified=datetime.now(timezone.utc),
         name=name,
         description="",
         tool_id=None,

--- a/tests/core/stable/engines/alpha/test_journey_node_selection.py
+++ b/tests/core/stable/engines/alpha/test_journey_node_selection.py
@@ -1076,6 +1076,7 @@ async def create_journey(
         id=journey_id,
         root_id=JourneyNodeId(root_guideline.id),
         creation_utc=datetime.now(timezone.utc),
+        last_modified=datetime.now(timezone.utc),
         description=description,
         conditions=condition_ids,
         title=title,

--- a/tests/core/stable/engines/alpha/test_journey_node_selection.py
+++ b/tests/core/stable/engines/alpha/test_journey_node_selection.py
@@ -969,6 +969,7 @@ def create_term(
     return Term(
         id=TermId("-"),
         creation_utc=datetime.now(timezone.utc),
+        last_modified=datetime.now(timezone.utc),
         name=name,
         description=description,
         synonyms=synonyms,

--- a/tests/core/stable/engines/alpha/test_previously_applied_actionable_batch.py
+++ b/tests/core/stable/engines/alpha/test_previously_applied_actionable_batch.py
@@ -130,6 +130,7 @@ def create_guideline(
     guideline = Guideline(
         id=GuidelineId(generate_id()),
         creation_utc=datetime.now(timezone.utc),
+        last_modified=datetime.now(timezone.utc),
         content=GuidelineContent(
             condition=condition,
             action=action,

--- a/tests/core/stable/engines/alpha/test_previously_applied_actionable_customer_dependent_batch.py
+++ b/tests/core/stable/engines/alpha/test_previously_applied_actionable_customer_dependent_batch.py
@@ -119,6 +119,7 @@ def create_guideline(
     guideline = Guideline(
         id=GuidelineId(generate_id()),
         creation_utc=datetime.now(timezone.utc),
+        last_modified=datetime.now(timezone.utc),
         content=GuidelineContent(
             condition=condition,
             action=action,

--- a/tests/core/stable/engines/alpha/test_tool_caller.py
+++ b/tests/core/stable/engines/alpha/test_tool_caller.py
@@ -119,6 +119,7 @@ def create_guideline_match(
     guideline = Guideline(
         id=GuidelineId(generate_id()),
         creation_utc=datetime.now(timezone.utc),
+        last_modified=datetime.now(timezone.utc),
         content=GuidelineContent(
             condition=condition,
             action=action,

--- a/tests/core/stable/services/indexing/test_agent_intention_proposer.py
+++ b/tests/core/stable/services/indexing/test_agent_intention_proposer.py
@@ -186,6 +186,7 @@ def create_guideline(
     guideline = Guideline(
         id=GuidelineId(generate_id()),
         creation_utc=datetime.now(timezone.utc),
+        last_modified=datetime.now(timezone.utc),
         content=GuidelineContent(
             condition=condition,
             action=action,

--- a/tests/core/stable/services/indexing/test_journey_reachable_nodes_evaluation.py
+++ b/tests/core/stable/services/indexing/test_journey_reachable_nodes_evaluation.py
@@ -67,6 +67,7 @@ def _make_guideline(
     return Guideline(
         id=GuidelineId(id),
         creation_utc=datetime.now(timezone.utc),
+        last_modified=datetime.now(timezone.utc),
         content=GuidelineContent(condition=condition, action=action),
         criticality=Criticality.MEDIUM,
         enabled=True,

--- a/tests/core/stable/services/indexing/test_relative_action_step_proposer.py
+++ b/tests/core/stable/services/indexing/test_relative_action_step_proposer.py
@@ -130,6 +130,7 @@ def create_journey(
         id=journey_id,
         root_id=JourneyNodeId(root_guideline.id),
         creation_utc=datetime.now(timezone.utc),
+        last_modified=datetime.now(timezone.utc),
         description="",
         conditions=[g.id for g in condition_guidelines],
         title=title,

--- a/tests/core/stable/services/indexing/test_relative_action_step_proposer.py
+++ b/tests/core/stable/services/indexing/test_relative_action_step_proposer.py
@@ -68,6 +68,7 @@ def create_journey(
         Guideline(
             id=GuidelineId(f"c-{i}"),
             creation_utc=datetime.now(timezone.utc),
+            last_modified=datetime.now(timezone.utc),
             content=GuidelineContent(condition=condition, action=None),
             criticality=Criticality.MEDIUM,
             enabled=False,
@@ -80,6 +81,7 @@ def create_journey(
     root_guideline = Guideline(
         id=GuidelineId("root"),
         creation_utc=datetime.now(timezone.utc),
+        last_modified=datetime.now(timezone.utc),
         content=GuidelineContent(condition="", action=None),
         criticality=Criticality.MEDIUM,
         enabled=True,
@@ -97,6 +99,7 @@ def create_journey(
         Guideline(
             id=GuidelineId(step.id),
             creation_utc=datetime.now(timezone.utc),
+            last_modified=datetime.now(timezone.utc),
             content=GuidelineContent(
                 condition=step.condition or "",
                 action=step.action,

--- a/tests/core/unstable/engines/alpha/test_agent_intention_proposer.py
+++ b/tests/core/unstable/engines/alpha/test_agent_intention_proposer.py
@@ -186,6 +186,7 @@ def create_guideline(
     guideline = Guideline(
         id=GuidelineId(generate_id()),
         creation_utc=datetime.now(timezone.utc),
+        last_modified=datetime.now(timezone.utc),
         content=GuidelineContent(
             condition=condition,
             action=action,

--- a/tests/core/unstable/engines/alpha/test_disambiguation_batch.py
+++ b/tests/core/unstable/engines/alpha/test_disambiguation_batch.py
@@ -191,6 +191,7 @@ def create_context_variable(
     return ContextVariable(
         id=ContextVariableId("-"),
         creation_utc=datetime.now(timezone.utc),
+        last_modified=datetime.now(timezone.utc),
         name=name,
         description="",
         tool_id=None,

--- a/tests/core/unstable/engines/alpha/test_disambiguation_batch.py
+++ b/tests/core/unstable/engines/alpha/test_disambiguation_batch.py
@@ -232,6 +232,7 @@ async def create_guideline(
     guideline = Guideline(
         id=GuidelineId(generate_id()),
         creation_utc=datetime.now(timezone.utc),
+        last_modified=datetime.now(timezone.utc),
         content=GuidelineContent(
             condition=condition,
             action=action,

--- a/tests/core/unstable/engines/alpha/test_disambiguation_batch.py
+++ b/tests/core/unstable/engines/alpha/test_disambiguation_batch.py
@@ -175,6 +175,7 @@ def create_term(
     return Term(
         id=TermId("-"),
         creation_utc=datetime.now(timezone.utc),
+        last_modified=datetime.now(timezone.utc),
         name=name,
         description=description,
         synonyms=synonyms,

--- a/tests/core/unstable/engines/alpha/test_guideline_matcher.py
+++ b/tests/core/unstable/engines/alpha/test_guideline_matcher.py
@@ -400,6 +400,7 @@ def create_context_variable(
     return ContextVariable(
         id=ContextVariableId("-"),
         creation_utc=datetime.now(timezone.utc),
+        last_modified=datetime.now(timezone.utc),
         name=name,
         description="",
         tool_id=None,

--- a/tests/core/unstable/engines/alpha/test_guideline_matcher.py
+++ b/tests/core/unstable/engines/alpha/test_guideline_matcher.py
@@ -362,6 +362,7 @@ async def create_guideline(
     guideline = Guideline(
         id=GuidelineId(generate_id()),
         creation_utc=datetime.now(timezone.utc),
+        last_modified=datetime.now(timezone.utc),
         content=GuidelineContent(
             condition=condition,
             action=action,

--- a/tests/core/unstable/engines/alpha/test_guideline_matcher.py
+++ b/tests/core/unstable/engines/alpha/test_guideline_matcher.py
@@ -384,6 +384,7 @@ def create_term(
     return Term(
         id=TermId("-"),
         creation_utc=datetime.now(timezone.utc),
+        last_modified=datetime.now(timezone.utc),
         name=name,
         description=description,
         synonyms=synonyms,


### PR DESCRIPTION
## Summary
- Add `last_modified: datetime` to **Guideline**, **Term**, **Journey**, **ContextVariable**, and **CannedResponse**
- Bump store versions with migrations that set `last_modified = creation_utc` for existing documents
- Journey piggybacks on the existing 0.7.0 version (no additional bump)
- All mutation methods update `last_modified` on change
- Added `LastModifiedField` to API DTOs following the annotated field convention
- Trace events (`gm.activate`, `gm.deactivate`, `journey.state.activate`) and ready status events now include `last_modified`

## Notes
- One commit per entity for clean review
- `LastModifiedField` defined once in `common.py`, imported everywhere