### PR TITLE
Add ensure_indexes to VectorCollection for dynamic filter fields

### DIFF
--- a/src/parlant/adapters/vector_db/chroma.py
+++ b/src/parlant/adapters/vector_db/chroma.py
@@ -42,6 +42,7 @@ from parlant.core.persistence.vector_database import (
     InsertResult,
     SimilarDocumentResult,
     UpdateResult,
+    VectorCollectionIndex,
     VectorDatabase,
     TDocument,
     identity_loader,
@@ -472,6 +473,13 @@ class ChromaCollection(Generic[TDocument], BaseVectorCollection[TDocument]):
         self._lock = ReaderWriterLock()
         self._unembedded_collection = unembedded_collection
         self.embedded_collection = embedded_collection
+
+    @override
+    async def ensure_indexes(
+        self,
+        indexes: Sequence[VectorCollectionIndex],
+    ) -> None:
+        pass
 
     @override
     async def find(

--- a/src/parlant/adapters/vector_db/mongo.py
+++ b/src/parlant/adapters/vector_db/mongo.py
@@ -102,125 +102,6 @@ class MongoVectorDatabase(VectorDatabase):
         if collection_name not in existing:
             await self._database.create_collection(collection_name)
 
-    async def _ensure_vector_index(
-        self,
-        mongo_collection: AsyncCollection[Any],
-        embedder: Embedder,
-        filter_fields: Sequence[str] = (),
-    ) -> None:
-        """Create a vector search index on the collection if it doesn't exist."""
-        # Ensure the collection exists in MongoDB before creating a search index
-        await self._ensure_collection_exists(mongo_collection.name)
-
-        all_filter_fields = sorted({"id"} | set(filter_fields))
-
-        expected_definition = self._build_index_definition(embedder, all_filter_fields)
-
-        # Check if the index already exists
-        existing_indexes: list[Mapping[str, Any]] = []
-        cursor = await mongo_collection.list_search_indexes()
-        async for index in cursor:
-            existing_indexes.append(index)
-
-        for index in existing_indexes:
-            if index.get("name") == VECTOR_INDEX_NAME:
-                if self._index_matches(index, all_filter_fields):
-                    return
-
-                # Index exists but is stale — drop and recreate
-                self._logger.info(
-                    f"Recreating vector search index '{VECTOR_INDEX_NAME}' "
-                    f"on collection '{mongo_collection.name}' (filter fields changed)"
-                )
-                await mongo_collection.drop_search_index(VECTOR_INDEX_NAME)
-                await self._wait_for_index_dropped(mongo_collection)
-                break
-
-        search_index_model = SearchIndexModel(
-            definition=expected_definition,
-            name=VECTOR_INDEX_NAME,
-            type="vectorSearch",
-        )
-
-        await mongo_collection.create_search_index(search_index_model)
-        self._logger.info(
-            f"Created vector search index '{VECTOR_INDEX_NAME}' "
-            f"on collection '{mongo_collection.name}'"
-        )
-
-        # Wait for the index to be ready
-        await self._wait_for_index_ready(mongo_collection)
-
-    @staticmethod
-    def _build_index_definition(
-        embedder: Embedder,
-        filter_fields: Sequence[str],
-    ) -> dict[str, Any]:
-        fields: list[dict[str, Any]] = [
-            {
-                "type": "vector",
-                "path": "__embedding__",
-                "numDimensions": embedder.dimensions,
-                "similarity": "cosine",
-            },
-        ]
-        for field in filter_fields:
-            fields.append({"type": "filter", "path": field})
-        return {"fields": fields}
-
-    @staticmethod
-    def _index_matches(
-        index: Mapping[str, Any],
-        expected_filter_fields: Sequence[str],
-    ) -> bool:
-        definition = index.get("latestDefinition", index.get("definition", {}))
-        existing_filter_paths = {
-            f["path"] for f in definition.get("fields", []) if f.get("type") == "filter"
-        }
-        return existing_filter_paths == set(expected_filter_fields)
-
-    async def _wait_for_index_dropped(
-        self,
-        mongo_collection: AsyncCollection[Any],
-    ) -> None:
-        """Poll until the vector search index is fully removed."""
-        elapsed = 0.0
-        while elapsed < _INDEX_READY_TIMEOUT:
-            index_cursor = await mongo_collection.list_search_indexes()
-            found = False
-            async for index in index_cursor:
-                if index.get("name") == VECTOR_INDEX_NAME:
-                    found = True
-                    break
-            if not found:
-                return
-            await asyncio.sleep(_INDEX_READY_POLL_INTERVAL)
-            elapsed += _INDEX_READY_POLL_INTERVAL
-
-        self._logger.warning(
-            f"Vector search index '{VECTOR_INDEX_NAME}' on '{mongo_collection.name}' "
-            f"did not drop within {_INDEX_READY_TIMEOUT}s"
-        )
-
-    async def _wait_for_index_ready(
-        self,
-        mongo_collection: AsyncCollection[Any],
-    ) -> None:
-        """Poll until the vector search index is queryable."""
-        elapsed = 0.0
-        while elapsed < _INDEX_READY_TIMEOUT:
-            index_cursor = await mongo_collection.list_search_indexes()
-            async for index in index_cursor:
-                if index.get("name") == VECTOR_INDEX_NAME and index.get("queryable") is True:
-                    return
-            await asyncio.sleep(_INDEX_READY_POLL_INTERVAL)
-            elapsed += _INDEX_READY_POLL_INTERVAL
-
-        self._logger.warning(
-            f"Vector search index '{VECTOR_INDEX_NAME}' on '{mongo_collection.name}' "
-            f"did not become ready within {_INDEX_READY_TIMEOUT}s"
-        )
-
     @override
     async def create_collection(
         self,
@@ -235,7 +116,7 @@ class MongoVectorDatabase(VectorDatabase):
         collection_name = self._format_collection_name(name, embedder_type)
 
         mongo_collection = self._database[collection_name]
-        await self._ensure_vector_index(mongo_collection, embedder)
+        await self._ensure_collection_exists(collection_name)
 
         collection = MongoVectorCollection(
             logger=self._logger,
@@ -245,7 +126,6 @@ class MongoVectorDatabase(VectorDatabase):
             schema=schema,
             embedder=embedder,
             embedding_cache_provider=self._embedding_cache_provider,
-            database=self,
         )
 
         self._collections[name] = collection  # type: ignore[assignment]
@@ -271,7 +151,6 @@ class MongoVectorDatabase(VectorDatabase):
             raise ValueError(f'Mongo vector collection "{name}" not found.')
 
         mongo_collection = self._database[collection_name]
-        await self._ensure_vector_index(mongo_collection, embedder)
 
         # Run document loader on existing documents for migration
         await self._migrate_documents(mongo_collection, embedder, document_loader)
@@ -284,7 +163,6 @@ class MongoVectorDatabase(VectorDatabase):
             schema=schema,
             embedder=embedder,
             embedding_cache_provider=self._embedding_cache_provider,
-            database=self,
         )
 
         self._collections[name] = collection  # type: ignore[assignment]
@@ -305,7 +183,7 @@ class MongoVectorDatabase(VectorDatabase):
         collection_name = self._format_collection_name(name, embedder_type)
 
         mongo_collection = self._database[collection_name]
-        await self._ensure_vector_index(mongo_collection, embedder)
+        await self._ensure_collection_exists(collection_name)
 
         # Run document loader on existing documents for migration
         await self._migrate_documents(mongo_collection, embedder, document_loader)
@@ -318,7 +196,6 @@ class MongoVectorDatabase(VectorDatabase):
             schema=schema,
             embedder=embedder,
             embedding_cache_provider=self._embedding_cache_provider,
-            database=self,
         )
 
         self._collections[name] = collection  # type: ignore[assignment]
@@ -417,7 +294,6 @@ class MongoVectorCollection(Generic[TDocument], BaseVectorCollection[TDocument])
         schema: type[TDocument],
         embedder: Embedder,
         embedding_cache_provider: EmbeddingCacheProvider,
-        database: MongoVectorDatabase,
     ) -> None:
         super().__init__(tracer)
 
