### PR TITLE
Start cloud connection without secure entitlement

### DIFF
--- a/src/parlant/adapters/modules/parlant_cloud/lifecycle.py
+++ b/src/parlant/adapters/modules/parlant_cloud/lifecycle.py
@@ -140,13 +140,6 @@ async def initialize_container(container: Container) -> None:
         if _cloud_project_auth is not None and not _cloud_project_auth.authenticated:
             return
 
-        if _cloud_project_auth is not None and not _cloud_project_auth.secured:
-            logger.warning(
-                "Parlant Cloud secure connection is not enabled for this project plan; "
-                "using direct project requests"
-            )
-            return
-
         tunnel = _create_tunnel_service(
             session_module=container[SessionModule],
             agent_module=container[AgentModule],

--- a/tests/adapters/tunnels/test_tunnel_wiring.py
+++ b/tests/adapters/tunnels/test_tunnel_wiring.py
@@ -226,7 +226,7 @@ async def test_that_cloud_initializer_starts_tunnel_after_session_module_exists(
             lifecycle._cloud_project_auth = None
 
 
-async def test_that_cloud_initializer_does_not_start_tunnel_without_secure_connection() -> None:
+async def test_that_cloud_initializer_starts_tunnel_without_secure_connection() -> None:
     with patch.dict(os.environ, {"PARLANT_CLOUD_PROJECT_TOKEN": "test-token"}):
         lifecycle._cloud_project_auth = CloudProjectAuth(
             project_id="project-1",
@@ -246,7 +246,8 @@ async def test_that_cloud_initializer_does_not_start_tunnel_without_secure_conne
         try:
             await initialize_container(container)
 
-            assert not background_task_service.started
+            assert background_task_service.started
+            assert background_task_service.tag == "parlant-cloud-tunnel"
         finally:
             lifecycle._cloud_project_auth = None
 


### PR DESCRIPTION
## Summary
- start the Parlant Cloud connection after valid project-token auth even when secured=false
- let the platform/tunnel-server decide which operations require secure entitlement
- update lifecycle coverage for non-secure connections

## Tests
- uv run pytest tests/adapters/tunnels/test_tunnel_wiring.py
- uv run ruff check src/parlant/adapters/modules/parlant_cloud/lifecycle.py tests/adapters/tunnels/test_tunnel_wiring.py
- uv run python -m compileall src/parlant/adapters/modules/parlant_cloud