### PR TITLE
feat(auth): add Parlant cloud platform policy

### DIFF
--- a/src/parlant/adapters/modules/parlant_cloud.py
+++ b/src/parlant/adapters/modules/parlant_cloud.py
@@ -1,0 +1,48 @@
+import hmac
+from collections.abc import Mapping
+
+from fastapi import FastAPI, Request
+from fastapi.middleware.cors import CORSMiddleware
+from typing_extensions import override
+
+from parlant.api.authorization import AuthorizationPolicy, Operation, ProductionAuthorizationPolicy
+
+PLATFORM_SECRET_HEADER = "X-Parlant-Cloud-Platform-Secret"
+
+
+class ParlantCloudAuthorizationPolicy(AuthorizationPolicy):
+    def __init__(self, platform_secret: str) -> None:
+        self._platform_secret = platform_secret
+        self._production_policy = ProductionAuthorizationPolicy()
+
+    @property
+    @override
+    def name(self) -> str:
+        return "parlant-cloud"
+
+    async def configure_app(self, app: FastAPI) -> FastAPI:
+        app.add_middleware(
+            CORSMiddleware,
+            allow_origins=["*"],
+            allow_credentials=True,
+            allow_methods=["*"],
+            allow_headers=["*"],
+        )
+
+        return app
+
+    def _is_trusted(self, headers: Mapping[str, str]) -> bool:
+        secret = headers.get(PLATFORM_SECRET_HEADER, "")
+        return bool(secret) and hmac.compare_digest(secret, self._platform_secret)
+
+    @override
+    async def check_permission(self, request: Request, operation: Operation) -> bool:
+        if self._is_trusted(request.headers):
+            return True
+        return await self._production_policy.check_permission(request, operation)
+
+    @override
+    async def check_rate_limit(self, request: Request, operation: Operation) -> bool:
+        if self._is_trusted(request.headers):
+            return True
+        return await self._production_policy.check_rate_limit(request, operation)


### PR DESCRIPTION
## Summary
- add ParlantCloudAuthorizationPolicy under parlant.adapters.modules.parlant_cloud
- trust platform requests carrying X-Parlant-Cloud-Platform-Secret
- delegate all non-platform requests to ProductionAuthorizationPolicy
- compare the platform secret with hmac.compare_digest

## Verification
- uv run ruff check src/parlant/adapters/modules/parlant_cloud.py
- PYTHONPYCACHEPREFIX=/private/tmp/codex-pycache python -m py_compile src/parlant/adapters/modules/parlant_cloud.py

Note: full pre-push mypy is currently blocked by unrelated existing type errors in tests/core/stable/nlp/test_embedding.py, tests/core/stable/nlp/test_generation.py, src/parlant/bin/client.py, and tests/adapters/nlp/test_litellm_service.py.