@@ -427,7 +303,6 @@ class MongoVectorCollection(Generic[TDocument], BaseVectorCollection[TDocument])
         self._embedder = embedder
         self._embedding_cache_provider = embedding_cache_provider
         self._mongo_collection = mongo_collection
-        self._database = database
         self._lock = ReaderWriterLock()
 
     @override
@@ -435,11 +310,105 @@ class MongoVectorCollection(Generic[TDocument], BaseVectorCollection[TDocument])
         self,
         indexes: Sequence[VectorCollectionIndex],
     ) -> None:
-        filter_fields = [idx.field for idx in indexes]
-        await self._database._ensure_vector_index(
-            self._mongo_collection,
-            self._embedder,
-            filter_fields=filter_fields,
+        filter_fields = sorted({idx.field for idx in indexes})
+
+        # Check if the index already exists with the right fields
+        existing_indexes: list[Mapping[str, Any]] = []
+        cursor = await self._mongo_collection.list_search_indexes()
+        async for index in cursor:
+            existing_indexes.append(index)
+
+        for index in existing_indexes:
+            if index.get("name") == VECTOR_INDEX_NAME:
+                if self._index_matches(index, filter_fields):
+                    return
+
+                # Index exists but is stale — drop and recreate
+                self._logger.info(
+                    f"Recreating vector search index '{VECTOR_INDEX_NAME}' "
+                    f"on collection '{self._mongo_collection.name}' (filter fields changed)"
+                )
+                await self._mongo_collection.drop_search_index(VECTOR_INDEX_NAME)
+                await self._wait_for_index_dropped()
+                break
+
+        definition = self._build_index_definition(self._embedder, filter_fields)
+        search_index_model = SearchIndexModel(
+            definition=definition,
+            name=VECTOR_INDEX_NAME,
+            type="vectorSearch",
+        )
+
+        await self._mongo_collection.create_search_index(search_index_model)
+        self._logger.info(
+            f"Created vector search index '{VECTOR_INDEX_NAME}' "
+            f"on collection '{self._mongo_collection.name}'"
+        )
+
+        await self._wait_for_index_ready()
+
+    @staticmethod
+    def _build_index_definition(
+        embedder: Embedder,
+        filter_fields: Sequence[str],
+    ) -> dict[str, Any]:
+        fields: list[dict[str, Any]] = [
+            {
+                "type": "vector",
+                "path": "__embedding__",
+                "numDimensions": embedder.dimensions,
+                "similarity": "cosine",
+            },
+        ]
+        for field in filter_fields:
+            fields.append({"type": "filter", "path": field})
+        return {"fields": fields}
+
+    @staticmethod
+    def _index_matches(
+        index: Mapping[str, Any],
+        expected_filter_fields: Sequence[str],
+    ) -> bool:
+        definition = index.get("latestDefinition", index.get("definition", {}))
+        existing_filter_paths = {
+            f["path"] for f in definition.get("fields", []) if f.get("type") == "filter"
+        }
+        return existing_filter_paths == set(expected_filter_fields)
+
+    async def _wait_for_index_dropped(self) -> None:
+        """Poll until the vector search index is fully removed."""
+        elapsed = 0.0
+        while elapsed < _INDEX_READY_TIMEOUT:
+            index_cursor = await self._mongo_collection.list_search_indexes()
+            found = False
+            async for index in index_cursor:
+                if index.get("name") == VECTOR_INDEX_NAME:
+                    found = True
+                    break
+            if not found:
+                return
+            await asyncio.sleep(_INDEX_READY_POLL_INTERVAL)
+            elapsed += _INDEX_READY_POLL_INTERVAL
+
+        self._logger.warning(
+            f"Vector search index '{VECTOR_INDEX_NAME}' on '{self._mongo_collection.name}' "
+            f"did not drop within {_INDEX_READY_TIMEOUT}s"
+        )
+
+    async def _wait_for_index_ready(self) -> None:
+        """Poll until the vector search index is queryable."""
+        elapsed = 0.0
+        while elapsed < _INDEX_READY_TIMEOUT:
+            index_cursor = await self._mongo_collection.list_search_indexes()
+            async for index in index_cursor:
+                if index.get("name") == VECTOR_INDEX_NAME and index.get("queryable") is True:
+                    return
+            await asyncio.sleep(_INDEX_READY_POLL_INTERVAL)
+            elapsed += _INDEX_READY_POLL_INTERVAL
+
+        self._logger.warning(
+            f"Vector search index '{VECTOR_INDEX_NAME}' on '{self._mongo_collection.name}' "
+            f"did not become ready within {_INDEX_READY_TIMEOUT}s"
         )
 
     def _strip_internal_fields(self, doc: dict[str, Any]) -> TDocument:

--- a/src/parlant/adapters/vector_db/mongo.py
+++ b/src/parlant/adapters/vector_db/mongo.py
@@ -44,6 +44,7 @@ from parlant.core.persistence.vector_database import (
     SimilarDocumentResult,
     TDocument,
     UpdateResult,
+    VectorCollectionIndex,
     VectorDatabase,
 )
 from parlant.core.tracer import Tracer
@@ -105,10 +106,16 @@ class MongoVectorDatabase(VectorDatabase):
         self,
         mongo_collection: AsyncCollection[Any],
         embedder: Embedder,
+        filter_fields: Sequence[str] = (),
     ) -> None:
         """Create a vector search index on the collection if it doesn't exist."""
         # Ensure the collection exists in MongoDB before creating a search index
         await self._ensure_collection_exists(mongo_collection.name)
