### PR TITLE
fix: restore context vars in resolve_tool endpoint

### DIFF
--- a/src/parlant/core/services/tools/plugins.py
+++ b/src/parlant/core/services/tools/plugins.py
@@ -624,6 +624,10 @@ class PluginServer:
                     detail=f"Tool: '{name}' does not exists",
                 )
 
+            # Restore context vars for same-process hosted mode
+            for var, value in self.context_vars.items():
+                var.set(value)
+
             tool = await _recompute_and_marshal_tool(
                 spec.tool,
                 self.plugin_data,


### PR DESCRIPTION
## Summary

Fix context var propagation in `resolve_tool` endpoint for uvicorn 0.39.0+.

## Problem

Uvicorn [PR #2742](https://github.com/Kludex/uvicorn/pull/2742) fixed contextvar loading
in version 0.39.0. Previously, `p.Server.current` was accessible in the `resolve_tool`
endpoint, but after uvicorn 0.39.0 it became unavailable.

This breaks choice providers that depend on `p.Server.current`, causing:
```
RuntimeError: No server available in current context
```

## Solution

Restore context vars in the `resolve_tool` endpoint, following the same pattern
used in the `call_tool` endpoint:

```python
# Restore context vars for same-process hosted mode
for var, value in self.context_vars.items():
    var.set(value)
```

This ensures `p.Server.current` is accessible regardless of uvicorn version.

## Testing

- Tested with uvicorn 0.38.0 (before fix)
- Tested with uvicorn 0.39.0+ (after fix)
- Choice providers now work correctly in both versions

## References

- Related uvicorn change: https://github.com/Kludex/uvicorn/pull/2742
- Similar implementation in `call_tool` endpoint (line ~716)