### PR TITLE
Add trace events for glossary, context variables, and canned response selection

### DIFF
--- a/src/parlant/core/engines/alpha/canned_response_generator.py
+++ b/src/parlant/core/engines/alpha/canned_response_generator.py
@@ -2434,6 +2434,14 @@ Output a JSON object with three properties:
                 chosen_canned_responses=[(no_match_canrep.id, no_match_canrep.value)],
             )
 
+        self._tracer.add_event(
+            "canrep.selected",
+            attributes={
+                "canned_response_id": selected_canrep_id,
+                "rendered": rendered_canned_response or "",
+            },
+        )
+
         return {
             "draft": draft_response.info,
             "selection": selection_response.info,

--- a/src/parlant/core/engines/alpha/engine.py
+++ b/src/parlant/core/engines/alpha/engine.py
@@ -475,6 +475,17 @@ class AlphaEngine(Engine):
         # Load the relevant context variable values.
         context.state.context_variables = await self._load_context_variables(context)
 
+        for var, val in context.state.context_variables:
+            self._tracer.add_event(
+                "ctx.variable_loaded",
+                attributes={
+                    "variable_id": var.id,
+                    "name": var.name,
+                    "value": str(val.data),
+                    "last_modified": var.last_modified.isoformat(),
+                },
+            )
+
         # Load relevant glossary terms and capabilities, initially based
         # mostly on the current interaction history.
         glossary, capabilities = await async_utils.safe_gather(
@@ -484,6 +495,16 @@ class AlphaEngine(Engine):
 
         context.state.glossary_terms.update(glossary)
         context.state.capabilities = list(capabilities)
+
+        for term in glossary:
+            self._tracer.add_event(
+                "glossary.term_loaded",
+                attributes={
+                    "term_id": term.id,
+                    "name": term.name,
+                    "last_modified": term.last_modified.isoformat(),
+                },
+            )
 
     async def _run_preparation_iteration(
         self,


### PR DESCRIPTION
## Summary
Adds three new trace events so the OTEL collector can resolve and display these entities in enriched traces.

### New events

| Event | When | Attributes |
|-------|------|------------|
| `glossary.terms_loaded` | After glossary terms are loaded for a request | `term_id_N`, `term_name_N`, `last_modified_N` per term |
| `ctx.variables_loaded` | After context variables are loaded for a request | `variable_id_N`, `variable_name_N`, `variable_value_N`, `last_modified_N` per variable |
| `canrep.selected` | When a canned response is chosen | `canned_response_id`, `rendered` |

### Context
The enrichedtrace exporter in the OTEL collector already handles these event names but they were never emitted by the engine. Currently `entities.terms`, `entities.context_variables`, and `entities.canned_responses` are always empty in enriched traces.

### Existing events (unchanged)
- `gm.activate` / `gm.deactivate` / `gm.skipped` — guideline events
- `journey.state.activate` / `journey.state.skipped` — journey events
- `tc` — tool calls
- `canrep.draft` — canned response draft (already has `insights` for reasoning)
- `canrep.ttfm` / `mg.ttfm` / `canrep.streaming.ttfm` — time-to-first-message metrics
- `canrep.preamble_generated` — preamble flag