+
+        base_filter_fields = {"id", "version", "checksum"}
+        all_filter_fields = sorted(base_filter_fields | set(filter_fields))
+
+        expected_definition = self._build_index_definition(embedder, all_filter_fields)
 
         # Check if the index already exists
         existing_indexes: list[Mapping[str, Any]] = []
@@ -118,35 +125,20 @@ class MongoVectorDatabase(VectorDatabase):
 
         for index in existing_indexes:
             if index.get("name") == VECTOR_INDEX_NAME:
-                return
+                if self._index_matches(index, all_filter_fields):
+                    return
+
+                # Index exists but is stale — drop and recreate
+                self._logger.info(
+                    f"Recreating vector search index '{VECTOR_INDEX_NAME}' "
+                    f"on collection '{mongo_collection.name}' (filter fields changed)"
+                )
+                await mongo_collection.drop_search_index(VECTOR_INDEX_NAME)
+                await self._wait_for_index_dropped(mongo_collection)
+                break
 
         search_index_model = SearchIndexModel(
-            definition={
-                "fields": [
-                    {
-                        "type": "vector",
-                        "path": "__embedding__",
-                        "numDimensions": embedder.dimensions,
-                        "similarity": "cosine",
-                    },
-                    {
-                        "type": "filter",
-                        "path": "id",
-                    },
-                    {
-                        "type": "filter",
-                        "path": "version",
-                    },
-                    {
-                        "type": "filter",
-                        "path": "name",
-                    },
-                    {
-                        "type": "filter",
-                        "path": "checksum",
-                    },
-                ]
-            },
+            definition=expected_definition,
             name=VECTOR_INDEX_NAME,
             type="vectorSearch",
         )
