### PR TITLE
Fix WebSocketLogger event loop starvation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to Parlant will be documented here.
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix WebSocketLogger event loop starvation — when no WebSocket clients are subscribed, the drain loop processed queued messages without yielding, progressively blocking the async event loop and causing increasing latency over time
+
 ### Removed
 
 - Remove redundant `glm_service.py` NLP adapter and `NLPServices.glm()` factory method — the GLM/bigmodel.cn API is already covered by the existing Zhipu adapter (`zhipu_service.py`), which uses the official `zhipuai` SDK and supports GLM-4 model variants. Use `NLPServices.zhipu()` instead.

--- a/src/parlant/adapters/loggers/websocket.py
+++ b/src/parlant/adapters/loggers/websocket.py
@@ -102,6 +102,10 @@ class WebSocketLogger(TracingLogger):
                     await self._messages_in_queue.acquire()
                     payload = self._message_queue.popleft()
 
+                    if not self._socket_subscriptions:
+                        await asyncio.sleep(0)
+                        continue
+
                     async with self._lock:
                         socket_subscriptions = dict(self._socket_subscriptions)
 

--- a/tests/api/test_websocket_logger.py
+++ b/tests/api/test_websocket_logger.py
@@ -19,7 +19,8 @@ from lagom import Container
 import pytest
 
 from parlant.adapters.loggers.websocket import WebSocketLogger
-from parlant.core.tracer import Tracer
+from parlant.core.loggers import LogLevel
+from parlant.core.tracer import LocalTracer, Tracer
 
 
 @pytest.fixture
@@ -69,3 +70,33 @@ async def test_that_websocket_reconnects_and_receives_messages(
         assert "Second connection test" in data2["message"]
         assert data2["level"] == "INFO"
         assert data2["trace_id"] == tracer.trace_id
+
+
+async def test_that_draining_queued_messages_without_subscribers_does_not_starve_event_loop() -> (
+    None
+):
+    NUM_MESSAGES = 200_000
+    MAX_STALL_SECONDS = 0.05
+
+    tracer = LocalTracer()
+    logger = WebSocketLogger(tracer, LogLevel.INFO)
+
+    for i in range(NUM_MESSAGES):
+        logger.info(f"Message {i}")
+
+    drain_task = asyncio.create_task(logger.start())
+
+    t0 = asyncio.get_event_loop().time()
+    await asyncio.sleep(0)
+    stall = asyncio.get_event_loop().time() - t0
+
+    drain_task.cancel()
+    try:
+        await drain_task
+    except asyncio.CancelledError:
+        pass
+
+    assert stall < MAX_STALL_SECONDS, (
+        f"Event loop was starved for {stall:.3f}s while draining {NUM_MESSAGES} messages "
+        f"(threshold: {MAX_STALL_SECONDS}s)"
+    )


### PR DESCRIPTION
## Summary

- Fix progressive latency degradation caused by `WebSocketLogger.start()` drain loop not yielding to the async event loop when no WebSocket clients are subscribed
- When `Semaphore.acquire()` and `Lock.acquire()` complete without contention, they return immediately in CPython — the drain loop processes all queued messages in one uninterrupted burst, starving other coroutines
- The fix short-circuits when no subscribers exist (skipping both lock acquisitions) and yields via `asyncio.sleep(0)` to prevent starvation

## Context

Reported by a community user running an agent with 57 guidelines on MongoDB. Latency degraded from 40ms to 2.4s+ over 8 hours, with the delay occurring before `matcher:always` guideline fired. Issue resolved after patching the WebSocketLogger to stop enqueuing.
