### PR TITLE
Rename last_modified to last_modified_utc on entity classes

### DIFF
--- a/src/parlant/api/canned_responses.py
+++ b/src/parlant/api/canned_responses.py
@@ -196,7 +196,7 @@ class CannedResponseDTO(
 ):
     id: CannedResponseIdField
     creation_utc: CannedResponseCreationUTCField
-    last_modified: CannedResponseLastModifiedField
+    last_modified_utc: CannedResponseLastModifiedField
     value: CannedResponseValueField
     fields: CannedResponseFieldSequenceField
     tags: TagIdSequenceField
@@ -386,7 +386,7 @@ def create_router(
         return CannedResponseDTO(
             id=canrep.id,
             creation_utc=canrep.creation_utc,
-            last_modified=canrep.last_modified,
+            last_modified_utc=canrep.last_modified_utc,
             value=canrep.value,
             fields=[_canned_response_field_to_dto(s) for s in canrep.fields],
             tags=canrep.tags,
@@ -422,7 +422,7 @@ def create_router(
         return CannedResponseDTO(
             id=canrep.id,
             creation_utc=canrep.creation_utc,
-            last_modified=canrep.last_modified,
+            last_modified_utc=canrep.last_modified_utc,
             value=canrep.value,
             fields=[_canned_response_field_to_dto(s) for s in canrep.fields],
             tags=canrep.tags,
@@ -455,7 +455,7 @@ def create_router(
             CannedResponseDTO(
                 id=f.id,
                 creation_utc=f.creation_utc,
-                last_modified=f.last_modified,
+                last_modified_utc=f.last_modified_utc,
                 value=f.value,
                 fields=[_canned_response_field_to_dto(s) for s in f.fields],
                 tags=f.tags,
@@ -526,7 +526,7 @@ def create_router(
         return CannedResponseDTO(
             id=canrep.id,
             creation_utc=canrep.creation_utc,
-            last_modified=canrep.last_modified,
+            last_modified_utc=canrep.last_modified_utc,
             value=canrep.value,
             fields=[_canned_response_field_to_dto(s) for s in canrep.fields],
             tags=canrep.tags,

--- a/src/parlant/api/common.py
+++ b/src/parlant/api/common.py
@@ -348,7 +348,7 @@ class GuidelineDTO(
     enabled: GuidelineEnabledField = True
     tags: GuidelineTagsField
     metadata: GuidelineMetadataField
-    last_modified: GuidelineLastModifiedField
+    last_modified_utc: GuidelineLastModifiedField
     composition_mode: CompositionModeDTO | None = None
     track: bool = True
     labels: GuidelineLabelsField = set()

--- a/src/parlant/api/context_variables.py
+++ b/src/parlant/api/context_variables.py
@@ -120,7 +120,7 @@ ContextVariableLastModifiedField: TypeAlias = Annotated[
 
 context_variable_value_example: ExampleJson = {
     "id": "val_789abc",
-    "last_modified": "2024-03-24T12:00:00Z",
+    "last_modified_utc": "2024-03-24T12:00:00Z",
     "data": {
         "balance": 5000.50,
         "currency": "USD",
@@ -143,7 +143,7 @@ class ContextVariableValueDTO(
     """
 
     id: ValueIdField
-    last_modified: LastModifiedField
+    last_modified_utc: LastModifiedField
     data: DataField
 
 
@@ -232,7 +232,7 @@ class ContextVariableDTO(
     tool_id: ToolIdDTO | None = None
     freshness_rules: FreshnessRulesField | None = None
     tags: ContextVariableTagsField | None = None
-    last_modified: ContextVariableLastModifiedField
+    last_modified_utc: ContextVariableLastModifiedField
 
 
 context_variable_tags_update_params_example: ExampleJson = {
@@ -420,7 +420,7 @@ def create_router(
             else None,
             freshness_rules=variable.freshness_rules,
             tags=variable.tags,
-            last_modified=variable.last_modified,
+            last_modified_utc=variable.last_modified_utc,
         )
 
     @router.patch(
@@ -482,7 +482,7 @@ def create_router(
             else None,
             freshness_rules=updated_variable.freshness_rules,
             tags=updated_variable.tags,
-            last_modified=updated_variable.last_modified,
+            last_modified_utc=updated_variable.last_modified_utc,
         )
 
     @router.get(
@@ -519,7 +519,7 @@ def create_router(
                 else None,
                 freshness_rules=v.freshness_rules,
                 tags=v.tags,
-                last_modified=v.last_modified,
+                last_modified_utc=v.last_modified_utc,
             )
             for v in variables
         ]
@@ -565,7 +565,7 @@ def create_router(
             else None,
             freshness_rules=variable.freshness_rules,
             tags=variable.tags,
-            last_modified=variable.last_modified,
+            last_modified_utc=variable.last_modified_utc,
         )
 
         if not include_values:
@@ -581,7 +581,7 @@ def create_router(
             key_value_pairs={
                 key: ContextVariableValueDTO(
                     id=value.id,
-                    last_modified=value.last_modified,
+                    last_modified_utc=value.last_modified_utc,
                     data=cast(JSONSerializableDTO, value.data),
                 )
                 for key, value in key_value_pairs
@@ -661,7 +661,7 @@ def create_router(
         if value:
             return ContextVariableValueDTO(
                 id=value.id,
-                last_modified=value.last_modified,
+                last_modified_utc=value.last_modified_utc,
                 data=cast(JSONSerializableDTO, value.data),
             )
 
@@ -703,7 +703,7 @@ def create_router(
 
         return ContextVariableValueDTO(
             id=value.id,
-            last_modified=value.last_modified,
+            last_modified_utc=value.last_modified_utc,
             data=cast(JSONSerializableDTO, value.data),
         )
 

--- a/src/parlant/api/glossary.py
+++ b/src/parlant/api/glossary.py
@@ -159,7 +159,7 @@ class TermDTO(
     description: TermDescriptionField
     synonyms: TermSynonymsField = []
     tags: TermTagsField
-    last_modified: TermLastModifiedField
+    last_modified_utc: TermLastModifiedField
 
 
 TermTagsUpdateAddField: TypeAlias = Annotated[
@@ -273,7 +273,7 @@ def create_router(
             description=term.description,
             synonyms=term.synonyms,
             tags=term.tags,
-            last_modified=term.last_modified,
+            last_modified_utc=term.last_modified_utc,
         )
 
     @router.get(
@@ -308,7 +308,7 @@ def create_router(
             description=term.description,
             synonyms=term.synonyms,
             tags=term.tags,
-            last_modified=term.last_modified,
+            last_modified_utc=term.last_modified_utc,
         )
 
     @router.get(
@@ -344,7 +344,7 @@ def create_router(
                 description=term.description,
                 synonyms=term.synonyms,
                 tags=term.tags,
-                last_modified=term.last_modified,
+                last_modified_utc=term.last_modified_utc,
             )
             for term in terms
         ]
@@ -399,7 +399,7 @@ def create_router(
             description=term.description,
             synonyms=term.synonyms,
             tags=term.tags,
-            last_modified=term.last_modified,
+            last_modified_utc=term.last_modified_utc,
         )
 
     @router.delete(

--- a/src/parlant/api/guidelines.py
+++ b/src/parlant/api/guidelines.py
@@ -439,7 +439,7 @@ def _guideline_relationship_to_dto(
             enabled=rel_source_guideline.enabled,
             tags=rel_source_guideline.tags,
             metadata=rel_source_guideline.metadata,
-            last_modified=rel_source_guideline.last_modified,
+            last_modified_utc=rel_source_guideline.last_modified_utc,
             composition_mode=composition_mode_to_composition_mode_dto(
                 rel_source_guideline.composition_mode
             )
@@ -468,7 +468,7 @@ def _guideline_relationship_to_dto(
             enabled=rel_target_guideline.enabled,
             tags=rel_target_guideline.tags,
             metadata=rel_target_guideline.metadata,
-            last_modified=rel_target_guideline.last_modified,
+            last_modified_utc=rel_target_guideline.last_modified_utc,
             composition_mode=composition_mode_to_composition_mode_dto(
                 rel_target_guideline.composition_mode
             )
@@ -560,7 +560,7 @@ def create_router(
             description=guideline.content.description,
             criticality=_criticality_to_dto(guideline.criticality),
             metadata=guideline.metadata,
-            last_modified=guideline.last_modified,
+            last_modified_utc=guideline.last_modified_utc,
             enabled=guideline.enabled,
             tags=guideline.tags,
             composition_mode=composition_mode_to_composition_mode_dto(guideline.composition_mode)
@@ -606,7 +606,7 @@ def create_router(
                 description=guideline.content.description,
                 criticality=_criticality_to_dto(guideline.criticality),
                 metadata=guideline.metadata,
-                last_modified=guideline.last_modified,
+                last_modified_utc=guideline.last_modified_utc,
                 enabled=guideline.enabled,
                 tags=guideline.tags,
                 composition_mode=composition_mode_to_composition_mode_dto(
@@ -671,7 +671,7 @@ def create_router(
                 description=guideline.content.description,
                 criticality=_criticality_to_dto(guideline.criticality),
                 metadata=guideline.metadata,
-                last_modified=guideline.last_modified,
+                last_modified_utc=guideline.last_modified_utc,
                 enabled=guideline.enabled,
                 tags=guideline.tags,
                 composition_mode=composition_mode_to_composition_mode_dto(
@@ -794,7 +794,7 @@ def create_router(
                 description=updated_guideline.content.description,
                 criticality=_criticality_to_dto(updated_guideline.criticality),
                 metadata=updated_guideline.metadata,
-                last_modified=updated_guideline.last_modified,
+                last_modified_utc=updated_guideline.last_modified_utc,
                 enabled=updated_guideline.enabled,
                 tags=updated_guideline.tags,
                 composition_mode=composition_mode_to_composition_mode_dto(

--- a/src/parlant/api/journeys.py
+++ b/src/parlant/api/journeys.py
@@ -183,7 +183,7 @@ class JourneyDTO(
     composition_mode: CompositionModeDTO | None = None
     labels: JourneyLabelsField = set()
     priority: int = 0
-    last_modified: JourneyLastModifiedField
+    last_modified_utc: JourneyLastModifiedField
 
 
 class JourneyGraphDTO(JourneyDTO):
@@ -526,7 +526,7 @@ def create_router(
             else None,
             labels=journey.labels,
             priority=journey.priority,
-            last_modified=journey.last_modified,
+            last_modified_utc=journey.last_modified_utc,
         )
 
     @router.get(
@@ -568,7 +568,7 @@ def create_router(
                     else None,
                     labels=journey.labels,
                     priority=journey.priority,
-                    last_modified=journey.last_modified,
+                    last_modified_utc=journey.last_modified_utc,
                 )
             )
 
@@ -634,7 +634,7 @@ def create_router(
             else None,
             labels=model.journey.labels,
             priority=model.journey.priority,
-            last_modified=model.journey.last_modified,
+            last_modified_utc=model.journey.last_modified_utc,
             nodes=[node_to_dto(n) for n in model.nodes],
             edges=[edge_to_dto(e) for e in model.edges],
         )
@@ -731,7 +731,7 @@ def create_router(
             else None,
             labels=journey.labels,
             priority=journey.priority,
-            last_modified=journey.last_modified,
+            last_modified_utc=journey.last_modified_utc,
         )
 
     @router.delete(

--- a/src/parlant/api/relationships.py
+++ b/src/parlant/api/relationships.py
@@ -177,7 +177,7 @@ def create_router(
                 enabled=model.source_guideline.enabled,
                 tags=model.source_guideline.tags,
                 metadata=model.source_guideline.metadata,
-                last_modified=model.source_guideline.last_modified,
+                last_modified_utc=model.source_guideline.last_modified_utc,
                 priority=model.source_guideline.priority,
             )
             if model.source_guideline
@@ -195,7 +195,7 @@ def create_router(
                 enabled=model.target_guideline.enabled,
                 tags=model.target_guideline.tags,
                 metadata=model.target_guideline.metadata,
-                last_modified=model.target_guideline.last_modified,
+                last_modified_utc=model.target_guideline.last_modified_utc,
                 priority=model.target_guideline.priority,
             )
             if model.target_guideline

--- a/src/parlant/core/canned_responses.py
+++ b/src/parlant/core/canned_responses.py
@@ -81,7 +81,7 @@ class CannedResponse:
             value=value,
             fields=[],
             creation_utc=now,
-            last_modified=now,
+            last_modified_utc=now,
             tags=[],
             signals=[],
             metadata={},
@@ -93,7 +93,7 @@ class CannedResponse:
 
     id: CannedResponseId
     creation_utc: datetime
-    last_modified: datetime
+    last_modified_utc: datetime
     value: str
     fields: Sequence[CannedResponseField]
     signals: Sequence[str]
@@ -563,7 +563,7 @@ class CannedResponseVectorStore(CannedResponseStore):
             id=ObjectId(canned_response_id.id),
             version=self.VERSION.to_string(),
             creation_utc=canned_response_id.creation_utc.isoformat(),
-            last_modified=canned_response_id.last_modified.isoformat(),
+            last_modified=canned_response_id.last_modified_utc.isoformat(),
             value=canned_response_id.value,
             fields=json.dumps(
                 [
@@ -589,7 +589,7 @@ class CannedResponseVectorStore(CannedResponseStore):
         return CannedResponse(
             id=CannedResponseId(canned_response_document["id"]),
             creation_utc=datetime.fromisoformat(canned_response_document["creation_utc"]),
-            last_modified=datetime.fromisoformat(
+            last_modified_utc=datetime.fromisoformat(
                 canned_response_document.get(
                     "last_modified", canned_response_document["creation_utc"]
                 )
@@ -658,7 +658,7 @@ class CannedResponseVectorStore(CannedResponseStore):
                 value=value,
                 fields=fields or [],
                 creation_utc=creation_utc,
-                last_modified=creation_utc,
+                last_modified_utc=creation_utc,
                 metadata=metadata,
                 tags=tags or [],
                 signals=signals or [],
@@ -736,7 +736,7 @@ class CannedResponseVectorStore(CannedResponseStore):
             canrep = CannedResponse(
                 id=CannedResponseId(canned_response_id),
                 creation_utc=datetime.fromisoformat(doc["creation_utc"]),
-                last_modified=datetime.now(timezone.utc),
+                last_modified_utc=datetime.now(timezone.utc),
                 value=params.get("value", existing_value.value),
                 fields=params.get("fields", existing_value.fields),
                 signals=params.get("signals", existing_value.signals),

--- a/src/parlant/core/context_variables.py
+++ b/src/parlant/core/context_variables.py
@@ -53,7 +53,7 @@ class ContextVariable:
     name: str
     description: Optional[str]
     creation_utc: datetime
-    last_modified: datetime
+    last_modified_utc: datetime
     tool_id: Optional[ToolId]
     freshness_rules: Optional[str]
     tags: Sequence[TagId]
@@ -66,7 +66,7 @@ class ContextVariable:
 @dataclass(frozen=True)
 class ContextVariableValue:
     id: ContextVariableValueId
-    last_modified: datetime
+    last_modified_utc: datetime
     data: JSONSerializable
 
 
@@ -447,7 +447,7 @@ class ContextVariableDocumentStore(ContextVariableStore):
             name=context_variable.name,
             description=context_variable.description,
             creation_utc=context_variable.creation_utc.isoformat(),
-            last_modified=context_variable.last_modified.isoformat(),
+            last_modified=context_variable.last_modified_utc.isoformat(),
             tool_id=context_variable.tool_id.to_string() if context_variable.tool_id else None,
             freshness_rules=context_variable.freshness_rules,
         )
@@ -458,7 +458,7 @@ class ContextVariableDocumentStore(ContextVariableStore):
         variable_id: ContextVariableId,
         key: str,
     ) -> _ContextVariableValueDocument:
-        last_modified_str = context_variable_value.last_modified.isoformat()
+        last_modified_str = context_variable_value.last_modified_utc.isoformat()
 
         return _ContextVariableValueDocument(
             id=ObjectId(context_variable_value.id),
@@ -486,7 +486,7 @@ class ContextVariableDocumentStore(ContextVariableStore):
             name=context_variable_document["name"],
             description=context_variable_document.get("description"),
             creation_utc=datetime.fromisoformat(context_variable_document["creation_utc"]),
-            last_modified=datetime.fromisoformat(context_variable_document["last_modified"]),
+            last_modified_utc=datetime.fromisoformat(context_variable_document["last_modified"]),
             tool_id=ToolId.from_string(context_variable_document["tool_id"])
             if context_variable_document["tool_id"]
             else None,
@@ -500,7 +500,9 @@ class ContextVariableDocumentStore(ContextVariableStore):
     ) -> ContextVariableValue:
         return ContextVariableValue(
             id=ContextVariableValueId(context_variable_value_document["id"]),
-            last_modified=datetime.fromisoformat(context_variable_value_document["last_modified"]),
+            last_modified_utc=datetime.fromisoformat(
+                context_variable_value_document["last_modified"]
+            ),
             data=context_variable_value_document["data"],
         )
 
@@ -525,7 +527,7 @@ class ContextVariableDocumentStore(ContextVariableStore):
                 name=name,
                 description=description,
                 creation_utc=creation_utc,
-                last_modified=creation_utc,
+                last_modified_utc=creation_utc,
                 tool_id=tool_id,
                 freshness_rules=freshness_rules,
                 tags=tags or [],
@@ -698,7 +700,7 @@ class ContextVariableDocumentStore(ContextVariableStore):
 
             value = ContextVariableValue(
                 id=ContextVariableValueId(self._id_generator.generate(value_checksum)),
-                last_modified=last_modified,
+                last_modified_utc=last_modified,
                 data=data,
             )
 

--- a/src/parlant/core/engines/alpha/engine.py
+++ b/src/parlant/core/engines/alpha/engine.py
@@ -1060,12 +1060,12 @@ class AlphaEngine(Engine):
             )
 
             event_data["matched_guidelines"] = [
-                {"id": m.guideline.id, "last_modified": m.guideline.last_modified.isoformat()}
+                {"id": m.guideline.id, "last_modified": m.guideline.last_modified_utc.isoformat()}
                 for m in all_matches
             ]
 
             event_data["matched_journeys"] = [
-                {"id": j.id, "last_modified": j.last_modified.isoformat()}
+                {"id": j.id, "last_modified": j.last_modified_utc.isoformat()}
                 for j in context.state.journeys
             ]
 
@@ -1176,11 +1176,11 @@ class AlphaEngine(Engine):
             if match.guideline.metadata.get("journey_node"):
                 edge_id = extract_edge_id_from_journey_node_guideline_id(match.guideline.id)
                 journey_id = cast(str, match.metadata.get("step_selection_journey_id"))
-                journey_last_modified = ""
+                journey_last_modified_utc = ""
                 if journeys and journey_id:
                     j = journeys.get(JourneyId(journey_id))
                     if j:
-                        journey_last_modified = j.last_modified.isoformat()
+                        journey_last_modified_utc = j.last_modified_utc.isoformat()
 
                 self._tracer.add_event(
                     "journey.state.activate",
@@ -1195,8 +1195,8 @@ class AlphaEngine(Engine):
                         "rationale": match.rationale,
                         "journey_id": journey_id,
                         **(
-                            {"last_modified": journey_last_modified}
-                            if journey_last_modified
+                            {"last_modified": journey_last_modified_utc}
+                            if journey_last_modified_utc
                             else {}
                         ),
                         **(
@@ -1224,7 +1224,7 @@ class AlphaEngine(Engine):
                     "gm.activate",
                     attributes={
                         "guideline_id": match.guideline.id,
-                        "last_modified": match.guideline.last_modified.isoformat(),
+                        "last_modified": match.guideline.last_modified_utc.isoformat(),
                         "rationale": match.rationale,
                     },
                 )
@@ -1234,11 +1234,11 @@ class AlphaEngine(Engine):
                 edge_id = extract_edge_id_from_journey_node_guideline_id(skip.guideline.id)
 
                 journey_id = cast(str, skip.metadata.get("step_selection_journey_id"))
-                skip_journey_last_modified = ""
+                skip_journey_last_modified_utc = ""
                 if journeys and journey_id:
                     j = journeys.get(JourneyId(journey_id))
                     if j:
-                        skip_journey_last_modified = j.last_modified.isoformat()
+                        skip_journey_last_modified_utc = j.last_modified_utc.isoformat()
 
                 self._tracer.add_event(
                     "journey.state.skipped",
@@ -1253,8 +1253,8 @@ class AlphaEngine(Engine):
                         ),
                         "journey_id": journey_id,
                         **(
-                            {"last_modified": skip_journey_last_modified}
-                            if skip_journey_last_modified
+                            {"last_modified": skip_journey_last_modified_utc}
+                            if skip_journey_last_modified_utc
                             else {}
                         ),
                         **(
@@ -1282,7 +1282,7 @@ class AlphaEngine(Engine):
                     "gm.skipped",
                     attributes={
                         "guideline_id": skip.guideline.id,
-                        "last_modified": skip.guideline.last_modified.isoformat(),
+                        "last_modified": skip.guideline.last_modified_utc.isoformat(),
                         "rationale": skip.rationale,
                     },
                 )
@@ -2045,7 +2045,7 @@ class AlphaEngine(Engine):
                 guideline=Guideline(
                     id=GuidelineId(f"<canrep-request-{i}>"),
                     creation_utc=datetime.now(timezone.utc),
-                    last_modified=datetime.now(timezone.utc),
+                    last_modified_utc=datetime.now(timezone.utc),
                     content=GuidelineContent(
                         condition="",  # FIXME: Change this to None when we support `str | None` conditions
                         action=utterance_request.action,
@@ -2119,7 +2119,7 @@ class AlphaEngine(Engine):
                             guideline=Guideline(
                                 id=GuidelineId(f"<tool-guideline-{guideline_index}>"),
                                 creation_utc=datetime.now(timezone.utc),
-                                last_modified=datetime.now(timezone.utc),
+                                last_modified_utc=datetime.now(timezone.utc),
                                 content=GuidelineContent(
                                     condition=guideline_data.get("condition", ""),
                                     action=guideline_data["action"],
@@ -2321,7 +2321,7 @@ async def load_fresh_context_variable_value(
     # So we do have a tool attached.
     # Do we already have a value, and is it sufficiently fresh?
     if value and variable.freshness_rules:
-        cron_iterator = croniter(variable.freshness_rules, value.last_modified)
+        cron_iterator = croniter(variable.freshness_rules, value.last_modified_utc)
 
         if cron_iterator.get_next(datetime) > current_time:
             # We already have a fresh value in store. Return it.

--- a/src/parlant/core/engines/alpha/guideline_matching/generic/generic_guideline_matching_strategy.py
+++ b/src/parlant/core/engines/alpha/guideline_matching/generic/generic_guideline_matching_strategy.py
@@ -317,7 +317,7 @@ class GenericGuidelineMatchingStrategy(GuidelineMatchingStrategy):
                         guideline=Guideline(
                             id=cast(GuidelineId, f"<transient_{generate_id()}>"),
                             creation_utc=datetime.now(),
-                            last_modified=datetime.now(),
+                            last_modified_utc=datetime.now(),
                             content=GuidelineContent(
                                 condition=internal_representation(m.guideline).condition,
                                 action=cast(

--- a/src/parlant/core/engines/alpha/guideline_matching/generic/journey/journey_backtrack_check.py
+++ b/src/parlant/core/engines/alpha/guideline_matching/generic/journey/journey_backtrack_check.py
@@ -526,7 +526,7 @@ OUTPUT FORMAT
                     Guideline(
                         id=GuidelineId(f"c-{i}"),
                         creation_utc=datetime.now(timezone.utc),
-                        last_modified=datetime.now(timezone.utc),
+                        last_modified_utc=datetime.now(timezone.utc),
                         metadata={"journey_node": {"journey_id": "journey"}},
                         content=GuidelineContent(
                             condition=c,

--- a/src/parlant/core/engines/alpha/guideline_matching/generic/journey/journey_backtrack_node_selection.py
+++ b/src/parlant/core/engines/alpha/guideline_matching/generic/journey/journey_backtrack_node_selection.py
@@ -575,7 +575,7 @@ class JourneyBacktrackNodeSelection:
                     Guideline(
                         id=GuidelineId(f"c-{i}"),
                         creation_utc=datetime.now(timezone.utc),
-                        last_modified=datetime.now(timezone.utc),
+                        last_modified_utc=datetime.now(timezone.utc),
                         metadata={"journey_node": {"journey_id": "journey"}},
                         content=GuidelineContent(
                             condition=c,

--- a/src/parlant/core/engines/alpha/guideline_matching/generic/journey/journey_next_step_selection.py
+++ b/src/parlant/core/engines/alpha/guideline_matching/generic/journey/journey_next_step_selection.py
@@ -545,7 +545,7 @@ OUTPUT FORMAT
                 Guideline(
                     id=GuidelineId(f"c-{i}"),
                     creation_utc=datetime.now(timezone.utc),
-                    last_modified=datetime.now(timezone.utc),
+                    last_modified_utc=datetime.now(timezone.utc),
                     metadata={"journey_node": {"journey_id": "journey"}},
                     content=GuidelineContent(
                         condition=c,

--- a/src/parlant/core/engines/alpha/relational_resolver.py
+++ b/src/parlant/core/engines/alpha/relational_resolver.py
@@ -1379,7 +1379,7 @@ class RelationalResolver:
                     "gm.activate",
                     attributes={
                         "guideline_id": match.guideline.id,
-                        "last_modified": match.guideline.last_modified.isoformat(),
+                        "last_modified": match.guideline.last_modified_utc.isoformat(),
                         "rationale": "Activated via entailment",
                     },
                 )
@@ -1394,7 +1394,7 @@ class RelationalResolver:
                 "gm.deactivate",
                 attributes={
                     "guideline_id": gid,
-                    "last_modified": m.guideline.last_modified.isoformat(),
+                    "last_modified": m.guideline.last_modified_utc.isoformat(),
                     "rationale": rationale,
                 },
             )

--- a/src/parlant/core/glossary.py
+++ b/src/parlant/core/glossary.py
@@ -58,7 +58,7 @@ TermId = NewType("TermId", str)
 class Term:
     id: TermId
     creation_utc: datetime
-    last_modified: datetime
+    last_modified_utc: datetime
     name: str
     description: str
     synonyms: list[str]
@@ -303,7 +303,7 @@ class GlossaryVectorStore(GlossaryStore):
             content=content,
             checksum=checksum,
             creation_utc=term.creation_utc.isoformat(),
-            last_modified=term.last_modified.isoformat(),
+            last_modified=term.last_modified_utc.isoformat(),
             name=term.name,
             description=term.description,
             synonyms=(", ").join(term.synonyms) if term.synonyms is not None else "",
@@ -317,7 +317,7 @@ class GlossaryVectorStore(GlossaryStore):
         return Term(
             id=TermId(term_document["id"]),
             creation_utc=datetime.fromisoformat(term_document["creation_utc"]),
-            last_modified=datetime.fromisoformat(term_document["last_modified"]),
+            last_modified_utc=datetime.fromisoformat(term_document["last_modified"]),
             name=term_document["name"],
             description=term_document["description"],
             synonyms=term_document["synonyms"].split(", ") if term_document["synonyms"] else [],
@@ -356,7 +356,7 @@ class GlossaryVectorStore(GlossaryStore):
             term = Term(
                 id=term_id,
                 creation_utc=creation_utc,
-                last_modified=creation_utc,
+                last_modified_utc=creation_utc,
                 name=name,
                 description=description,
                 synonyms=list(synonyms) if synonyms else [],

--- a/src/parlant/core/guidelines.py
+++ b/src/parlant/core/guidelines.py
@@ -57,7 +57,7 @@ class GuidelineContent:
 class Guideline:
     id: GuidelineId
     creation_utc: datetime
-    last_modified: datetime
+    last_modified_utc: datetime
     content: GuidelineContent
     enabled: bool
     tags: Sequence[TagId]
@@ -586,7 +586,7 @@ class GuidelineDocumentStore(GuidelineStore):
             id=ObjectId(guideline.id),
             version=self.VERSION.to_string(),
             creation_utc=guideline.creation_utc.isoformat(),
-            last_modified=guideline.last_modified.isoformat(),
+            last_modified=guideline.last_modified_utc.isoformat(),
             condition=guideline.content.condition,
             action=guideline.content.action,
             description=guideline.content.description,
@@ -618,7 +618,7 @@ class GuidelineDocumentStore(GuidelineStore):
         return Guideline(
             id=GuidelineId(guideline_document["id"]),
             creation_utc=datetime.fromisoformat(guideline_document["creation_utc"]),
-            last_modified=datetime.fromisoformat(guideline_document["last_modified"]),
+            last_modified_utc=datetime.fromisoformat(guideline_document["last_modified"]),
             content=GuidelineContent(
                 condition=guideline_document["condition"],
                 action=guideline_document["action"],
@@ -670,7 +670,7 @@ class GuidelineDocumentStore(GuidelineStore):
             guideline = Guideline(
                 id=guideline_id,
                 creation_utc=creation_utc,
-                last_modified=creation_utc,
+                last_modified_utc=creation_utc,
                 content=GuidelineContent(
                     condition=condition,
                     action=action,

--- a/src/parlant/core/journey_guideline_projection.py
+++ b/src/parlant/core/journey_guideline_projection.py
@@ -485,7 +485,7 @@ class JourneyGuidelineProjection:
                 ),
                 criticality=Criticality.HIGH,
                 creation_utc=datetime.now(timezone.utc),
-                last_modified=datetime.now(timezone.utc),
+                last_modified_utc=datetime.now(timezone.utc),
                 enabled=True,
                 tags=list(journey.tags),
                 metadata=metadata,

--- a/src/parlant/core/journeys.py
+++ b/src/parlant/core/journeys.py
@@ -121,7 +121,7 @@ class JourneyLink:
 class Journey:
     id: JourneyId
     creation_utc: datetime
-    last_modified: datetime
+    last_modified_utc: datetime
     description: str
     triggers: Sequence[GuidelineId]
     title: str
@@ -946,7 +946,7 @@ class JourneyVectorStore(JourneyStore):
             id=ObjectId(journey.id),
             version=self.VERSION.to_string(),
             creation_utc=journey.creation_utc.isoformat(),
-            last_modified=journey.last_modified.isoformat(),
+            last_modified=journey.last_modified_utc.isoformat(),
             title=journey.title,
             description=journey.description,
             root_id=journey.root_id,
@@ -976,7 +976,7 @@ class JourneyVectorStore(JourneyStore):
         return Journey(
             id=JourneyId(doc["id"]),
             creation_utc=datetime.fromisoformat(doc["creation_utc"]),
-            last_modified=datetime.fromisoformat(doc.get("last_modified", doc["creation_utc"])),
+            last_modified_utc=datetime.fromisoformat(doc.get("last_modified", doc["creation_utc"])),
             triggers=triggers,
             title=doc["title"],
             description=doc["description"],
@@ -1145,7 +1145,7 @@ class JourneyVectorStore(JourneyStore):
             journey = Journey(
                 id=journey_id,
                 creation_utc=creation_utc,
-                last_modified=creation_utc,
+                last_modified_utc=creation_utc,
                 triggers=triggers,
                 title=title,
                 description=description,

--- a/tests/core/stable/engines/alpha/test_disambiguation_batch.py
+++ b/tests/core/stable/engines/alpha/test_disambiguation_batch.py
@@ -181,7 +181,7 @@ def create_term(
     return Term(
         id=TermId("-"),
         creation_utc=datetime.now(timezone.utc),
-        last_modified=datetime.now(timezone.utc),
+        last_modified_utc=datetime.now(timezone.utc),
         name=name,
         description=description,
         synonyms=synonyms,
@@ -197,7 +197,7 @@ def create_context_variable(
     return ContextVariable(
         id=ContextVariableId("-"),
         creation_utc=datetime.now(timezone.utc),
-        last_modified=datetime.now(timezone.utc),
+        last_modified_utc=datetime.now(timezone.utc),
         name=name,
         description="",
         tool_id=None,
@@ -205,7 +205,7 @@ def create_context_variable(
         tags=tags,
     ), ContextVariableValue(
         ContextVariableValueId("-"),
-        last_modified=datetime.now(timezone.utc),
+        last_modified_utc=datetime.now(timezone.utc),
         data=data,
     )
 
@@ -240,7 +240,7 @@ async def create_guideline(
     guideline = Guideline(
         id=GuidelineId(generate_id()),
         creation_utc=datetime.now(timezone.utc),
-        last_modified=datetime.now(timezone.utc),
+        last_modified_utc=datetime.now(timezone.utc),
         content=GuidelineContent(
             condition=condition,
             action=action,

--- a/tests/core/stable/engines/alpha/test_generic_response_analysis.py
+++ b/tests/core/stable/engines/alpha/test_generic_response_analysis.py
@@ -138,7 +138,7 @@ def create_guideline(
     guideline = Guideline(
         id=GuidelineId(generate_id()),
         creation_utc=datetime.now(timezone.utc),
-        last_modified=datetime.now(timezone.utc),
+        last_modified_utc=datetime.now(timezone.utc),
         content=GuidelineContent(
             condition=condition,
             action=action,
@@ -164,7 +164,7 @@ def create_guideline_with_tools(
     guideline = Guideline(
         id=GuidelineId(generate_id()),
         creation_utc=datetime.now(timezone.utc),
-        last_modified=datetime.now(timezone.utc),
+        last_modified_utc=datetime.now(timezone.utc),
         content=GuidelineContent(
             condition=condition,
             action=action,

--- a/tests/core/stable/engines/alpha/test_guideline_actionable_batch.py
+++ b/tests/core/stable/engines/alpha/test_guideline_actionable_batch.py
@@ -152,7 +152,7 @@ def create_guideline(
     guideline = Guideline(
         id=GuidelineId(generate_id()),
         creation_utc=datetime.now(timezone.utc),
-        last_modified=datetime.now(timezone.utc),
+        last_modified_utc=datetime.now(timezone.utc),
         content=GuidelineContent(
             condition=condition,
             action=action,

--- a/tests/core/stable/engines/alpha/test_guideline_low_criticality_batch.py
+++ b/tests/core/stable/engines/alpha/test_guideline_low_criticality_batch.py
@@ -182,7 +182,7 @@ def create_guideline(
     guideline = Guideline(
         id=GuidelineId(generate_id()),
         creation_utc=datetime.now(timezone.utc),
-        last_modified=datetime.now(timezone.utc),
+        last_modified_utc=datetime.now(timezone.utc),
         content=GuidelineContent(
             condition=condition,
             action=action,

--- a/tests/core/stable/engines/alpha/test_guideline_matcher.py
+++ b/tests/core/stable/engines/alpha/test_guideline_matcher.py
@@ -453,7 +453,7 @@ async def create_guideline(
     guideline = Guideline(
         id=GuidelineId(generate_id()),
         creation_utc=datetime.now(timezone.utc),
-        last_modified=datetime.now(timezone.utc),
+        last_modified_utc=datetime.now(timezone.utc),
         content=GuidelineContent(
             condition=condition,
             action=action,
@@ -475,7 +475,7 @@ async def create_disambiguation_guideline(
     guideline = Guideline(
         id=GuidelineId(generate_id()),
         creation_utc=datetime.now(timezone.utc),
-        last_modified=datetime.now(timezone.utc),
+        last_modified_utc=datetime.now(timezone.utc),
         content=GuidelineContent(
             condition=condition,
             action=None,
@@ -510,7 +510,7 @@ def create_term(
     return Term(
         id=TermId("-"),
         creation_utc=datetime.now(timezone.utc),
-        last_modified=datetime.now(timezone.utc),
+        last_modified_utc=datetime.now(timezone.utc),
         name=name,
         description=description,
         synonyms=synonyms,
@@ -526,7 +526,7 @@ def create_context_variable(
     return ContextVariable(
         id=ContextVariableId("-"),
         creation_utc=datetime.now(timezone.utc),
-        last_modified=datetime.now(timezone.utc),
+        last_modified_utc=datetime.now(timezone.utc),
         name=name,
         description="",
         tool_id=None,
@@ -534,7 +534,7 @@ def create_context_variable(
         tags=tags,
     ), ContextVariableValue(
         ContextVariableValueId("-"),
-        last_modified=datetime.now(timezone.utc),
+        last_modified_utc=datetime.now(timezone.utc),
         data=data,
     )
 

--- a/tests/core/stable/engines/alpha/test_journey_node_selection.py
+++ b/tests/core/stable/engines/alpha/test_journey_node_selection.py
@@ -969,7 +969,7 @@ def create_term(
     return Term(
         id=TermId("-"),
         creation_utc=datetime.now(timezone.utc),
-        last_modified=datetime.now(timezone.utc),
+        last_modified_utc=datetime.now(timezone.utc),
         name=name,
         description=description,
         synonyms=synonyms,
@@ -985,7 +985,7 @@ def create_context_variable(
     return ContextVariable(
         id=ContextVariableId("-"),
         creation_utc=datetime.now(timezone.utc),
-        last_modified=datetime.now(timezone.utc),
+        last_modified_utc=datetime.now(timezone.utc),
         name=name,
         description="",
         tool_id=None,
@@ -993,7 +993,7 @@ def create_context_variable(
         tags=tags,
     ), ContextVariableValue(
         ContextVariableValueId("-"),
-        last_modified=datetime.now(timezone.utc),
+        last_modified_utc=datetime.now(timezone.utc),
         data=data,
     )
 
@@ -1020,7 +1020,7 @@ async def create_journey(
     root_guideline = Guideline(
         id=GuidelineId("root"),
         creation_utc=datetime.now(timezone.utc),
-        last_modified=datetime.now(timezone.utc),
+        last_modified_utc=datetime.now(timezone.utc),
         content=GuidelineContent(condition="", action=None),
         criticality=Criticality.MEDIUM,
         enabled=True,
@@ -1038,7 +1038,7 @@ async def create_journey(
         Guideline(
             id=GuidelineId(node.id),
             creation_utc=datetime.now(timezone.utc),
-            last_modified=datetime.now(timezone.utc),
+            last_modified_utc=datetime.now(timezone.utc),
             content=GuidelineContent(
                 condition=node.condition or "",
                 action=node.action,
@@ -1077,7 +1077,7 @@ async def create_journey(
         id=journey_id,
         root_id=JourneyNodeId(root_guideline.id),
         creation_utc=datetime.now(timezone.utc),
-        last_modified=datetime.now(timezone.utc),
+        last_modified_utc=datetime.now(timezone.utc),
         description=description,
         triggers=trigger_ids,
         title=title,

--- a/tests/core/stable/engines/alpha/test_previously_applied_actionable_batch.py
+++ b/tests/core/stable/engines/alpha/test_previously_applied_actionable_batch.py
@@ -130,7 +130,7 @@ def create_guideline(
     guideline = Guideline(
         id=GuidelineId(generate_id()),
         creation_utc=datetime.now(timezone.utc),
-        last_modified=datetime.now(timezone.utc),
+        last_modified_utc=datetime.now(timezone.utc),
         content=GuidelineContent(
             condition=condition,
             action=action,

--- a/tests/core/stable/engines/alpha/test_previously_applied_actionable_customer_dependent_batch.py
+++ b/tests/core/stable/engines/alpha/test_previously_applied_actionable_customer_dependent_batch.py
@@ -119,7 +119,7 @@ def create_guideline(
     guideline = Guideline(
         id=GuidelineId(generate_id()),
         creation_utc=datetime.now(timezone.utc),
-        last_modified=datetime.now(timezone.utc),
+        last_modified_utc=datetime.now(timezone.utc),
         content=GuidelineContent(
             condition=condition,
             action=action,

--- a/tests/core/stable/engines/alpha/test_tool_caller.py
+++ b/tests/core/stable/engines/alpha/test_tool_caller.py
@@ -119,7 +119,7 @@ def create_guideline_match(
     guideline = Guideline(
         id=GuidelineId(generate_id()),
         creation_utc=datetime.now(timezone.utc),
-        last_modified=datetime.now(timezone.utc),
+        last_modified_utc=datetime.now(timezone.utc),
         content=GuidelineContent(
             condition=condition,
             action=action,

--- a/tests/core/stable/services/indexing/test_agent_intention_proposer.py
+++ b/tests/core/stable/services/indexing/test_agent_intention_proposer.py
@@ -185,7 +185,7 @@ def create_guideline(
     guideline = Guideline(
         id=GuidelineId(generate_id()),
         creation_utc=datetime.now(timezone.utc),
-        last_modified=datetime.now(timezone.utc),
+        last_modified_utc=datetime.now(timezone.utc),
         content=GuidelineContent(
             condition=condition,
             action=action,

--- a/tests/core/stable/services/indexing/test_journey_reachable_nodes_evaluation.py
+++ b/tests/core/stable/services/indexing/test_journey_reachable_nodes_evaluation.py
@@ -67,7 +67,7 @@ def _make_guideline(
     return Guideline(
         id=GuidelineId(id),
         creation_utc=datetime.now(timezone.utc),
-        last_modified=datetime.now(timezone.utc),
+        last_modified_utc=datetime.now(timezone.utc),
         content=GuidelineContent(condition=condition, action=action),
         criticality=Criticality.MEDIUM,
         enabled=True,

--- a/tests/core/stable/services/indexing/test_relative_action_step_proposer.py
+++ b/tests/core/stable/services/indexing/test_relative_action_step_proposer.py
@@ -68,7 +68,7 @@ def create_journey(
         Guideline(
             id=GuidelineId(f"c-{i}"),
             creation_utc=datetime.now(timezone.utc),
-            last_modified=datetime.now(timezone.utc),
+            last_modified_utc=datetime.now(timezone.utc),
             content=GuidelineContent(condition=condition, action=None),
             criticality=Criticality.MEDIUM,
             enabled=False,
@@ -81,7 +81,7 @@ def create_journey(
     root_guideline = Guideline(
         id=GuidelineId("root"),
         creation_utc=datetime.now(timezone.utc),
-        last_modified=datetime.now(timezone.utc),
+        last_modified_utc=datetime.now(timezone.utc),
         content=GuidelineContent(condition="", action=None),
         criticality=Criticality.MEDIUM,
         enabled=True,
@@ -99,7 +99,7 @@ def create_journey(
         Guideline(
             id=GuidelineId(step.id),
             creation_utc=datetime.now(timezone.utc),
-            last_modified=datetime.now(timezone.utc),
+            last_modified_utc=datetime.now(timezone.utc),
             content=GuidelineContent(
                 condition=step.condition or "",
                 action=step.action,
@@ -130,7 +130,7 @@ def create_journey(
         id=journey_id,
         root_id=JourneyNodeId(root_guideline.id),
         creation_utc=datetime.now(timezone.utc),
-        last_modified=datetime.now(timezone.utc),
+        last_modified_utc=datetime.now(timezone.utc),
         description="",
         triggers=[g.id for g in condition_guidelines],
         title=title,

--- a/tests/core/unstable/engines/alpha/test_agent_intention_proposer.py
+++ b/tests/core/unstable/engines/alpha/test_agent_intention_proposer.py
@@ -185,7 +185,7 @@ def create_guideline(
     guideline = Guideline(
         id=GuidelineId(generate_id()),
         creation_utc=datetime.now(timezone.utc),
-        last_modified=datetime.now(timezone.utc),
+        last_modified_utc=datetime.now(timezone.utc),
         content=GuidelineContent(
             condition=condition,
             action=action,

--- a/tests/core/unstable/engines/alpha/test_disambiguation_batch.py
+++ b/tests/core/unstable/engines/alpha/test_disambiguation_batch.py
@@ -175,7 +175,7 @@ def create_term(
     return Term(
         id=TermId("-"),
         creation_utc=datetime.now(timezone.utc),
-        last_modified=datetime.now(timezone.utc),
+        last_modified_utc=datetime.now(timezone.utc),
         name=name,
         description=description,
         synonyms=synonyms,
@@ -191,7 +191,7 @@ def create_context_variable(
     return ContextVariable(
         id=ContextVariableId("-"),
         creation_utc=datetime.now(timezone.utc),
-        last_modified=datetime.now(timezone.utc),
+        last_modified_utc=datetime.now(timezone.utc),
         name=name,
         description="",
         tool_id=None,
@@ -199,7 +199,7 @@ def create_context_variable(
         tags=tags,
     ), ContextVariableValue(
         id=ContextVariableValueId("-"),
-        last_modified=datetime.now(timezone.utc),
+        last_modified_utc=datetime.now(timezone.utc),
         data=data,
     )
 
@@ -234,7 +234,7 @@ async def create_guideline(
     guideline = Guideline(
         id=GuidelineId(generate_id()),
         creation_utc=datetime.now(timezone.utc),
-        last_modified=datetime.now(timezone.utc),
+        last_modified_utc=datetime.now(timezone.utc),
         content=GuidelineContent(
             condition=condition,
             action=action,

--- a/tests/core/unstable/engines/alpha/test_guideline_matcher.py
+++ b/tests/core/unstable/engines/alpha/test_guideline_matcher.py
@@ -361,7 +361,7 @@ async def create_guideline(
     guideline = Guideline(
         id=GuidelineId(generate_id()),
         creation_utc=datetime.now(timezone.utc),
-        last_modified=datetime.now(timezone.utc),
+        last_modified_utc=datetime.now(timezone.utc),
         content=GuidelineContent(
             condition=condition,
             action=action,
@@ -383,7 +383,7 @@ def create_term(
     return Term(
         id=TermId("-"),
         creation_utc=datetime.now(timezone.utc),
-        last_modified=datetime.now(timezone.utc),
+        last_modified_utc=datetime.now(timezone.utc),
         name=name,
         description=description,
         synonyms=synonyms,
@@ -399,7 +399,7 @@ def create_context_variable(
     return ContextVariable(
         id=ContextVariableId("-"),
         creation_utc=datetime.now(timezone.utc),
-        last_modified=datetime.now(timezone.utc),
+        last_modified_utc=datetime.now(timezone.utc),
         name=name,
         description="",
         tool_id=None,
@@ -407,7 +407,7 @@ def create_context_variable(
         tags=tags,
     ), ContextVariableValue(
         ContextVariableValueId("-"),
-        last_modified=datetime.now(timezone.utc),
+        last_modified_utc=datetime.now(timezone.utc),
         data=data,
     )
 


### PR DESCRIPTION
## Summary

Rename the `last_modified` datetime field to `last_modified_utc` on all entity dataclasses for consistency with the existing `creation_utc` naming convention.

## Entities renamed

| Entity | File |
|--------|------|
| `Guideline` | `core/guidelines.py` |
| `Journey` | `core/journeys.py` |
| `ContextVariable` | `core/context_variables.py` |
| `ContextVariableValue` | `core/context_variables.py` |
| `Term` | `core/glossary.py` |
| `CannedResponse` | `core/canned_responses.py` |

## Scope

- Entity dataclass fields, attribute access, and constructor kwargs → renamed
- API DTO Pydantic fields → renamed (public API contract changes)
- Database document TypedDict fields and dict string keys → **not renamed** (DB schema stays as `"last_modified"`)
- Serialization boundary: entity `.last_modified_utc` ↔ document `"last_modified"`

## Test plan

- [x] mypy: 0 errors
- [x] ruff check + format: clean
- 34 files changed across src/ and tests/