@@ -159,6 +151,57 @@ class MongoVectorDatabase(VectorDatabase):
 
         # Wait for the index to be ready
         await self._wait_for_index_ready(mongo_collection)
+
+    @staticmethod
+    def _build_index_definition(
+        embedder: Embedder,
+        filter_fields: Sequence[str],
+    ) -> dict[str, Any]:
+        fields: list[dict[str, Any]] = [
+            {
+                "type": "vector",
+                "path": "__embedding__",
+                "numDimensions": embedder.dimensions,
+                "similarity": "cosine",
+            },
+        ]
+        for field in filter_fields:
+            fields.append({"type": "filter", "path": field})
+        return {"fields": fields}
+
+    @staticmethod
+    def _index_matches(
+        index: Mapping[str, Any],
+        expected_filter_fields: Sequence[str],
+    ) -> bool:
+        definition = index.get("latestDefinition", index.get("definition", {}))
+        existing_filter_paths = {
+            f["path"] for f in definition.get("fields", []) if f.get("type") == "filter"
+        }
+        return existing_filter_paths == set(expected_filter_fields)
+
+    async def _wait_for_index_dropped(
+        self,
+        mongo_collection: AsyncCollection[Any],
+    ) -> None:
+        """Poll until the vector search index is fully removed."""
+        elapsed = 0.0
+        while elapsed < _INDEX_READY_TIMEOUT:
+            index_cursor = await mongo_collection.list_search_indexes()
+            found = False
+            async for index in index_cursor:
+                if index.get("name") == VECTOR_INDEX_NAME:
+                    found = True
+                    break
+            if not found:
+                return
+            await asyncio.sleep(_INDEX_READY_POLL_INTERVAL)
+            elapsed += _INDEX_READY_POLL_INTERVAL
+
+        self._logger.warning(
+            f"Vector search index '{VECTOR_INDEX_NAME}' on '{mongo_collection.name}' "
+            f"did not drop within {_INDEX_READY_TIMEOUT}s"
+        )
 
     async def _wait_for_index_ready(
         self,
@@ -203,6 +246,7 @@ class MongoVectorDatabase(VectorDatabase):
             schema=schema,
             embedder=embedder,
             embedding_cache_provider=self._embedding_cache_provider,
+            database=self,
         )
 
         self._collections[name] = collection  # type: ignore[assignment]
