### PR TITLE
fix: make journey reachable-follow-ups order-independent at fan-in nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ All notable changes to Parlant will be documented here.
 
 - Fix low-criticality matcher logging the entire inference blob once per guideline in a batch (N copies of the same payload at debug level); now logs a single per-item entry
 - Fix WebSocketLogger event loop starvation — when no WebSocket clients are subscribed, the drain loop processed queued messages without yielding, progressively blocking the async event loop and causing increasing latency over time
+- Fix journey reachable-follow-ups evaluation being order-dependent at fan-in nodes — `JourneyReachableNodesEvaluator` captured a child's path list by reference and then prepended to it in place, so a node with multiple parents had its stored routes mutated by whichever parent was visited first; the second parent then lost routes (or double-counted a hop) depending purely on graph/DFS order. The child's routes are now snapshotted per parent, making the result depend only on journey structure. This intentionally changes the computed follow-ups for existing fan-in journeys: a shared child's later parent now retains the routes it previously lost
 
 ### Security
 

--- a/src/parlant/core/services/indexing/journey_reachable_nodes_evaluation.py
+++ b/src/parlant/core/services/indexing/journey_reachable_nodes_evaluation.py
@@ -373,7 +373,8 @@ class JourneyReachableNodesEvaluator:
                         ):
                             truncated_follow_ups[str(id)] = _ReachableFollowUps(
                                 condition=r.condition,
-                                path=r.path,
+                                # copy so a parent's prepend can't mutate the child's shared list
+                                path=list(r.path),
                             )
                             id += 1
                 children_info[child_idx] = _ChildInfo(

--- a/tests/core/stable/services/indexing/test_journey_reachable_nodes_evaluator.py
+++ b/tests/core/stable/services/indexing/test_journey_reachable_nodes_evaluator.py
@@ -1,0 +1,203 @@
+# Copyright 2026 Emcie Co Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import re
+from datetime import datetime, timezone
+from typing import Any, Mapping, Sequence
+from lagom import Container
+from typing_extensions import override
+
+from parlant.core.common import Criticality
+from parlant.core.engines.alpha.optimization_policy import OptimizationPolicy
+from parlant.core.engines.alpha.prompt_builder import PromptBuilder
+from parlant.core.guidelines import Guideline, GuidelineContent, GuidelineId
+from parlant.core.loggers import Logger
+from parlant.core.nlp.generation import SchematicGenerator, SchematicGenerationResult
+from parlant.core.nlp.generation_info import GenerationInfo, UsageInfo
+from parlant.core.nlp.tokenization import EstimatingTokenizer
+from parlant.core.services.indexing.journey_reachable_nodes_evaluation import (
+    ChildEvaluation,
+    JourneyReachableNodesEvaluator,
+    PathCondition,
+    ReachableNodesEvaluation,
+    ReachableNodesEvaluationSchema,
+)
+from parlant.core.services.tools.service_registry import ServiceRegistry
+
+
+class _ForwardAllReachableNodesGenerator(SchematicGenerator[ReachableNodesEvaluationSchema]):
+    # A deterministic stand-in for the LLM: it reads which children and onward-path ids
+    # the prompt exposes for the current node and forwards all of them, mimicking an
+    # ideal compliant model. This lets us exercise the graph-walk/path logic without
+    # real generation. Only `generate` is used.
+
+    _CHILD_RE = re.compile(r"Child id:\s*(\S+)")
+    _PATH_RE = re.compile(r"-\s*Condition\s*\((\d+)\)\s*:")
+
+    @override
+    async def generate(
+        self,
+        prompt: str | PromptBuilder,
+        hints: Mapping[str, Any] = {},
+    ) -> SchematicGenerationResult[ReachableNodesEvaluationSchema]:
+        text = prompt.build() if isinstance(prompt, PromptBuilder) else prompt
+        # Drop the few-shot examples, which render the same child/condition lines.
+        real_data = text.split("Example section is over")[-1]
+
+        children: dict[str, list[str]] = {}
+        current_child: str | None = None
+        for line in real_data.splitlines():
+            if child_match := self._CHILD_RE.search(line):
+                current_child = child_match.group(1)
+                children[current_child] = []
+            elif (path_match := self._PATH_RE.search(line)) and current_child is not None:
+                children[current_child].append(path_match.group(1))
+
+        children_conditions = [
+            ChildEvaluation(
+                child_id=child_id,
+                child_action=f"action of {child_id}",
+                condition_to_child=f"condition to {child_id}",
+                condition_to_child_and_stop=f"reached {child_id} and stopped",
+                conditions_to_child_and_forward=[
+                    PathCondition(
+                        id=path_id,
+                        path_condition=f"path {path_id} from {child_id}",
+                        condition_to_child_then_to_path=f"through {child_id} via {path_id}",
+                    )
+                    for path_id in path_ids
+                ]
+                or None,
+            )
+            for child_id, path_ids in children.items()
+        ]
+
+        return SchematicGenerationResult(
+            content=ReachableNodesEvaluationSchema(
+                step_action="step action",
+                step_action_completed="step action completed",
+                children_conditions=children_conditions or None,
+            ),
+            info=GenerationInfo(
+                schema_name=ReachableNodesEvaluationSchema.__name__,
+                model="fake",
+                duration=0.0,
+                usage=UsageInfo(input_tokens=0, output_tokens=0),
+            ),
+        )
+
+    @property
+    @override
+    def id(self) -> str:
+        raise NotImplementedError
+
+    @property
+    @override
+    def max_tokens(self) -> int:
+        raise NotImplementedError
+
+    @property
+    @override
+    def tokenizer(self) -> EstimatingTokenizer:
+        raise NotImplementedError
+
+
+def _node_guideline(
+    index: str,
+    action: str,
+    follow_ups: Sequence[str],
+) -> Guideline:
+    return Guideline(
+        id=GuidelineId(index),
+        creation_utc=datetime.now(timezone.utc),
+        content=GuidelineContent(condition="", action=action),
+        enabled=True,
+        tags=[],
+        metadata={
+            "journey_node": {
+                "index": index,
+                "follow_ups": [GuidelineId(f) for f in follow_ups],
+                "kind": "chat",
+            },
+            "customer_dependent_action_data": {
+                "is_customer_dependent": True,
+                "customer_action": f"the customer completed step {index}",
+                "agent_action": "",
+            },
+        },
+        criticality=Criticality.MEDIUM,
+    )
+
+
+def _fan_in_journey(root_follow_ups: Sequence[str]) -> Sequence[Guideline]:
+    # Diamond: root (1) branches to two parents B (2) and C (3) that reconverge on the
+    # fan-in node D (4), followed by a chain D -> E (5) -> G (6) -> H (7). The depth of
+    # the chain makes the look-ahead depth filter relevant at D's parents.
+    return [
+        _node_guideline("1", "greet the customer", root_follow_ups),
+        _node_guideline("2", "ask the customer for B", ["4"]),
+        _node_guideline("3", "ask the customer for C", ["4"]),
+        _node_guideline("4", "ask the customer for D", ["5"]),
+        _node_guideline("5", "ask the customer for E", ["6"]),
+        _node_guideline("6", "ask the customer for G", ["7"]),
+        _node_guideline("7", "ask the customer for H", []),
+    ]
+
+
+def _paths(result: ReachableNodesEvaluation, node_index: str) -> set[tuple[str, ...]]:
+    return {tuple(path) for _, path in result.node_to_reachable_follow_ups[node_index]}
+
+
+async def _evaluate(
+    container: Container,
+    node_guidelines: Sequence[Guideline],
+) -> ReachableNodesEvaluation:
+    evaluator = JourneyReachableNodesEvaluator(
+        logger=container[Logger],
+        optimization_policy=container[OptimizationPolicy],
+        schematic_generator=_ForwardAllReachableNodesGenerator(),
+        service_registry=container[ServiceRegistry],
+    )
+    return await evaluator.evaluate_reachable_follow_ups(node_guidelines=node_guidelines)
+
+
+async def test_that_fan_in_node_parents_have_identical_reachable_follow_ups(
+    container: Container,
+) -> None:
+    result = await _evaluate(container, _fan_in_journey(["2", "3"]))
+
+    assert _paths(result, "2") == _paths(result, "3")
+
+
+async def test_that_reachable_follow_ups_are_independent_of_node_visit_order(
+    container: Container,
+) -> None:
+    result_b_first = await _evaluate(container, _fan_in_journey(["2", "3"]))
+    result_c_first = await _evaluate(container, _fan_in_journey(["3", "2"]))
+
+    for node_index in result_b_first.node_to_reachable_follow_ups:
+        assert _paths(result_b_first, node_index) == _paths(result_c_first, node_index)
+
+
+async def test_that_reachable_follow_up_paths_have_no_repeated_consecutive_node(
+    container: Container,
+) -> None:
+    result = await _evaluate(container, _fan_in_journey(["2", "3"]))
+
+    for node_index, follow_ups in result.node_to_reachable_follow_ups.items():
+        for _, path in follow_ups:
+            for current, following in zip(path, path[1:]):
+                assert current != following, (
+                    f"node {node_index} has a repeated consecutive id in path {path}"
+                )


### PR DESCRIPTION
## Summary

`JourneyReachableNodesEvaluator.evaluate_reachable_follow_ups` computes each node's reachable follow-ups by mutating the child's stored path list **in place**. The child's path list is captured **by reference** (not copied) when a parent reads it, and `do_node_evaluation` then prepends to it with `list.insert(0, …)`. As a result, the reachable follow-ups computed for the parents of a **fan-in node** (a node with ≥2 parents) depend on the order in which those parents happen to be visited — i.e. on graph construction / DFS edge order — rather than only on the journey's semantics.

The output is deterministic for a fixed input, so it doesn't surface as flakiness, but:

- Two structurally-equivalent journeys built in a different order can get different follow-ups for the same fan-in region.
- The later-visited parent of a shared child systematically loses follow-up routes the first parent keeps (the first parent has already lengthened the shared list past the depth filter), and can also re-prepend onto an already-prepended list, double-counting a hop.
- It blocks any safe parallelization or reordering of node evaluation.

`reachable_follow_ups` feeds `node_properties_proposition["journey_node"]["reachable_follow_ups"]`, consumed at runtime by journey next-step selection — so this can change which states the engine considers reachable from a fan-in node, and therefore routing.

## Root cause

`src/parlant/core/services/indexing/journey_reachable_nodes_evaluation.py`:

1. **Aliasing** — the child's stored `path` list is captured by reference into `children_info` (`path=r.path`).
2. **In-place mutation** — `do_node_evaluation` does `path.insert(0, c.child_id)` on that same list, mutating the child node's stored `reachable_follow_ups[...].path`.

When a second parent of the same child later reads it, it sees the already-lengthened list, and the depth filter (`len(r.path) + 1 <= max_depth`) drops routes the first parent kept.

The node's own output is captured immediately after its own evaluation, so the fan-in node itself is fine — it's the **parents** of a shared child whose results diverge. Linear/tree journeys (every node has ≤1 parent) are unaffected.

## Fix

Snapshot the child's path when it's read into `children_info`, so a parent's prepend can only ever touch a parent-private list:

```python
truncated_follow_ups[str(id)] = _ReachableFollowUps(
    condition=r.condition,
    # copy so a parent's prepend can't mutate the child's shared list
    path=list(r.path),
)
```

One line + one comment. After the fix, every parent reads the child's pristine routes regardless of visit order, so the result depends only on journey structure.

> **Behavior change:** this intentionally changes the computed follow-ups for existing fan-in journeys — a shared child's later parent now retains the routes it previously lost. This is the correct, order-independent result. Noted in the changelog.

## Tests

New deterministic tests in `tests/core/stable/services/indexing/test_journey_reachable_nodes_evaluator.py` (a fake `SchematicGenerator` that forwards every route the prompt exposes — no live LLM). They run a fan-in/diamond journey and assert:

1. the two parents of a shared child get identical follow-ups;
2. each node's follow-ups are independent of node visit order (same journey, parents declared in either order → same result);
3. no follow-up path contains a repeated consecutive node id (catches the double-prepend).

All three **fail on `develop`** (the third reports the corrupted path `['4', '4', '5']`) and **pass with the fix**.
