### PR TITLE
Fix CompositeJourneyStore list_nodes/list_edges with try_or_none

### DIFF
--- a/src/parlant/core/guidelines.py
+++ b/src/parlant/core/guidelines.py
@@ -1083,9 +1083,12 @@ class CompositeGuidelineStore(GuidelineStore):
         results = await safe_gather(
             *[try_or_none(store.read_guideline(guideline_id)) for store in self._all_stores]
         )
+
         result = next((r for r in results if r is not None), None)
+
         if result is None:
             raise ItemNotFoundError(item_id=UniqueId(guideline_id))
+
         return result
 
     @override

--- a/src/parlant/core/journeys.py
+++ b/src/parlant/core/journeys.py
@@ -2186,9 +2186,12 @@ class CompositeJourneyStore(JourneyStore):
         results = await safe_gather(
             *[try_or_none(store.read_journey(journey_id)) for store in self._all_stores]
         )
+
         result = next((r for r in results if r is not None), None)
+
         if result is None:
             raise ItemNotFoundError(item_id=UniqueId(journey_id))
+
         return result
 
     @override
@@ -2306,8 +2309,10 @@ class CompositeJourneyStore(JourneyStore):
         self,
         journey_id: JourneyId,
     ) -> Sequence[JourneyNode]:
-        results = await safe_gather(*[store.list_nodes(journey_id) for store in self._all_stores])
-        return list(chain.from_iterable(results))
+        raw_results = await safe_gather(
+            *[try_or_none(store.list_nodes(journey_id)) for store in self._all_stores]
+        )
+        return list(chain.from_iterable(r for r in raw_results if r is not None))
 
     @override
     async def set_node_metadata(
@@ -2389,9 +2394,9 @@ class CompositeJourneyStore(JourneyStore):
         node_id: Optional[JourneyNodeId] = None,
     ) -> Sequence[JourneyEdge]:
         results = await safe_gather(
-            *[store.list_edges(journey_id, node_id) for store in self._all_stores]
+            *[try_or_none(store.list_edges(journey_id, node_id)) for store in self._all_stores]
         )
-        return list(chain.from_iterable(results))
+        return list(chain.from_iterable(r for r in results if r is not None))
 
     @override
     async def delete_edge(


### PR DESCRIPTION
## Summary
- `CompositeJourneyStore.list_nodes` and `list_edges` now wrap per-store calls with `try_or_none`, matching the pattern already used by `read_journey` and `read_edge`
- Fixes journey read returning 404 when journey exists in base store but not in MongoDB writable store

## Root cause
`list_nodes`/`list_edges` internally call `read_journey` which throws `ItemNotFoundError` when the journey doesn't exist in that particular store. `safe_gather(return_exceptions=False)` propagates the first error, discarding successful results from other stores.

## Test plan
- [x] Reproduced locally with bank-agent-demo connected to real MongoDB (composite store active) — all 3 journeys return 404 on read
- [x] Applied fix — all 3 journeys read OK (11/7/7 nodes, 9/5/5 edges)
- [ ] Verify on deployed cluster service after merge