@@ -241,6 +285,7 @@ class MongoVectorDatabase(VectorDatabase):
             schema=schema,
             embedder=embedder,
             embedding_cache_provider=self._embedding_cache_provider,
+            database=self,
         )
 
         self._collections[name] = collection  # type: ignore[assignment]
@@ -274,6 +319,7 @@ class MongoVectorDatabase(VectorDatabase):
             schema=schema,
             embedder=embedder,
             embedding_cache_provider=self._embedding_cache_provider,
+            database=self,
         )
 
         self._collections[name] = collection  # type: ignore[assignment]
@@ -372,6 +418,7 @@ class MongoVectorCollection(Generic[TDocument], BaseVectorCollection[TDocument])
         schema: type[TDocument],
         embedder: Embedder,
         embedding_cache_provider: EmbeddingCacheProvider,
+        database: MongoVectorDatabase,
     ) -> None:
         super().__init__(tracer)
 
@@ -381,7 +428,20 @@ class MongoVectorCollection(Generic[TDocument], BaseVectorCollection[TDocument])
         self._embedder = embedder
         self._embedding_cache_provider = embedding_cache_provider
         self._mongo_collection = mongo_collection
+        self._database = database
         self._lock = ReaderWriterLock()
+
+    @override
+    async def ensure_indexes(
+        self,
+        indexes: Sequence[VectorCollectionIndex],
+    ) -> None:
+        filter_fields = [idx.field for idx in indexes]
+        await self._database._ensure_vector_index(
+            self._mongo_collection,
+            self._embedder,
+            filter_fields=filter_fields,
+        )
 
     def _strip_internal_fields(self, doc: dict[str, Any]) -> TDocument:
         """Remove MongoDB internal fields and embedding from a document."""

--- a/src/parlant/adapters/vector_db/mongo.py
+++ b/src/parlant/adapters/vector_db/mongo.py
@@ -112,8 +112,7 @@ class MongoVectorDatabase(VectorDatabase):
         # Ensure the collection exists in MongoDB before creating a search index
         await self._ensure_collection_exists(mongo_collection.name)
 
-        base_filter_fields = {"id", "version", "checksum"}
-        all_filter_fields = sorted(base_filter_fields | set(filter_fields))
+        all_filter_fields = sorted({"id"} | set(filter_fields))
 
         expected_definition = self._build_index_definition(embedder, all_filter_fields)
 

