### PR TITLE
Remove cloud auth secured flag

### DIFF
--- a/src/parlant/adapters/modules/parlant_cloud/lifecycle.py
+++ b/src/parlant/adapters/modules/parlant_cloud/lifecycle.py
@@ -22,7 +22,6 @@ policy, tracer, logger, meter, and tunnel service into the lagom container.
 import os
 from contextlib import AsyncExitStack
 from dataclasses import dataclass
-from typing import Any
 
 import httpx
 from lagom import Container
@@ -51,7 +50,6 @@ _exit_stack = AsyncExitStack()
 @dataclass(frozen=True)
 class CloudProjectAuth:
     project_id: str
-    secured: bool
     authenticated: bool
 
 
@@ -84,7 +82,6 @@ async def configure_container(container: Container) -> Container:
     except Exception:
         _cloud_project_auth = CloudProjectAuth(
             project_id="",
-            secured=False,
             authenticated=False,
         )
         logger.warning("Parlant Cloud project token validation failed; observability disabled")
@@ -93,7 +90,6 @@ async def configure_container(container: Container) -> Container:
     if not isinstance(project_id, str) or not project_id:
         _cloud_project_auth = CloudProjectAuth(
             project_id="",
-            secured=False,
             authenticated=False,
         )
         logger.warning("Parlant Cloud auth response missing project_id; observability disabled")
@@ -101,7 +97,6 @@ async def configure_container(container: Container) -> Container:
 
     _cloud_project_auth = CloudProjectAuth(
         project_id=project_id,
-        secured=_secured(auth_data),
         authenticated=True,
     )
 
@@ -157,11 +152,3 @@ async def initialize_container(container: Container) -> None:
             )
     except Exception as e:
         logger.warning(f"Failed to start Parlant Cloud tunnel: {e}")
-
-
-def _secured(auth_data: Any) -> bool:
-    if not isinstance(auth_data, dict):
-        return False
-
-    secured = auth_data.get("secured")
-    return secured if isinstance(secured, bool) else False

--- a/tests/adapters/tunnels/test_tunnel_wiring.py
+++ b/tests/adapters/tunnels/test_tunnel_wiring.py
@@ -204,7 +204,6 @@ async def test_that_cloud_initializer_starts_tunnel_after_session_module_exists(
     with patch.dict(os.environ, {"PARLANT_CLOUD_PROJECT_TOKEN": "test-token"}):
         lifecycle._cloud_project_auth = CloudProjectAuth(
             project_id="project-1",
-            secured=True,
             authenticated=True,
         )
         container = Container()
@@ -224,35 +223,3 @@ async def test_that_cloud_initializer_starts_tunnel_after_session_module_exists(
             assert background_task_service.tag == "parlant-cloud-tunnel"
         finally:
             lifecycle._cloud_project_auth = None
-
-
-async def test_that_cloud_initializer_starts_tunnel_without_secure_connection() -> None:
-    with patch.dict(os.environ, {"PARLANT_CLOUD_PROJECT_TOKEN": "test-token"}):
-        lifecycle._cloud_project_auth = CloudProjectAuth(
-            project_id="project-1",
-            secured=False,
-            authenticated=True,
-        )
-        container = Container()
-        background_task_service = FakeBackgroundTaskService()
-
-        container[SessionModule] = cast(SessionModule, object())
-        container[AgentModule] = cast(AgentModule, object())
-        container[CustomerModule] = cast(CustomerModule, object())
-        container[TagModule] = cast(TagModule, object())
-        container[BackgroundTaskService] = cast(BackgroundTaskService, background_task_service)
-        container[Logger] = cast(Logger, FakeLogger())
-
-        try:
-            await initialize_container(container)
-
-            assert background_task_service.started
-            assert background_task_service.tag == "parlant-cloud-tunnel"
-        finally:
-            lifecycle._cloud_project_auth = None
-
-
-def test_that_cloud_auth_reads_secured_from_project_token_response() -> None:
-    assert lifecycle._secured({"secured": True}) is True
-    assert lifecycle._secured({"secured": False}) is False
-    assert lifecycle._secured({"features": {"secure_connection": True}}) is False


### PR DESCRIPTION
## Summary
- Removes secured from Parlant Cloud project auth state.
- Starts the cloud tunnel whenever project-token validation succeeds.
- Updates tunnel wiring tests for the always-secure token contract.

## Test Plan
- uv run pytest tests/adapters/tunnels/test_tunnel_wiring.py -q
- uv run ruff check src/parlant/adapters/modules/parlant_cloud/lifecycle.py tests/adapters/tunnels/test_tunnel_wiring.py
- uv run ruff format --check src/parlant/adapters/modules/parlant_cloud/lifecycle.py tests/adapters/tunnels/test_tunnel_wiring.py