--- a/src/parlant/adapters/vector_db/qdrant.py
+++ b/src/parlant/adapters/vector_db/qdrant.py
@@ -44,6 +44,7 @@ from parlant.core.persistence.vector_database import (
     InsertResult,
     SimilarDocumentResult,
     UpdateResult,
+    VectorCollectionIndex,
     VectorDatabase,
     TDocument,
     identity_loader,
@@ -922,6 +923,13 @@ class QdrantCollection(Generic[TDocument], BaseVectorCollection[TDocument]):
         self._database: Optional[QdrantDatabase] = (
             None  # Reference to parent database for version methods
         )
+
+    @override
+    async def ensure_indexes(
+        self,
+        indexes: Sequence[VectorCollectionIndex],
+    ) -> None:
+        pass
 
     @override
     async def find(

--- a/src/parlant/adapters/vector_db/transient.py
+++ b/src/parlant/adapters/vector_db/transient.py
@@ -71,6 +71,7 @@ from parlant.core.persistence.vector_database import (
     InsertResult,
     SimilarDocumentResult,
     UpdateResult,
+    VectorCollectionIndex,
     VectorDatabase,
     TDocument,
 )
@@ -213,6 +214,13 @@ class TransientVectorCollection(Generic[TDocument], BaseVectorCollection[TDocume
         self._lock = asyncio.Lock()
         self._nano_db = nano_db
         self._documents: list[TDocument] = []
+
+    @override
+    async def ensure_indexes(
+        self,
+        indexes: Sequence[VectorCollectionIndex],
+    ) -> None:
+        pass
 
     @staticmethod
     def _build_filter_lambda(

--- a/src/parlant/core/canned_responses.py
+++ b/src/parlant/core/canned_responses.py
@@ -32,6 +32,7 @@ from parlant.core.persistence.document_database_helper import (
 from parlant.core.persistence.vector_database import (
     SimilarDocumentResult,
     VectorCollection,
+    VectorCollectionIndex,
     VectorDatabase,
     BaseDocument as VectorDocument,
 )
@@ -517,6 +518,9 @@ class CannedResponseVectorStore(CannedResponseStore):
                 schema=CannedResponseVectorDocument,
                 embedder_type=embedder_type,
                 document_loader=self._vector_document_loader,
+            )
+            await self._canreps_vector_collection.ensure_indexes(
+                [VectorCollectionIndex(field="canned_response_id")]
             )
 
         async with DocumentStoreMigrationHelper(

--- a/src/parlant/core/capabilities.py
+++ b/src/parlant/core/capabilities.py
@@ -35,6 +35,7 @@ from parlant.core.persistence.vector_database import (
     BaseDocument as VectorBaseDocument,
     SimilarDocumentResult,
     VectorCollection,
+    VectorCollectionIndex,
     VectorDatabase,
 )
 from parlant.core.persistence.vector_database_helper import (
@@ -234,6 +235,9 @@ class CapabilityVectorStore(CapabilityStore):
                 schema=CapabilityVectorDocument,
                 embedder_type=embedder_type,
                 document_loader=self._vector_document_loader,
+            )
+            await self._vector_collection.ensure_indexes(
+                [VectorCollectionIndex(field="capability_id")]
             )
 
         async with DocumentStoreMigrationHelper(

--- a/src/parlant/core/glossary.py
+++ b/src/parlant/core/glossary.py
@@ -34,6 +34,7 @@ from parlant.core.nlp.embedding import Embedder, EmbedderFactory
 from parlant.core.persistence.vector_database import (
     BaseDocument as VectorBaseDocument,
     VectorCollection,
+    VectorCollectionIndex,
     VectorDatabase,
 )
 from parlant.core.persistence.vector_database_helper import (
@@ -264,6 +265,7 @@ class GlossaryVectorStore(GlossaryStore):
                 embedder_type=embedder_type,
                 document_loader=self._document_loader,
             )
+            await self._collection.ensure_indexes([VectorCollectionIndex(field="id")])
 
         async with DocumentStoreMigrationHelper(
             store=self,

--- a/src/parlant/core/journeys.py
+++ b/src/parlant/core/journeys.py
@@ -48,6 +48,7 @@ from parlant.core.persistence.document_database_helper import (
 )
 from parlant.core.persistence.vector_database import (
     VectorCollection,
+    VectorCollectionIndex,
     VectorDatabase,
     BaseDocument as VectorDocument,
 )
@@ -858,6 +859,9 @@ class JourneyVectorStore(JourneyStore):
                 schema=JourneyVectorDocument,
                 embedder_type=embedder_type,
                 document_loader=self._vector_document_loader,
+            )
+            await self._vector_collection.ensure_indexes(
+                [VectorCollectionIndex(field="journey_id")]
             )
 
         async with DocumentStoreMigrationHelper(

--- a/src/parlant/core/persistence/vector_database.py
+++ b/src/parlant/core/persistence/vector_database.py
@@ -44,6 +44,11 @@ class BaseDocument(TypedDict, total=False):
 TDocument = TypeVar("TDocument", bound=BaseDocument)
 
 
+@dataclass(frozen=True)
+class VectorCollectionIndex:
+    field: str
+
+
 async def identity_loader(doc: BaseDocument) -> BaseDocument:
     return doc
 
@@ -175,6 +180,14 @@ class VectorCollection(ABC, Generic[TDocument]):
         k: int,
         hints: Mapping[str, Any] = {},
     ) -> Sequence[SimilarDocumentResult[TDocument]]: ...
+
+    @abstractmethod
+    async def ensure_indexes(
+        self,
+        indexes: Sequence[VectorCollectionIndex],
+    ) -> None:
+        """Ensures the requested filter indexes exist for the collection."""
+        ...
 
 
 class BaseVectorCollection(VectorCollection[TDocument]):

--- a/tests/adapters/vector_db/test_transient.py
+++ b/tests/adapters/vector_db/test_transient.py
@@ -1,7 +1,72 @@
-from parlant.adapters.vector_db.transient import TransientVectorCollection
+from typing import AsyncIterator, TypedDict, cast
+
+from lagom import Container
+from pytest import fixture
+from typing_extensions import Required
+
+from parlant.adapters.vector_db.transient import TransientVectorCollection, TransientVectorDatabase
+from parlant.core.common import Version
+from parlant.core.loggers import Logger
+from parlant.core.nlp.embedding import EmbedderFactory, NullEmbeddingCache
+from parlant.core.persistence.common import ObjectId
+from parlant.core.persistence.vector_database import BaseDocument, VectorCollectionIndex
+from parlant.core.tracer import Tracer
+
+
+class _TestDocument(TypedDict, total=False):
+    id: ObjectId
+    version: Version.String
+    content: str
+    checksum: Required[str]
+    category: str
+
+
+@fixture
+async def transient_database(
+    container: Container,
+) -> AsyncIterator[TransientVectorDatabase]:
+    db = TransientVectorDatabase(
+        logger=container[Logger],
+        tracer=container[Tracer],
+        embedder_factory=EmbedderFactory(container),
+        embedding_cache_provider=NullEmbeddingCache,
+    )
+    yield db
+
+
+@fixture
+async def transient_collection(
+    transient_database: TransientVectorDatabase,
+) -> TransientVectorCollection[_TestDocument]:
+    async def loader(doc: BaseDocument) -> _TestDocument:
+        return cast(_TestDocument, doc)
+
+    from parlant.core.nlp.embedding import NullEmbedder
+
+    collection = await transient_database.get_or_create_collection(
+        "test_collection",
+        _TestDocument,
+        embedder_type=NullEmbedder,
+        document_loader=loader,
+    )
+    return collection
 
 
 def test_that_negative_cosine_similarity_is_not_treated_as_close_distance() -> None:
     assert TransientVectorCollection._distance_from_similarity(1.0) == 0.0
     assert TransientVectorCollection._distance_from_similarity(0.0) == 1.0
     assert TransientVectorCollection._distance_from_similarity(-1.0) == 2.0
+
+
+async def test_that_ensure_indexes_accepts_vector_collection_indexes(
+    transient_collection: TransientVectorCollection[_TestDocument],
+) -> None:
+    await transient_collection.ensure_indexes([VectorCollectionIndex(field="category")])
+
+
+async def test_that_ensure_indexes_is_idempotent(
+    transient_collection: TransientVectorCollection[_TestDocument],
+) -> None:
+    indexes = [VectorCollectionIndex(field="category")]
+    await transient_collection.ensure_indexes(indexes)
+    await transient_collection.ensure_indexes(indexes)


### PR DESCRIPTION
## Summary

- Add `VectorCollectionIndex` dataclass and `ensure_indexes` abstract method to `VectorCollection`, mirroring the existing `DocumentCollection.ensure_indexes` / `CollectionIndex` pattern
- Stores declare which fields they need filterable in vector search via `ensure_indexes` after obtaining their collection
- The Mongo adapter builds the Atlas vector search index definition dynamically from the declared fields, and detects stale indexes to drop and recreate them
- Other adapters (transient, qdrant, chroma) implement `ensure_indexes` as a no-op

## Problem

The Mongo vector search index had hardcoded filter fields (`id`, `version`, `name`, `checksum`). Stores filtering on `journey_id`, `capability_id`, and `canned_response_id` during `$vectorSearch` were silently failing because those fields weren't declared as filterable in the index definition.

## Stores updated

| Store | Filter field declared |
|-------|---------------------|
| Journeys | `journey_id` |
| Capabilities | `capability_id` |
| Canned Responses | `canned_response_id` |
| Glossary | _(none — filters on `id` which is a base field)_ |

## Test plan

- [x] Added `test_that_ensure_indexes_accepts_vector_collection_indexes`
- [x] Added `test_that_ensure_indexes_is_idempotent`
- [x] Tests written first (TDD) — failed with `ImportError` before implementation
- [x] mypy + ruff clean