### PR TITLE
Add modified_utc to sessions and events

### DIFF
--- a/src/parlant/api/canned_responses.py
+++ b/src/parlant/api/canned_responses.py
@@ -196,7 +196,7 @@ class CannedResponseDTO(
 ):
     id: CannedResponseIdField
     creation_utc: CannedResponseCreationUTCField
-    last_modified_utc: CannedResponseLastModifiedField
+    modified_utc: CannedResponseLastModifiedField
     value: CannedResponseValueField
     fields: CannedResponseFieldSequenceField
     tags: TagIdSequenceField
@@ -386,7 +386,7 @@ def create_router(
         return CannedResponseDTO(
             id=canrep.id,
             creation_utc=canrep.creation_utc,
-            last_modified_utc=canrep.last_modified_utc,
+            modified_utc=canrep.modified_utc,
             value=canrep.value,
             fields=[_canned_response_field_to_dto(s) for s in canrep.fields],
             tags=canrep.tags,
@@ -422,7 +422,7 @@ def create_router(
         return CannedResponseDTO(
             id=canrep.id,
             creation_utc=canrep.creation_utc,
-            last_modified_utc=canrep.last_modified_utc,
+            modified_utc=canrep.modified_utc,
             value=canrep.value,
             fields=[_canned_response_field_to_dto(s) for s in canrep.fields],
             tags=canrep.tags,
@@ -455,7 +455,7 @@ def create_router(
             CannedResponseDTO(
                 id=f.id,
                 creation_utc=f.creation_utc,
-                last_modified_utc=f.last_modified_utc,
+                modified_utc=f.modified_utc,
                 value=f.value,
                 fields=[_canned_response_field_to_dto(s) for s in f.fields],
                 tags=f.tags,
@@ -526,7 +526,7 @@ def create_router(
         return CannedResponseDTO(
             id=canrep.id,
             creation_utc=canrep.creation_utc,
-            last_modified_utc=canrep.last_modified_utc,
+            modified_utc=canrep.modified_utc,
             value=canrep.value,
             fields=[_canned_response_field_to_dto(s) for s in canrep.fields],
             tags=canrep.tags,

--- a/src/parlant/api/common.py
+++ b/src/parlant/api/common.py
@@ -416,7 +416,7 @@ class GuidelineDTO(
     enabled: GuidelineEnabledField = True
     tags: GuidelineTagsField
     metadata: GuidelineMetadataField
-    last_modified_utc: GuidelineLastModifiedField
+    modified_utc: GuidelineLastModifiedField
     composition_mode: CompositionModeDTO | None = None
     track: bool = True
     labels: GuidelineLabelsField = set()

--- a/src/parlant/api/context_variables.py
+++ b/src/parlant/api/context_variables.py
@@ -120,7 +120,7 @@ ContextVariableLastModifiedField: TypeAlias = Annotated[
 
 context_variable_value_example: ExampleJson = {
     "id": "val_789abc",
-    "last_modified_utc": "2024-03-24T12:00:00Z",
+    "modified_utc": "2024-03-24T12:00:00Z",
     "data": {
         "balance": 5000.50,
         "currency": "USD",
@@ -143,7 +143,7 @@ class ContextVariableValueDTO(
     """
 
     id: ValueIdField
-    last_modified_utc: LastModifiedField
+    modified_utc: LastModifiedField
     data: DataField
 
 
@@ -232,7 +232,7 @@ class ContextVariableDTO(
     tool_id: ToolIdDTO | None = None
     freshness_rules: FreshnessRulesField | None = None
     tags: ContextVariableTagsField | None = None
-    last_modified_utc: ContextVariableLastModifiedField
+    modified_utc: ContextVariableLastModifiedField
 
 
 context_variable_tags_update_params_example: ExampleJson = {
@@ -420,7 +420,7 @@ def create_router(
             else None,
             freshness_rules=variable.freshness_rules,
             tags=variable.tags,
-            last_modified_utc=variable.last_modified_utc,
+            modified_utc=variable.modified_utc,
         )
 
     @router.patch(
@@ -482,7 +482,7 @@ def create_router(
             else None,
             freshness_rules=updated_variable.freshness_rules,
             tags=updated_variable.tags,
-            last_modified_utc=updated_variable.last_modified_utc,
+            modified_utc=updated_variable.modified_utc,
         )
 
     @router.get(
@@ -519,7 +519,7 @@ def create_router(
                 else None,
                 freshness_rules=v.freshness_rules,
                 tags=v.tags,
-                last_modified_utc=v.last_modified_utc,
+                modified_utc=v.modified_utc,
             )
             for v in variables
         ]
@@ -565,7 +565,7 @@ def create_router(
             else None,
             freshness_rules=variable.freshness_rules,
             tags=variable.tags,
-            last_modified_utc=variable.last_modified_utc,
+            modified_utc=variable.modified_utc,
         )
 
         if not include_values:
@@ -581,7 +581,7 @@ def create_router(
             key_value_pairs={
                 key: ContextVariableValueDTO(
                     id=value.id,
-                    last_modified_utc=value.last_modified_utc,
+                    modified_utc=value.modified_utc,
                     data=cast(JSONSerializableDTO, value.data),
                 )
                 for key, value in key_value_pairs
@@ -661,7 +661,7 @@ def create_router(
         if value:
             return ContextVariableValueDTO(
                 id=value.id,
-                last_modified_utc=value.last_modified_utc,
+                modified_utc=value.modified_utc,
                 data=cast(JSONSerializableDTO, value.data),
             )
 
@@ -703,7 +703,7 @@ def create_router(
 
         return ContextVariableValueDTO(
             id=value.id,
-            last_modified_utc=value.last_modified_utc,
+            modified_utc=value.modified_utc,
             data=cast(JSONSerializableDTO, value.data),
         )
 

--- a/src/parlant/api/glossary.py
+++ b/src/parlant/api/glossary.py
@@ -159,7 +159,7 @@ class TermDTO(
     description: TermDescriptionField
     synonyms: TermSynonymsField = []
     tags: TermTagsField
-    last_modified_utc: TermLastModifiedField
+    modified_utc: TermLastModifiedField
 
 
 TermTagsUpdateAddField: TypeAlias = Annotated[
@@ -273,7 +273,7 @@ def create_router(
             description=term.description,
             synonyms=term.synonyms,
             tags=term.tags,
-            last_modified_utc=term.last_modified_utc,
+            modified_utc=term.modified_utc,
         )
 
     @router.get(
@@ -308,7 +308,7 @@ def create_router(
             description=term.description,
             synonyms=term.synonyms,
             tags=term.tags,
-            last_modified_utc=term.last_modified_utc,
+            modified_utc=term.modified_utc,
         )
 
     @router.get(
@@ -344,7 +344,7 @@ def create_router(
                 description=term.description,
                 synonyms=term.synonyms,
                 tags=term.tags,
-                last_modified_utc=term.last_modified_utc,
+                modified_utc=term.modified_utc,
             )
             for term in terms
         ]
@@ -399,7 +399,7 @@ def create_router(
             description=term.description,
             synonyms=term.synonyms,
             tags=term.tags,
-            last_modified_utc=term.last_modified_utc,
+            modified_utc=term.modified_utc,
         )
 
     @router.delete(

--- a/src/parlant/api/guidelines.py
+++ b/src/parlant/api/guidelines.py
@@ -448,7 +448,7 @@ def _guideline_relationship_to_dto(
             enabled=rel_source_guideline.enabled,
             tags=rel_source_guideline.tags,
             metadata=rel_source_guideline.metadata,
-            last_modified_utc=rel_source_guideline.last_modified_utc,
+            modified_utc=rel_source_guideline.modified_utc,
             composition_mode=composition_mode_to_composition_mode_dto(
                 rel_source_guideline.composition_mode
             )
@@ -479,7 +479,7 @@ def _guideline_relationship_to_dto(
             enabled=rel_target_guideline.enabled,
             tags=rel_target_guideline.tags,
             metadata=rel_target_guideline.metadata,
-            last_modified_utc=rel_target_guideline.last_modified_utc,
+            modified_utc=rel_target_guideline.modified_utc,
             composition_mode=composition_mode_to_composition_mode_dto(
                 rel_target_guideline.composition_mode
             )
@@ -576,7 +576,7 @@ def create_router(
             title=guideline.title,
             criticality=_criticality_to_dto(guideline.criticality),
             metadata=guideline.metadata,
-            last_modified_utc=guideline.last_modified_utc,
+            modified_utc=guideline.modified_utc,
             enabled=guideline.enabled,
             tags=guideline.tags,
             composition_mode=composition_mode_to_composition_mode_dto(guideline.composition_mode)
@@ -624,7 +624,7 @@ def create_router(
                 title=guideline.title,
                 criticality=_criticality_to_dto(guideline.criticality),
                 metadata=guideline.metadata,
-                last_modified_utc=guideline.last_modified_utc,
+                modified_utc=guideline.modified_utc,
                 enabled=guideline.enabled,
                 tags=guideline.tags,
                 composition_mode=composition_mode_to_composition_mode_dto(
@@ -691,7 +691,7 @@ def create_router(
                 title=guideline.title,
                 criticality=_criticality_to_dto(guideline.criticality),
                 metadata=guideline.metadata,
-                last_modified_utc=guideline.last_modified_utc,
+                modified_utc=guideline.modified_utc,
                 enabled=guideline.enabled,
                 tags=guideline.tags,
                 composition_mode=composition_mode_to_composition_mode_dto(
@@ -818,7 +818,7 @@ def create_router(
                 title=updated_guideline.title,
                 criticality=_criticality_to_dto(updated_guideline.criticality),
                 metadata=updated_guideline.metadata,
-                last_modified_utc=updated_guideline.last_modified_utc,
+                modified_utc=updated_guideline.modified_utc,
                 enabled=updated_guideline.enabled,
                 tags=updated_guideline.tags,
                 composition_mode=composition_mode_to_composition_mode_dto(

--- a/src/parlant/api/journeys.py
+++ b/src/parlant/api/journeys.py
@@ -183,7 +183,7 @@ class JourneyDTO(
     composition_mode: CompositionModeDTO | None = None
     labels: JourneyLabelsField = set()
     priority: int = 0
-    last_modified_utc: JourneyLastModifiedField
+    modified_utc: JourneyLastModifiedField
 
 
 class JourneyGraphDTO(JourneyDTO):
@@ -526,7 +526,7 @@ def create_router(
             else None,
             labels=journey.labels,
             priority=journey.priority,
-            last_modified_utc=journey.last_modified_utc,
+            modified_utc=journey.modified_utc,
         )
 
     @router.get(
@@ -568,7 +568,7 @@ def create_router(
                     else None,
                     labels=journey.labels,
                     priority=journey.priority,
-                    last_modified_utc=journey.last_modified_utc,
+                    modified_utc=journey.modified_utc,
                 )
             )
 
@@ -634,7 +634,7 @@ def create_router(
             else None,
             labels=model.journey.labels,
             priority=model.journey.priority,
-            last_modified_utc=model.journey.last_modified_utc,
+            modified_utc=model.journey.modified_utc,
             nodes=[node_to_dto(n) for n in model.nodes],
             edges=[edge_to_dto(e) for e in model.edges],
         )
@@ -731,7 +731,7 @@ def create_router(
             else None,
             labels=journey.labels,
             priority=journey.priority,
-            last_modified_utc=journey.last_modified_utc,
+            modified_utc=journey.modified_utc,
         )
 
     @router.delete(

--- a/src/parlant/api/relationships.py
+++ b/src/parlant/api/relationships.py
@@ -182,7 +182,7 @@ def create_router(
                 enabled=model.source_guideline.enabled,
                 tags=model.source_guideline.tags,
                 metadata=model.source_guideline.metadata,
-                last_modified_utc=model.source_guideline.last_modified_utc,
+                modified_utc=model.source_guideline.modified_utc,
                 priority=model.source_guideline.priority,
             )
             if model.source_guideline
@@ -200,7 +200,7 @@ def create_router(
                 enabled=model.target_guideline.enabled,
                 tags=model.target_guideline.tags,
                 metadata=model.target_guideline.metadata,
-                last_modified_utc=model.target_guideline.last_modified_utc,
+                modified_utc=model.target_guideline.modified_utc,
                 priority=model.target_guideline.priority,
             )
             if model.target_guideline

--- a/src/parlant/api/sessions.py
+++ b/src/parlant/api/sessions.py
@@ -51,6 +51,7 @@ from parlant.core.sessions import (
     EventKind,
     EventSource,
     Participant,
+    Session,
     SessionId,
     SessionStatus,
 )
@@ -161,6 +162,14 @@ SessionCreationUTCField: TypeAlias = Annotated[
     ),
 ]
 
+SessionModifiedUTCField: TypeAlias = Annotated[
+    datetime,
+    Field(
+        description="UTC timestamp of when the session was last modified",
+        examples=["2024-03-24T12:00:00Z"],
+    ),
+]
+
 SessionTitleField: TypeAlias = Annotated[
     str,
     Field(
@@ -208,6 +217,7 @@ session_example: ExampleJson = {
     "agent_id": "ag_123xyz",
     "customer_id": "cust_123xy",
     "creation_utc": "2024-03-24T12:00:00Z",
+    "modified_utc": "2024-03-24T12:00:00Z",
     "title": "Product inquiry session",
     "mode": "auto",
     "consumption_offsets": consumption_offsets_example,
@@ -226,6 +236,7 @@ class SessionDTO(
     agent_id: SessionAgentIdPath
     customer_id: SessionCustomerIdField
     creation_utc: SessionCreationUTCField
+    modified_utc: SessionModifiedUTCField
     title: SessionTitleField | None = None
     mode: SessionModeField
     consumption_offsets: ConsumptionOffsetsDTO
@@ -385,6 +396,11 @@ EventCreationUTCField: TypeAlias = Annotated[
     Field(description="UTC timestamp of when the event was created"),
 ]
 
+EventModifiedUTCField: TypeAlias = Annotated[
+    datetime,
+    Field(description="UTC timestamp of when the event was last modified"),
+]
+
 EventCorrelationIdField: TypeAlias = Annotated[
     str,
     Field(
@@ -409,6 +425,7 @@ event_example: ExampleJson = {
     "kind": "message",
     "offset": 0,
     "creation_utc": "2024-03-24T12:00:00Z",
+    "modified_utc": "2024-03-24T12:00:00Z",
     "trace_id": "corr_13xyz",
     "data": {
         "message": "Hello, I need help with my account",
@@ -428,6 +445,7 @@ class EventDTO(
     kind: EventKindDTO
     offset: EventOffsetField
     creation_utc: EventCreationUTCField
+    modified_utc: EventModifiedUTCField
     trace_id: EventTraceIdField
     correlation_id: EventCorrelationIdField
     data: JSONSerializableDTO
@@ -1133,11 +1151,27 @@ def event_to_dto(event: Event) -> EventDTO:
         kind=_event_kind_to_event_kind_dto(event.kind),
         offset=event.offset,
         creation_utc=event.creation_utc,
+        modified_utc=event.modified_utc,
         trace_id=event.trace_id,
         correlation_id=event.trace_id,
         data=cast(JSONSerializableDTO, event.data),
         metadata=event.metadata,
         deleted=event.deleted,
+    )
+
+
+def session_to_dto(session: Session) -> SessionDTO:
+    return SessionDTO(
+        id=session.id,
+        agent_id=session.agent_id,
+        customer_id=session.customer_id,
+        creation_utc=session.creation_utc,
+        modified_utc=session.modified_utc,
+        consumption_offsets=ConsumptionOffsetsDTO(client=session.consumption_offsets["client"]),
+        title=session.title,
+        mode=SessionModeDTO(session.mode),
+        metadata=session.metadata,
+        labels=session.labels,
     )
 
 
@@ -1248,6 +1282,14 @@ SortQuery: TypeAlias = Annotated[
     Query(
         description="Sort direction for results",
         examples=["asc", "desc"],
+    ),
+]
+
+MinModifiedUTCQuery: TypeAlias = Annotated[
+    datetime,
+    Query(
+        description="Only return sessions modified at or after this UTC timestamp",
+        examples=["2024-03-24T12:00:00Z"],
     ),
 ]
 
@@ -1388,17 +1430,7 @@ def create_router(
             labels=params.labels,
         )
 
-        return SessionDTO(
-            id=session.id,
-            agent_id=session.agent_id,
-            customer_id=session.customer_id,
-            creation_utc=session.creation_utc,
-            consumption_offsets=ConsumptionOffsetsDTO(client=session.consumption_offsets["client"]),
-            title=session.title,
-            mode=SessionModeDTO(session.mode),
-            metadata=session.metadata,
-            labels=session.labels,
-        )
+        return session_to_dto(session)
 
     @router.get(
         "/{session_id}",
@@ -1422,19 +1454,7 @@ def create_router(
 
         session = await app.sessions.read(session_id=session_id)
 
-        return SessionDTO(
-            id=session.id,
-            agent_id=session.agent_id,
-            creation_utc=session.creation_utc,
-            title=session.title,
-            customer_id=session.customer_id,
-            consumption_offsets=ConsumptionOffsetsDTO(
-                client=session.consumption_offsets["client"],
-            ),
-            mode=SessionModeDTO(session.mode),
-            metadata=session.metadata,
-            labels=session.labels,
-        )
+        return session_to_dto(session)
 
     @router.get(
         "",
@@ -1471,6 +1491,7 @@ def create_router(
         limit: LimitQuery | None = None,
         cursor: CursorQuery | None = None,
         sort: SortQuery | None = None,
+        min_modified_utc: MinModifiedUTCQuery | None = None,
     ) -> SessionListingDTO | Sequence[SessionDTO]:
         """Lists all sessions matching the specified filters with pagination support.
 
@@ -1485,43 +1506,14 @@ def create_router(
             cursor=decode_cursor(cursor) if cursor else None,
             sort_direction=sort_direction_dto_to_sort_direction(sort) if sort else None,
             labels=set(labels) if labels else None,
+            min_modified_utc=min_modified_utc,
         )
 
         if limit is None:
-            return [
-                SessionDTO(
-                    id=s.id,
-                    agent_id=s.agent_id,
-                    creation_utc=s.creation_utc,
-                    title=s.title,
-                    customer_id=s.customer_id,
-                    consumption_offsets=ConsumptionOffsetsDTO(
-                        client=s.consumption_offsets["client"],
-                    ),
-                    mode=SessionModeDTO(s.mode),
-                    metadata=s.metadata,
-                    labels=s.labels,
-                )
-                for s in sessions_result.items
-            ]
+            return [session_to_dto(s) for s in sessions_result.items]
 
         return SessionListingDTO(
-            items=[
-                SessionDTO(
-                    id=s.id,
-                    agent_id=s.agent_id,
-                    creation_utc=s.creation_utc,
-                    title=s.title,
-                    customer_id=s.customer_id,
-                    consumption_offsets=ConsumptionOffsetsDTO(
-                        client=s.consumption_offsets["client"],
-                    ),
-                    mode=SessionModeDTO(s.mode),
-                    metadata=s.metadata,
-                    labels=s.labels,
-                )
-                for s in sessions_result.items
-            ],
+            items=[session_to_dto(s) for s in sessions_result.items],
             total_count=sessions_result.total_count,
             has_more=sessions_result.has_more,
             next_cursor=encode_cursor(sessions_result.next_cursor)
@@ -1655,19 +1647,7 @@ def create_router(
             else None,
         )
 
-        return SessionDTO(
-            id=session.id,
-            agent_id=session.agent_id,
-            creation_utc=session.creation_utc,
-            title=session.title,
-            customer_id=session.customer_id,
-            consumption_offsets=ConsumptionOffsetsDTO(
-                client=session.consumption_offsets["client"],
-            ),
-            mode=SessionModeDTO(session.mode),
-            metadata=session.metadata,
-            labels=session.labels,
-        )
+        return session_to_dto(session)
 
     @router.post(
         "/{session_id}/events",
@@ -1874,18 +1854,7 @@ def create_router(
             metadata=params.metadata,
         )
 
-        return EventDTO(
-            id=event.id,
-            source=_event_source_to_event_source_dto(event.source),
-            kind=_event_kind_to_event_kind_dto(event.kind),
-            offset=event.offset,
-            creation_utc=event.creation_utc,
-            trace_id=event.trace_id,
-            correlation_id=event.trace_id,
-            data=cast(JSONSerializableDTO, event.data),
-            metadata=event.metadata,
-            deleted=event.deleted,
-        )
+        return event_to_dto(event)
 
     async def _add_custom_event(
         session_id: SessionIdPath,
@@ -1906,18 +1875,7 @@ def create_router(
             trigger_processing=False,
         )
 
-        return EventDTO(
-            id=event.id,
-            source=_event_source_to_event_source_dto(event.source),
-            kind=_event_kind_to_event_kind_dto(event.kind),
-            offset=event.offset,
-            creation_utc=event.creation_utc,
-            trace_id=event.trace_id,
-            correlation_id=event.trace_id,
-            data=cast(JSONSerializableDTO, event.data),
-            metadata=event.metadata,
-            deleted=event.deleted,
-        )
+        return event_to_dto(event)
 
     @router.get(
         "/{session_id}/events",
@@ -2051,21 +2009,7 @@ def create_router(
             trace_id=trace_id,
         )
 
-        return [
-            EventDTO(
-                id=e.id,
-                source=_event_source_to_event_source_dto(e.source),
-                kind=_event_kind_to_event_kind_dto(e.kind),
-                offset=e.offset,
-                creation_utc=e.creation_utc,
-                trace_id=e.trace_id,
-                correlation_id=e.trace_id,
-                data=cast(JSONSerializableDTO, e.data),
-                metadata=e.metadata,
-                deleted=e.deleted,
-            )
-            for e in events
-        ]
+        return [event_to_dto(e) for e in events]
 
     @router.get(
         "/{session_id}/events/{event_id}",

--- a/src/parlant/core/agents.py
+++ b/src/parlant/core/agents.py
@@ -90,7 +90,7 @@ class Agent:
     name: str
     description: Optional[str]
     creation_utc: datetime
-    last_modified_utc: datetime
+    modified_utc: datetime
     max_engine_iterations: int
     tags: Sequence[TagId]
     engine: str
@@ -351,7 +351,7 @@ class AgentDocumentStore(AgentStore):
             id=ObjectId(agent.id),
             version=self.VERSION.to_string(),
             creation_utc=agent.creation_utc.isoformat(),
-            last_modified=agent.last_modified_utc.isoformat(),
+            last_modified=agent.modified_utc.isoformat(),
             name=agent.name,
             description=agent.description,
             max_engine_iterations=agent.max_engine_iterations,
@@ -372,7 +372,7 @@ class AgentDocumentStore(AgentStore):
         return Agent(
             id=AgentId(agent_document["id"]),
             creation_utc=datetime.fromisoformat(agent_document["creation_utc"]),
-            last_modified_utc=datetime.fromisoformat(agent_document["last_modified"]),
+            modified_utc=datetime.fromisoformat(agent_document["last_modified"]),
             name=agent_document["name"],
             description=agent_document["description"],
             max_engine_iterations=agent_document["max_engine_iterations"],
@@ -420,7 +420,7 @@ class AgentDocumentStore(AgentStore):
                 name=name,
                 description=description,
                 creation_utc=creation_utc,
-                last_modified_utc=creation_utc,
+                modified_utc=creation_utc,
                 max_engine_iterations=max_engine_iterations,
                 tags=tags or [],
                 composition_mode=composition_mode or CompositionMode.FLUID,

--- a/src/parlant/core/app_modules/relationships.py
+++ b/src/parlant/core/app_modules/relationships.py
@@ -118,7 +118,7 @@ class RelationshipModule:
                 id=tag_id,
                 name=agent.name,
                 creation_utc=agent.creation_utc,
-                last_modified_utc=agent.last_modified_utc,
+                modified_utc=agent.modified_utc,
             )
         elif journey_id := Tag.extract_journey_id(tag_id):
             journey = await self._journey_store.read_journey(journey_id=cast(JourneyId, journey_id))
@@ -126,7 +126,7 @@ class RelationshipModule:
                 id=tag_id,
                 name=journey.title,
                 creation_utc=journey.creation_utc,
-                last_modified_utc=journey.last_modified_utc,
+                modified_utc=journey.modified_utc,
             )
         elif journey_node_id := Tag.extract_journey_node_id(tag_id):
             journey_node = await self._journey_store.read_node(
@@ -136,7 +136,7 @@ class RelationshipModule:
                 id=tag_id,
                 name=str(journey_node.action),
                 creation_utc=journey_node.creation_utc,
-                last_modified_utc=journey_node.creation_utc,
+                modified_utc=journey_node.creation_utc,
             )
         else:
             return await self._tag_store.read_tag(tag_id=tag_id)

--- a/src/parlant/core/app_modules/sessions.py
+++ b/src/parlant/core/app_modules/sessions.py
@@ -249,6 +249,7 @@ class SessionModule:
         cursor: Cursor | None = None,
         sort_direction: SortDirection | None = None,
         labels: Set[str] | None = None,
+        min_modified_utc: datetime | None = None,
     ) -> SessionListingModel:
         result = await self._session_store.list_sessions(
             agent_id=agent_id,
@@ -257,6 +258,7 @@ class SessionModule:
             cursor=cursor,
             sort_direction=sort_direction,
             labels=labels,
+            min_modified_utc=min_modified_utc,
         )
 
         return SessionListingModel(
@@ -272,9 +274,13 @@ class SessionModule:
         params: SessionUpdateParamsModel,
         labels: SessionLabelsUpdateParams | None = None,
     ) -> Session:
-        session = await self._session_store.update_session(
-            session_id=session_id,
-            params=params,
+        session = (
+            await self._session_store.update_session(
+                session_id=session_id,
+                params=params,
+            )
+            if params
+            else await self._session_store.read_session(session_id)
         )
 
         if labels:

--- a/src/parlant/core/canned_responses.py
+++ b/src/parlant/core/canned_responses.py
@@ -81,7 +81,7 @@ class CannedResponse:
             value=value,
             fields=[],
             creation_utc=now,
-            last_modified_utc=now,
+            modified_utc=now,
             tags=[],
             signals=[],
             metadata={},
@@ -93,7 +93,7 @@ class CannedResponse:
 
     id: CannedResponseId
     creation_utc: datetime
-    last_modified_utc: datetime
+    modified_utc: datetime
     value: str
     fields: Sequence[CannedResponseField]
     signals: Sequence[str]
@@ -563,7 +563,7 @@ class CannedResponseVectorStore(CannedResponseStore):
             id=ObjectId(canned_response_id.id),
             version=self.VERSION.to_string(),
             creation_utc=canned_response_id.creation_utc.isoformat(),
-            last_modified=canned_response_id.last_modified_utc.isoformat(),
+            last_modified=canned_response_id.modified_utc.isoformat(),
             value=canned_response_id.value,
             fields=json.dumps(
                 [
@@ -589,7 +589,7 @@ class CannedResponseVectorStore(CannedResponseStore):
         return CannedResponse(
             id=CannedResponseId(canned_response_document["id"]),
             creation_utc=datetime.fromisoformat(canned_response_document["creation_utc"]),
-            last_modified_utc=datetime.fromisoformat(
+            modified_utc=datetime.fromisoformat(
                 canned_response_document.get(
                     "last_modified", canned_response_document["creation_utc"]
                 )
@@ -658,7 +658,7 @@ class CannedResponseVectorStore(CannedResponseStore):
                 value=value,
                 fields=fields or [],
                 creation_utc=creation_utc,
-                last_modified_utc=creation_utc,
+                modified_utc=creation_utc,
                 metadata=metadata,
                 tags=tags or [],
                 signals=signals or [],
@@ -736,7 +736,7 @@ class CannedResponseVectorStore(CannedResponseStore):
             canrep = CannedResponse(
                 id=CannedResponseId(canned_response_id),
                 creation_utc=datetime.fromisoformat(doc["creation_utc"]),
-                last_modified_utc=datetime.now(timezone.utc),
+                modified_utc=datetime.now(timezone.utc),
                 value=params.get("value", existing_value.value),
                 fields=params.get("fields", existing_value.fields),
                 signals=params.get("signals", existing_value.signals),

--- a/src/parlant/core/context_variables.py
+++ b/src/parlant/core/context_variables.py
@@ -53,7 +53,7 @@ class ContextVariable:
     name: str
     description: Optional[str]
     creation_utc: datetime
-    last_modified_utc: datetime
+    modified_utc: datetime
     tool_id: Optional[ToolId]
     freshness_rules: Optional[str]
     tags: Sequence[TagId]
@@ -66,7 +66,7 @@ class ContextVariable:
 @dataclass(frozen=True)
 class ContextVariableValue:
     id: ContextVariableValueId
-    last_modified_utc: datetime
+    modified_utc: datetime
     data: JSONSerializable
 
 
@@ -447,7 +447,7 @@ class ContextVariableDocumentStore(ContextVariableStore):
             name=context_variable.name,
             description=context_variable.description,
             creation_utc=context_variable.creation_utc.isoformat(),
-            last_modified=context_variable.last_modified_utc.isoformat(),
+            last_modified=context_variable.modified_utc.isoformat(),
             tool_id=context_variable.tool_id.to_string() if context_variable.tool_id else None,
             freshness_rules=context_variable.freshness_rules,
         )
@@ -458,7 +458,7 @@ class ContextVariableDocumentStore(ContextVariableStore):
         variable_id: ContextVariableId,
         key: str,
     ) -> _ContextVariableValueDocument:
-        last_modified_str = context_variable_value.last_modified_utc.isoformat()
+        last_modified_str = context_variable_value.modified_utc.isoformat()
 
         return _ContextVariableValueDocument(
             id=ObjectId(context_variable_value.id),
@@ -486,7 +486,7 @@ class ContextVariableDocumentStore(ContextVariableStore):
             name=context_variable_document["name"],
             description=context_variable_document.get("description"),
             creation_utc=datetime.fromisoformat(context_variable_document["creation_utc"]),
-            last_modified_utc=datetime.fromisoformat(context_variable_document["last_modified"]),
+            modified_utc=datetime.fromisoformat(context_variable_document["last_modified"]),
             tool_id=ToolId.from_string(context_variable_document["tool_id"])
             if context_variable_document["tool_id"]
             else None,
@@ -500,9 +500,7 @@ class ContextVariableDocumentStore(ContextVariableStore):
     ) -> ContextVariableValue:
         return ContextVariableValue(
             id=ContextVariableValueId(context_variable_value_document["id"]),
-            last_modified_utc=datetime.fromisoformat(
-                context_variable_value_document["last_modified"]
-            ),
+            modified_utc=datetime.fromisoformat(context_variable_value_document["last_modified"]),
             data=context_variable_value_document["data"],
         )
 
@@ -527,7 +525,7 @@ class ContextVariableDocumentStore(ContextVariableStore):
                 name=name,
                 description=description,
                 creation_utc=creation_utc,
-                last_modified_utc=creation_utc,
+                modified_utc=creation_utc,
                 tool_id=tool_id,
                 freshness_rules=freshness_rules,
                 tags=tags or [],
@@ -700,7 +698,7 @@ class ContextVariableDocumentStore(ContextVariableStore):
 
             value = ContextVariableValue(
                 id=ContextVariableValueId(self._id_generator.generate(value_checksum)),
-                last_modified_utc=last_modified,
+                modified_utc=last_modified,
                 data=data,
             )
 

--- a/src/parlant/core/engines/alpha/engine.py
+++ b/src/parlant/core/engines/alpha/engine.py
@@ -210,7 +210,7 @@ class AlphaEngine(Engine):
                 {
                     "session_id": context.session_id,
                     "agent_id": context.agent_id,
-                    "agent_last_modified": loaded_context.agent.last_modified_utc.isoformat(),
+                    "agent_last_modified": loaded_context.agent.modified_utc.isoformat(),
                 },
             ):
                 async with self._hist_engine_process_duration.measure():
@@ -277,7 +277,7 @@ class AlphaEngine(Engine):
                     {
                         "session_id": context.session_id,
                         "agent_id": context.agent_id,
-                        "agent_last_modified": loaded_context.agent.last_modified_utc.isoformat(),
+                        "agent_last_modified": loaded_context.agent.modified_utc.isoformat(),
                     },
                 ):
                     await self._do_utter(loaded_context, requests)
@@ -1110,12 +1110,12 @@ class AlphaEngine(Engine):
             )
 
             event_data["matched_guidelines"] = [
-                {"id": m.guideline.id, "last_modified": m.guideline.last_modified_utc.isoformat()}
+                {"id": m.guideline.id, "last_modified": m.guideline.modified_utc.isoformat()}
                 for m in all_matches
             ]
 
             event_data["matched_journeys"] = [
-                {"id": j.id, "last_modified": j.last_modified_utc.isoformat()}
+                {"id": j.id, "last_modified": j.modified_utc.isoformat()}
                 for j in context.state.journeys
             ]
 
@@ -1946,7 +1946,7 @@ class AlphaEngine(Engine):
                 guideline=Guideline(
                     id=GuidelineId(f"<canrep-request-{i}>"),
                     creation_utc=datetime.now(timezone.utc),
-                    last_modified_utc=datetime.now(timezone.utc),
+                    modified_utc=datetime.now(timezone.utc),
                     content=GuidelineContent(
                         condition="",  # FIXME: Change this to None when we support `str | None` conditions
                         action=utterance_request.action,
@@ -2030,7 +2030,7 @@ class AlphaEngine(Engine):
                             guideline=Guideline(
                                 id=GuidelineId(f"<tool-guideline-{guideline_index}>"),
                                 creation_utc=datetime.now(timezone.utc),
-                                last_modified_utc=datetime.now(timezone.utc),
+                                modified_utc=datetime.now(timezone.utc),
                                 content=GuidelineContent(
                                     condition=guideline_data.get("condition", ""),
                                     action=guideline_data["action"],
@@ -2263,7 +2263,7 @@ async def load_fresh_context_variable_value(
     # So we do have a tool attached.
     # Do we already have a value, and is it sufficiently fresh?
     if value and variable.freshness_rules:
-        cron_iterator = croniter(variable.freshness_rules, value.last_modified_utc)
+        cron_iterator = croniter(variable.freshness_rules, value.modified_utc)
 
         if cron_iterator.get_next(datetime) > current_time:
             # We already have a fresh value in store. Return it.

--- a/src/parlant/core/engines/alpha/guideline_matching/generic/disambiguation_batch.py
+++ b/src/parlant/core/engines/alpha/guideline_matching/generic/disambiguation_batch.py
@@ -464,6 +464,7 @@ def _make_event(e_id: str, source: EventSource, message: str) -> Event:
         source=source,
         kind=EventKind.MESSAGE,
         creation_utc=datetime.now(timezone.utc),
+        modified_utc=datetime.now(timezone.utc),
         offset=0,
         trace_id="",
         data={"message": message},

--- a/src/parlant/core/engines/alpha/guideline_matching/generic/generic_guideline_matching_strategy.py
+++ b/src/parlant/core/engines/alpha/guideline_matching/generic/generic_guideline_matching_strategy.py
@@ -317,7 +317,7 @@ class GenericGuidelineMatchingStrategy(GuidelineMatchingStrategy):
                         guideline=Guideline(
                             id=cast(GuidelineId, f"<transient_{generate_id()}>"),
                             creation_utc=datetime.now(),
-                            last_modified_utc=datetime.now(),
+                            modified_utc=datetime.now(),
                             content=GuidelineContent(
                                 condition=internal_representation(m.guideline).condition,
                                 action=cast(

--- a/src/parlant/core/engines/alpha/guideline_matching/generic/guideline_actionable_batch.py
+++ b/src/parlant/core/engines/alpha/guideline_matching/generic/guideline_actionable_batch.py
@@ -440,6 +440,7 @@ def _make_event(e_id: str, source: EventSource, message: str) -> Event:
         source=source,
         kind=EventKind.MESSAGE,
         creation_utc=datetime.now(timezone.utc),
+        modified_utc=datetime.now(timezone.utc),
         offset=0,
         trace_id="",
         data={"message": message},

--- a/src/parlant/core/engines/alpha/guideline_matching/generic/guideline_low_criticality_batch.py
+++ b/src/parlant/core/engines/alpha/guideline_matching/generic/guideline_low_criticality_batch.py
@@ -424,6 +424,7 @@ def _make_event(e_id: str, source: EventSource, message: str) -> Event:
         source=source,
         kind=EventKind.MESSAGE,
         creation_utc=datetime.now(timezone.utc),
+        modified_utc=datetime.now(timezone.utc),
         offset=0,
         trace_id="",
         data={"message": message},

--- a/src/parlant/core/engines/alpha/guideline_matching/generic/guideline_previously_applied_actionable_batch.py
+++ b/src/parlant/core/engines/alpha/guideline_matching/generic/guideline_previously_applied_actionable_batch.py
@@ -459,6 +459,7 @@ def _make_event(e_id: str, source: EventSource, message: str) -> Event:
         source=source,
         kind=EventKind.MESSAGE,
         creation_utc=datetime.now(timezone.utc),
+        modified_utc=datetime.now(timezone.utc),
         offset=0,
         trace_id="",
         data={"message": message},

--- a/src/parlant/core/engines/alpha/guideline_matching/generic/guideline_previously_applied_actionable_customer_dependent_batch.py
+++ b/src/parlant/core/engines/alpha/guideline_matching/generic/guideline_previously_applied_actionable_customer_dependent_batch.py
@@ -466,6 +466,7 @@ def _make_event(e_id: str, source: EventSource, message: str) -> Event:
         source=source,
         kind=EventKind.MESSAGE,
         creation_utc=datetime.now(timezone.utc),
+        modified_utc=datetime.now(timezone.utc),
         offset=0,
         trace_id="",
         data={"message": message},

--- a/src/parlant/core/engines/alpha/guideline_matching/generic/journey/journey_backtrack_check.py
+++ b/src/parlant/core/engines/alpha/guideline_matching/generic/journey/journey_backtrack_check.py
@@ -526,7 +526,7 @@ OUTPUT FORMAT
                     Guideline(
                         id=GuidelineId(f"c-{i}"),
                         creation_utc=datetime.now(timezone.utc),
-                        last_modified_utc=datetime.now(timezone.utc),
+                        modified_utc=datetime.now(timezone.utc),
                         metadata={"journey_node": {"journey_id": "journey"}},
                         content=GuidelineContent(
                             condition=c,
@@ -556,6 +556,7 @@ def _make_event(e_id: str, source: EventSource, message: str) -> Event:
         source=source,
         kind=EventKind.MESSAGE,
         creation_utc=datetime.now(timezone.utc),
+        modified_utc=datetime.now(timezone.utc),
         offset=0,
         trace_id="",
         data={"message": message},

--- a/src/parlant/core/engines/alpha/guideline_matching/generic/journey/journey_backtrack_node_selection.py
+++ b/src/parlant/core/engines/alpha/guideline_matching/generic/journey/journey_backtrack_node_selection.py
@@ -575,7 +575,7 @@ class JourneyBacktrackNodeSelection:
                     Guideline(
                         id=GuidelineId(f"c-{i}"),
                         creation_utc=datetime.now(timezone.utc),
-                        last_modified_utc=datetime.now(timezone.utc),
+                        modified_utc=datetime.now(timezone.utc),
                         metadata={"journey_node": {"journey_id": "journey"}},
                         content=GuidelineContent(
                             condition=c,
@@ -876,6 +876,7 @@ def _make_event(e_id: str, source: EventSource, message: str) -> Event:
         source=source,
         kind=EventKind.MESSAGE,
         creation_utc=datetime.now(timezone.utc),
+        modified_utc=datetime.now(timezone.utc),
         offset=0,
         trace_id="",
         data={"message": message},

--- a/src/parlant/core/engines/alpha/guideline_matching/generic/journey/journey_next_step_selection.py
+++ b/src/parlant/core/engines/alpha/guideline_matching/generic/journey/journey_next_step_selection.py
@@ -545,7 +545,7 @@ OUTPUT FORMAT
                 Guideline(
                     id=GuidelineId(f"c-{i}"),
                     creation_utc=datetime.now(timezone.utc),
-                    last_modified_utc=datetime.now(timezone.utc),
+                    modified_utc=datetime.now(timezone.utc),
                     metadata={"journey_node": {"journey_id": "journey"}},
                     content=GuidelineContent(
                         condition=c,
@@ -704,6 +704,7 @@ def _make_event(e_id: str, source: EventSource, message: str) -> Event:
         source=source,
         kind=EventKind.MESSAGE,
         creation_utc=datetime.now(timezone.utc),
+        modified_utc=datetime.now(timezone.utc),
         offset=0,
         trace_id="",
         data={"message": message},

--- a/src/parlant/core/engines/alpha/guideline_matching/generic/observational_batch.py
+++ b/src/parlant/core/engines/alpha/guideline_matching/generic/observational_batch.py
@@ -436,6 +436,7 @@ def _make_event(e_id: str, source: EventSource, message: str) -> Event:
         source=source,
         kind=EventKind.MESSAGE,
         creation_utc=datetime.now(timezone.utc),
+        modified_utc=datetime.now(timezone.utc),
         offset=0,
         trace_id="",
         data={"message": message},

--- a/src/parlant/core/engines/alpha/tracing.py
+++ b/src/parlant/core/engines/alpha/tracing.py
@@ -117,7 +117,7 @@ class EngineTracer:
             "glossary.term_loaded",
             attributes={
                 "term_id": term.id,
-                "last_modified": term.last_modified_utc.isoformat(),
+                "last_modified": term.modified_utc.isoformat(),
                 "name": term.name,
             },
         )
@@ -205,7 +205,7 @@ class EngineTracer:
     ) -> None:
         attributes: dict[str, AttributeValue] = {
             "canned_response_id": canned_response.id,
-            "last_modified": canned_response.last_modified_utc.isoformat(),
+            "last_modified": canned_response.modified_utc.isoformat(),
             "rendered": rendered or "",
             "is_fallback": is_fallback,
         }
@@ -237,19 +237,19 @@ class EngineTracer:
                 return {
                     "entity_type": "guideline",
                     "id": str(re.entity.id),
-                    "last_modified": re.entity.last_modified_utc.isoformat(),
+                    "last_modified": re.entity.modified_utc.isoformat(),
                 }
             if isinstance(re.entity, Journey):
                 return {
                     "entity_type": "journey",
                     "id": str(re.entity.id),
-                    "last_modified": re.entity.last_modified_utc.isoformat(),
+                    "last_modified": re.entity.modified_utc.isoformat(),
                 }
             if isinstance(re.entity, Tag):
                 return {
                     "entity_type": "tag",
                     "id": str(re.entity.id),
-                    "last_modified": re.entity.last_modified_utc.isoformat(),
+                    "last_modified": re.entity.modified_utc.isoformat(),
                 }
             raise ValueError(f"Unknown ResolvedEntity entity type: {type(re.entity).__name__}")
 
@@ -263,7 +263,7 @@ class EngineTracer:
                         {
                             "relationship": {
                                 "id": str(r.details.relationship.id),
-                                "last_modified": r.details.relationship.last_modified_utc.isoformat(),
+                                "last_modified": r.details.relationship.modified_utc.isoformat(),
                             }
                         }
                         if r.details.relationship
@@ -283,11 +283,11 @@ class EngineTracer:
             if journey_node:
                 edge_id = extract_edge_id_from_journey_node_guideline_id(gid)
                 journey_id = cast(str, match.metadata.get("step_selection_journey_id"))
-                journey_last_modified_utc = ""
+                journey_modified_utc = ""
                 if journeys and journey_id:
                     j = journeys.get(JourneyId(journey_id))
                     if j:
-                        journey_last_modified_utc = j.last_modified_utc.isoformat()
+                        journey_modified_utc = j.modified_utc.isoformat()
 
                 self._tracer.add_event(
                     "journey.state.selected",
@@ -299,11 +299,7 @@ class EngineTracer:
                         ),
                         "rationale": rationale,
                         "journey_id": journey_id,
-                        **(
-                            {"last_modified": journey_last_modified_utc}
-                            if journey_last_modified_utc
-                            else {}
-                        ),
+                        **({"last_modified": journey_modified_utc} if journey_modified_utc else {}),
                         **(
                             {
                                 "sub_journey_id": cast(str, journey_node["sub_journey_id"]),
@@ -322,7 +318,7 @@ class EngineTracer:
                     "gm.selected",
                     attributes={
                         "guideline_id": gid,
-                        "last_modified": match.guideline.last_modified_utc.isoformat(),
+                        "last_modified": match.guideline.modified_utc.isoformat(),
                         "rationale": rationale,
                         **_resolutions_attr(gid),
                     },
@@ -337,11 +333,11 @@ class EngineTracer:
             if journey_node:
                 edge_id = extract_edge_id_from_journey_node_guideline_id(gid)
                 journey_id = cast(str, match.metadata.get("step_selection_journey_id"))
-                journey_last_modified_utc = ""
+                journey_modified_utc = ""
                 if journeys and journey_id:
                     j = journeys.get(JourneyId(journey_id))
                     if j:
-                        journey_last_modified_utc = j.last_modified_utc.isoformat()
+                        journey_modified_utc = j.modified_utc.isoformat()
 
                 self._tracer.add_event(
                     "journey.state.ruled_out",
@@ -353,11 +349,7 @@ class EngineTracer:
                         ),
                         "rationale": rationale,
                         "journey_id": journey_id,
-                        **(
-                            {"last_modified": journey_last_modified_utc}
-                            if journey_last_modified_utc
-                            else {}
-                        ),
+                        **({"last_modified": journey_modified_utc} if journey_modified_utc else {}),
                         **(
                             {
                                 "sub_journey_id": cast(str, journey_node["sub_journey_id"]),
@@ -376,7 +368,7 @@ class EngineTracer:
                     "gm.ruled_out",
                     attributes={
                         "guideline_id": gid,
-                        "last_modified": match.guideline.last_modified_utc.isoformat(),
+                        "last_modified": match.guideline.modified_utc.isoformat(),
                         "rationale": rationale,
                         **_resolutions_attr(gid),
                     },

--- a/src/parlant/core/engines/compass/guideline_matching/guideline_distiller.py
+++ b/src/parlant/core/engines/compass/guideline_matching/guideline_distiller.py
@@ -371,6 +371,7 @@ def _make_event(e_id: str, source: EventSource, message: str) -> Event:
         source=source,
         kind=EventKind.MESSAGE,
         creation_utc=datetime.now(timezone.utc),
+        modified_utc=datetime.now(timezone.utc),
         offset=0,
         trace_id="",
         data={"message": message},

--- a/src/parlant/core/engines/compass/guideline_matching/guideline_ranker.py
+++ b/src/parlant/core/engines/compass/guideline_matching/guideline_ranker.py
@@ -418,6 +418,7 @@ def _make_event(e_id: str, source: EventSource, message: str) -> Event:
         source=source,
         kind=EventKind.MESSAGE,
         creation_utc=datetime.now(timezone.utc),
+        modified_utc=datetime.now(timezone.utc),
         offset=0,
         trace_id="",
         data={"message": message},

--- a/src/parlant/core/glossary.py
+++ b/src/parlant/core/glossary.py
@@ -58,7 +58,7 @@ TermId = NewType("TermId", str)
 class Term:
     id: TermId
     creation_utc: datetime
-    last_modified_utc: datetime
+    modified_utc: datetime
     name: str
     description: str
     synonyms: list[str]
@@ -303,7 +303,7 @@ class GlossaryVectorStore(GlossaryStore):
             content=content,
             checksum=checksum,
             creation_utc=term.creation_utc.isoformat(),
-            last_modified=term.last_modified_utc.isoformat(),
+            last_modified=term.modified_utc.isoformat(),
             name=term.name,
             description=term.description,
             synonyms=(", ").join(term.synonyms) if term.synonyms is not None else "",
@@ -317,7 +317,7 @@ class GlossaryVectorStore(GlossaryStore):
         return Term(
             id=TermId(term_document["id"]),
             creation_utc=datetime.fromisoformat(term_document["creation_utc"]),
-            last_modified_utc=datetime.fromisoformat(term_document["last_modified"]),
+            modified_utc=datetime.fromisoformat(term_document["last_modified"]),
             name=term_document["name"],
             description=term_document["description"],
             synonyms=term_document["synonyms"].split(", ") if term_document["synonyms"] else [],
@@ -356,7 +356,7 @@ class GlossaryVectorStore(GlossaryStore):
             term = Term(
                 id=term_id,
                 creation_utc=creation_utc,
-                last_modified_utc=creation_utc,
+                modified_utc=creation_utc,
                 name=name,
                 description=description,
                 synonyms=list(synonyms) if synonyms else [],

--- a/src/parlant/core/guidelines.py
+++ b/src/parlant/core/guidelines.py
@@ -71,7 +71,7 @@ class GuidelineContent:
 class Guideline:
     id: GuidelineId
     creation_utc: datetime
-    last_modified_utc: datetime
+    modified_utc: datetime
     content: GuidelineContent
     enabled: bool
     tags: Sequence[TagId]
@@ -705,7 +705,7 @@ class GuidelineVectorStore(GuidelineStore):
             id=ObjectId(guideline.id),
             version=self.VERSION.to_string(),
             creation_utc=guideline.creation_utc.isoformat(),
-            last_modified=guideline.last_modified_utc.isoformat(),
+            last_modified=guideline.modified_utc.isoformat(),
             condition=guideline.content.condition,
             action=guideline.content.action,
             description=guideline.content.description,
@@ -739,7 +739,7 @@ class GuidelineVectorStore(GuidelineStore):
         return Guideline(
             id=GuidelineId(guideline_document["id"]),
             creation_utc=datetime.fromisoformat(guideline_document["creation_utc"]),
-            last_modified_utc=datetime.fromisoformat(guideline_document["last_modified"]),
+            modified_utc=datetime.fromisoformat(guideline_document["last_modified"]),
             content=GuidelineContent(
                 condition=guideline_document["condition"],
                 action=guideline_document["action"],
@@ -850,7 +850,7 @@ class GuidelineVectorStore(GuidelineStore):
             guideline = Guideline(
                 id=guideline_id,
                 creation_utc=creation_utc,
-                last_modified_utc=creation_utc,
+                modified_utc=creation_utc,
                 content=GuidelineContent(
                     condition=condition,
                     action=action,

--- a/src/parlant/core/journey_guideline_projection.py
+++ b/src/parlant/core/journey_guideline_projection.py
@@ -117,7 +117,7 @@ class JourneyGuidelineProjection:
         link_metadata: dict[str, JSONSerializable] = {
             "link_id": link.id,
             "sub_journey_id": link.sub_journey_id,
-            "sub_journey_last_modified": sub_journey.last_modified_utc.isoformat(),
+            "sub_journey_last_modified": sub_journey.modified_utc.isoformat(),
         }
 
         # Sub-journey root handling:
@@ -481,7 +481,7 @@ class JourneyGuidelineProjection:
                 ),
                 criticality=Criticality.HIGH,
                 creation_utc=datetime.now(timezone.utc),
-                last_modified_utc=datetime.now(timezone.utc),
+                modified_utc=datetime.now(timezone.utc),
                 enabled=True,
                 tags=list(journey.tags),
                 metadata=metadata,

--- a/src/parlant/core/journeys.py
+++ b/src/parlant/core/journeys.py
@@ -122,7 +122,7 @@ class JourneyLink:
 class Journey:
     id: JourneyId
     creation_utc: datetime
-    last_modified_utc: datetime
+    modified_utc: datetime
     description: str
     triggers: Sequence[GuidelineId]
     title: str
@@ -947,7 +947,7 @@ class JourneyVectorStore(JourneyStore):
             id=ObjectId(journey.id),
             version=self.VERSION.to_string(),
             creation_utc=journey.creation_utc.isoformat(),
-            last_modified=journey.last_modified_utc.isoformat(),
+            last_modified=journey.modified_utc.isoformat(),
             title=journey.title,
             description=journey.description,
             root_id=journey.root_id,
@@ -977,7 +977,7 @@ class JourneyVectorStore(JourneyStore):
         return Journey(
             id=JourneyId(doc["id"]),
             creation_utc=datetime.fromisoformat(doc["creation_utc"]),
-            last_modified_utc=datetime.fromisoformat(doc.get("last_modified", doc["creation_utc"])),
+            modified_utc=datetime.fromisoformat(doc.get("last_modified", doc["creation_utc"])),
             triggers=triggers,
             title=doc["title"],
             description=doc["description"],
@@ -1146,7 +1146,7 @@ class JourneyVectorStore(JourneyStore):
             journey = Journey(
                 id=journey_id,
                 creation_utc=creation_utc,
-                last_modified_utc=creation_utc,
+                modified_utc=creation_utc,
                 triggers=triggers,
                 title=title,
                 description=description,

--- a/src/parlant/core/relationships.py
+++ b/src/parlant/core/relationships.py
@@ -110,7 +110,7 @@ class Relationship:
 
     id: RelationshipId
     creation_utc: datetime
-    last_modified_utc: datetime
+    modified_utc: datetime
     source: RelationshipEntity
     target: RelationshipEntity
     kind: RelationshipKind
@@ -279,7 +279,7 @@ class RelationshipDocumentStore(RelationshipStore):
             id=ObjectId(relationship.id),
             version=self.VERSION.to_string(),
             creation_utc=relationship.creation_utc.isoformat(),
-            last_modified=relationship.last_modified_utc.isoformat(),
+            last_modified=relationship.modified_utc.isoformat(),
             source=relationship.source.id_to_string(),
             source_type=relationship.source.kind.value,
             target=relationship.target.id_to_string(),
@@ -336,7 +336,7 @@ class RelationshipDocumentStore(RelationshipStore):
         return Relationship(
             id=RelationshipId(relationship_document["id"]),
             creation_utc=datetime.fromisoformat(relationship_document["creation_utc"]),
-            last_modified_utc=datetime.fromisoformat(relationship_document["last_modified"]),
+            modified_utc=datetime.fromisoformat(relationship_document["last_modified"]),
             source=source,
             target=target,
             kind=kind,
@@ -404,7 +404,7 @@ class RelationshipDocumentStore(RelationshipStore):
             relationship = Relationship(
                 id=relationship_id,
                 creation_utc=creation_utc,
-                last_modified_utc=creation_utc,
+                modified_utc=creation_utc,
                 source=source,
                 target=target,
                 kind=kind,

--- a/src/parlant/core/sessions.py
+++ b/src/parlant/core/sessions.py
@@ -15,7 +15,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from datetime import datetime, timezone
 from enum import Enum
 from dataclasses import field
@@ -122,6 +122,7 @@ class Event:
     source: EventSource
     kind: EventKind
     creation_utc: datetime
+    modified_utc: datetime
     offset: int
     trace_id: str
     data: JSONSerializable
@@ -257,6 +258,7 @@ class AgentState:
 class Session:
     id: SessionId
     creation_utc: datetime
+    modified_utc: datetime
     customer_id: CustomerId
     agent_id: AgentId
     mode: SessionMode
@@ -337,6 +339,7 @@ class SessionStore(ABC):
         cursor: Cursor | None = None,
         sort_direction: SortDirection | None = None,
         labels: Optional[Set[str]] = None,
+        min_modified_utc: datetime | None = None,
     ) -> SessionListing: ...
 
     @abstractmethod
@@ -477,6 +480,7 @@ class _SessionDocument(TypedDict, total=False):
     id: ObjectId
     version: Version.String
     creation_utc: str
+    modified_utc: str
     customer_id: CustomerId
     agent_id: AgentId
     mode: SessionMode
@@ -517,6 +521,7 @@ class _EventDocument(TypedDict, total=False):
     id: ObjectId
     version: Version.String
     creation_utc: str
+    modified_utc: str
     session_id: SessionId
     source: str
     kind: str
@@ -654,7 +659,7 @@ class _ToolEventData_v0_5_0(TypedDict):
 
 
 class SessionDocumentStore(SessionStore):
-    VERSION = Version.from_string("0.9.0")
+    VERSION = Version.from_string("0.10.0")
 
     def __init__(
         self,
@@ -775,6 +780,24 @@ class SessionDocumentStore(SessionStore):
                 labels=[],  # Default to empty labels for existing sessions
             )
 
+        async def v0_9_0_to_v0_10_0(doc: BaseDocument) -> BaseDocument | None:
+            doc = cast(_SessionDocument, doc)
+
+            return _SessionDocument(
+                id=doc["id"],
+                version=Version.String("0.10.0"),
+                creation_utc=doc["creation_utc"],
+                modified_utc=doc.get("modified_utc", doc["creation_utc"]),
+                customer_id=doc["customer_id"],
+                agent_id=doc["agent_id"],
+                mode=doc["mode"],
+                title=doc["title"],
+                consumption_offsets=doc["consumption_offsets"],
+                agent_states=doc["agent_states"],
+                metadata=doc.get("metadata", {}),
+                labels=doc.get("labels", []),
+            )
+
         return await DocumentMigrationHelper[_SessionDocument](
             self,
             {
@@ -786,6 +809,7 @@ class SessionDocumentStore(SessionStore):
                 "0.6.0": v0_6_0_to_v0_7_0,
                 "0.7.0": v0_7_0_to_v0_8_0,
                 "0.8.0": v0_8_0_to_v0_9_0,
+                "0.9.0": v0_9_0_to_v0_10_0,
             },
         ).migrate(doc)
 
@@ -898,6 +922,41 @@ class SessionDocumentStore(SessionStore):
                 deleted=doc["deleted"],
             )
 
+        async def v0_8_0_to_v0_9_0(doc: BaseDocument) -> BaseDocument | None:
+            doc = cast(_EventDocument, doc)
+
+            return _EventDocument(
+                id=doc["id"],
+                version=Version.String("0.9.0"),
+                creation_utc=doc["creation_utc"],
+                session_id=doc["session_id"],
+                source=doc["source"],
+                kind=doc["kind"],
+                offset=doc["offset"],
+                trace_id=doc["trace_id"],
+                data=doc["data"],
+                metadata=doc.get("metadata"),
+                deleted=doc["deleted"],
+            )
+
+        async def v0_9_0_to_v0_10_0(doc: BaseDocument) -> BaseDocument | None:
+            doc = cast(_EventDocument, doc)
+
+            return _EventDocument(
+                id=doc["id"],
+                version=Version.String("0.10.0"),
+                creation_utc=doc["creation_utc"],
+                modified_utc=doc.get("modified_utc", doc["creation_utc"]),
+                session_id=doc["session_id"],
+                source=doc["source"],
+                kind=doc["kind"],
+                offset=doc["offset"],
+                trace_id=doc["trace_id"],
+                data=doc["data"],
+                metadata=doc.get("metadata"),
+                deleted=doc["deleted"],
+            )
+
         return await DocumentMigrationHelper[_EventDocument](
             self,
             {
@@ -908,6 +967,8 @@ class SessionDocumentStore(SessionStore):
                 "0.5.0": v0_5_0_to_v0_6_0,
                 "0.6.0": v0_6_0_to_v0_7_0,
                 "0.7.0": v0_7_0_to_v0_8_0,
+                "0.8.0": v0_8_0_to_v0_9_0,
+                "0.9.0": v0_9_0_to_v0_10_0,
             },
         ).migrate(doc)
 
@@ -941,6 +1002,12 @@ class SessionDocumentStore(SessionStore):
                     ),
                     CollectionIndex(
                         fields=(
+                            ("modified_utc", SortDirection.ASC),
+                            ("id", SortDirection.ASC),
+                        )
+                    ),
+                    CollectionIndex(
+                        fields=(
                             ("agent_id", SortDirection.ASC),
                             ("creation_utc", SortDirection.ASC),
                             ("id", SortDirection.ASC),
@@ -962,6 +1029,12 @@ class SessionDocumentStore(SessionStore):
                         fields=(
                             ("session_id", SortDirection.ASC),
                             ("offset", SortDirection.ASC),
+                        )
+                    ),
+                    CollectionIndex(
+                        fields=(
+                            ("modified_utc", SortDirection.ASC),
+                            ("session_id", SortDirection.ASC),
                         )
                     ),
                     CollectionIndex(
@@ -1019,6 +1092,7 @@ class SessionDocumentStore(SessionStore):
             id=ObjectId(session.id),
             version=self.VERSION.to_string(),
             creation_utc=session.creation_utc.isoformat(),
+            modified_utc=session.modified_utc.isoformat(),
             customer_id=session.customer_id,
             agent_id=session.agent_id,
             mode=session.mode,
@@ -1043,6 +1117,7 @@ class SessionDocumentStore(SessionStore):
         return Session(
             id=SessionId(session_document["id"]),
             creation_utc=datetime.fromisoformat(session_document["creation_utc"]),
+            modified_utc=datetime.fromisoformat(session_document["modified_utc"]),
             customer_id=session_document["customer_id"],
             agent_id=session_document["agent_id"],
             mode=session_document["mode"],
@@ -1069,6 +1144,7 @@ class SessionDocumentStore(SessionStore):
             id=ObjectId(event.id),
             version=self.VERSION.to_string(),
             creation_utc=event.creation_utc.isoformat(),
+            modified_utc=event.modified_utc.isoformat(),
             session_id=session_id,
             source=event.source.value,
             kind=event.kind.value,
@@ -1086,6 +1162,7 @@ class SessionDocumentStore(SessionStore):
         return Event(
             id=EventId(event_document["id"]),
             creation_utc=datetime.fromisoformat(event_document["creation_utc"]),
+            modified_utc=datetime.fromisoformat(event_document["modified_utc"]),
             source=EventSource(event_document["source"]),
             kind=EventKind(event_document["kind"]),
             offset=event_document["offset"],
@@ -1114,6 +1191,7 @@ class SessionDocumentStore(SessionStore):
             session = Session(
                 id=SessionId(generate_id()),
                 creation_utc=creation_utc,
+                modified_utc=creation_utc,
                 customer_id=customer_id,
                 agent_id=agent_id,
                 mode=mode or "auto",
@@ -1175,7 +1253,10 @@ class SessionDocumentStore(SessionStore):
 
             result = await self._session_collection.update_one(
                 filters={"id": {"$eq": session_id}},
-                params=self._serialize_session_update_params(params),
+                params={
+                    **self._serialize_session_update_params(params),
+                    "modified_utc": datetime.now(timezone.utc).isoformat(),
+                },
             )
 
         assert result.updated_document
@@ -1191,12 +1272,111 @@ class SessionDocumentStore(SessionStore):
         cursor: Cursor | None = None,
         sort_direction: SortDirection | None = None,
         labels: Optional[Set[str]] = None,
+        min_modified_utc: datetime | None = None,
     ) -> SessionListing:
         async with self._lock.reader_lock:
             filters = {
                 **({"agent_id": {"$eq": agent_id}} if agent_id else {}),
                 **({"customer_id": {"$eq": customer_id}} if customer_id else {}),
             }
+
+            if min_modified_utc:
+                min_modified_utc_str = min_modified_utc.isoformat()
+
+                event_result = await self._event_collection.find(
+                    filters={"modified_utc": {"$gte": min_modified_utc_str}},
+                )
+
+                event_session_ids = {d["session_id"] for d in event_result.items}
+                latest_event_modified_utc_by_session_id: dict[SessionId, datetime] = {}
+
+                for event_document in event_result.items:
+                    event_modified_utc = datetime.fromisoformat(event_document["modified_utc"])
+                    session_id = event_document["session_id"]
+                    latest_event_modified_utc_by_session_id[session_id] = max(
+                        latest_event_modified_utc_by_session_id.get(session_id, event_modified_utc),
+                        event_modified_utc,
+                    )
+
+                modified_filters: list[Where] = [
+                    {"modified_utc": {"$gte": min_modified_utc_str}},
+                ]
+                if event_session_ids:
+                    modified_filters.append(
+                        {
+                            "id": {
+                                "$in": [ObjectId(session_id) for session_id in event_session_ids],
+                            }
+                        }
+                    )
+
+                session_filters: Where = (
+                    cast(Where, {"$and": [filters, {"$or": modified_filters}]})
+                    if filters
+                    else cast(Where, {"$or": modified_filters})
+                )
+
+                result = await self._session_collection.find(
+                    filters=session_filters,
+                    sort_direction=sort_direction,
+                )
+
+                matching_session_documents = list(result.items)
+
+                if labels:
+                    matching_session_documents = [
+                        d
+                        for d in matching_session_documents
+                        if labels.issubset(set(d.get("labels", [])))
+                    ]
+
+                sessions = []
+                for session_document in matching_session_documents:
+                    session = self._deserialize_session(session_document)
+                    latest_event_modified_utc = latest_event_modified_utc_by_session_id.get(
+                        session.id,
+                    )
+                    if latest_event_modified_utc:
+                        session = replace(
+                            session,
+                            modified_utc=max(session.modified_utc, latest_event_modified_utc),
+                        )
+                    sessions.append(session)
+
+                if cursor:
+                    if sort_direction == SortDirection.DESC:
+                        sessions = [
+                            s
+                            for s in sessions
+                            if (s.creation_utc.isoformat(), str(s.id))
+                            < (cursor.creation_utc, str(cursor.id))
+                        ]
+                    else:
+                        sessions = [
+                            s
+                            for s in sessions
+                            if (s.creation_utc.isoformat(), str(s.id))
+                            > (cursor.creation_utc, str(cursor.id))
+                        ]
+
+                total_count = len(sessions)
+                paginated_sessions = sessions[:limit] if limit else sessions
+                has_more = bool(limit and len(sessions) > limit)
+                next_cursor = (
+                    Cursor(
+                        creation_utc=paginated_sessions[-1].creation_utc.isoformat(),
+                        id=ObjectId(paginated_sessions[-1].id),
+                    )
+                    if has_more and paginated_sessions
+                    else None
+                )
+
+                return SessionListing(
+                    items=paginated_sessions,
+                    total_count=total_count,
+                    has_more=has_more,
+                    next_cursor=next_cursor,
+                )
 
             result = await self._session_collection.find(
                 filters=cast(Where, filters),
@@ -1241,6 +1421,7 @@ class SessionDocumentStore(SessionStore):
                 filters={"id": {"$eq": session_id}},
                 params={
                     "metadata": updated_metadata,
+                    "modified_utc": datetime.now(timezone.utc).isoformat(),
                 },
             )
 
@@ -1266,6 +1447,7 @@ class SessionDocumentStore(SessionStore):
                 filters={"id": {"$eq": session_id}},
                 params={
                     "metadata": updated_metadata,
+                    "modified_utc": datetime.now(timezone.utc).isoformat(),
                 },
             )
 
@@ -1290,7 +1472,10 @@ class SessionDocumentStore(SessionStore):
 
             result = await self._session_collection.update_one(
                 filters={"id": {"$eq": session_id}},
-                params={"labels": updated_labels},
+                params={
+                    "labels": updated_labels,
+                    "modified_utc": datetime.now(timezone.utc).isoformat(),
+                },
             )
 
         assert result.updated_document
@@ -1314,7 +1499,10 @@ class SessionDocumentStore(SessionStore):
 
             result = await self._session_collection.update_one(
                 filters={"id": {"$eq": session_id}},
-                params={"labels": updated_labels},
+                params={
+                    "labels": updated_labels,
+                    "modified_utc": datetime.now(timezone.utc).isoformat(),
+                },
             )
 
         assert result.updated_document
@@ -1349,6 +1537,7 @@ class SessionDocumentStore(SessionStore):
                 kind=kind,
                 offset=offset,
                 creation_utc=creation_utc,
+                modified_utc=creation_utc,
                 trace_id=trace_id,
                 data=data,
                 metadata=metadata,
@@ -1386,7 +1575,10 @@ class SessionDocumentStore(SessionStore):
         async with self._lock.writer_lock:
             result = await self._event_collection.update_one(
                 filters={"id": {"$eq": event_id}},
-                params={"deleted": True},
+                params={
+                    "deleted": True,
+                    "modified_utc": datetime.now(timezone.utc).isoformat(),
+                },
             )
 
         if result.matched_count == 0:
@@ -1458,6 +1650,8 @@ class SessionDocumentStore(SessionStore):
 
             if not update_params:
                 return self._deserialize_event(event_document)
+
+            update_params["modified_utc"] = datetime.now(timezone.utc).isoformat()
 
             result = await self._event_collection.update_one(
                 filters={
@@ -1685,6 +1879,7 @@ class CompositeSessionStore(SessionStore):
         cursor: Cursor | None = None,
         sort_direction: SortDirection | None = None,
         labels: Optional[Set[str]] = None,
+        min_modified_utc: datetime | None = None,
     ) -> SessionListing:
         results = await safe_gather(
             *[
@@ -1695,6 +1890,7 @@ class CompositeSessionStore(SessionStore):
                     cursor=cursor,
                     sort_direction=sort_direction,
                     labels=labels,
+                    min_modified_utc=min_modified_utc,
                 )
                 for store in self._all_stores
             ]

--- a/src/parlant/core/sessions.py
+++ b/src/parlant/core/sessions.py
@@ -1343,19 +1343,24 @@ class SessionDocumentStore(SessionStore):
                         )
                     sessions.append(session)
 
+                sessions.sort(
+                    key=lambda s: (s.modified_utc.isoformat(), str(s.id)),
+                    reverse=sort_direction == SortDirection.DESC,
+                )
+
                 if cursor:
                     if sort_direction == SortDirection.DESC:
                         sessions = [
                             s
                             for s in sessions
-                            if (s.creation_utc.isoformat(), str(s.id))
+                            if (s.modified_utc.isoformat(), str(s.id))
                             < (cursor.creation_utc, str(cursor.id))
                         ]
                     else:
                         sessions = [
                             s
                             for s in sessions
-                            if (s.creation_utc.isoformat(), str(s.id))
+                            if (s.modified_utc.isoformat(), str(s.id))
                             > (cursor.creation_utc, str(cursor.id))
                         ]
 
@@ -1364,7 +1369,7 @@ class SessionDocumentStore(SessionStore):
                 has_more = bool(limit and len(sessions) > limit)
                 next_cursor = (
                     Cursor(
-                        creation_utc=paginated_sessions[-1].creation_utc.isoformat(),
+                        creation_utc=paginated_sessions[-1].modified_utc.isoformat(),
                         id=ObjectId(paginated_sessions[-1].id),
                     )
                     if has_more and paginated_sessions

--- a/src/parlant/core/shots.py
+++ b/src/parlant/core/shots.py
@@ -34,11 +34,14 @@ class Shot:
 
     @staticmethod
     def message_event(source: EventSource, data: MessageEventData) -> Event:
+        creation_utc = datetime.now(timezone.utc)
+
         return Event(
             id=EventId(generate_id()),
             source=source,
             kind=EventKind.MESSAGE,
-            creation_utc=datetime.now(timezone.utc),  # unused in shots
+            creation_utc=creation_utc,  # unused in shots
+            modified_utc=creation_utc,  # unused in shots
             offset=0,  # unused in shots
             trace_id="<unused>",  # unused in shots
             data=cast(JSONSerializable, data),
@@ -48,11 +51,14 @@ class Shot:
 
     @staticmethod
     def tool_event(data: ToolEventData) -> Event:  # noqa: F821
+        creation_utc = datetime.now(timezone.utc)
+
         return Event(
             id=EventId(generate_id()),
             source=EventSource.SYSTEM,
             kind=EventKind.TOOL,
-            creation_utc=datetime.now(timezone.utc),  # unused in shots
+            creation_utc=creation_utc,  # unused in shots
+            modified_utc=creation_utc,  # unused in shots
             offset=0,  # unused in shots
             trace_id="<unused>",  # unused in shots
             data=cast(JSONSerializable, data),

--- a/src/parlant/core/tags.py
+++ b/src/parlant/core/tags.py
@@ -44,7 +44,7 @@ _BUILT_IN_TAG_CREATION_TIME = datetime(2025, 1, 1, tzinfo=timezone.utc)
 class Tag:
     id: TagId
     creation_utc: datetime
-    last_modified_utc: datetime
+    modified_utc: datetime
     name: str
 
     @staticmethod
@@ -53,7 +53,7 @@ class Tag:
             id=TagId("__preamble__"),
             name="__preamble__",
             creation_utc=_BUILT_IN_TAG_CREATION_TIME,
-            last_modified_utc=_BUILT_IN_TAG_CREATION_TIME,
+            modified_utc=_BUILT_IN_TAG_CREATION_TIME,
         )
 
     @staticmethod
@@ -62,7 +62,7 @@ class Tag:
             id=TagId(f"agent:{agent_id}"),
             name=f"agent:{agent_id}",
             creation_utc=_BUILT_IN_TAG_CREATION_TIME,
-            last_modified_utc=_BUILT_IN_TAG_CREATION_TIME,
+            modified_utc=_BUILT_IN_TAG_CREATION_TIME,
         )
 
     @staticmethod
@@ -78,7 +78,7 @@ class Tag:
             id=TagId(f"journey:{journey_id}"),
             name=f"journey:{journey_id}",
             creation_utc=_BUILT_IN_TAG_CREATION_TIME,
-            last_modified_utc=_BUILT_IN_TAG_CREATION_TIME,
+            modified_utc=_BUILT_IN_TAG_CREATION_TIME,
         )
 
     @staticmethod
@@ -94,7 +94,7 @@ class Tag:
             id=TagId(f"journey_node:{journey_node_id}"),
             name=f"journey_node:{journey_node_id}",
             creation_utc=_BUILT_IN_TAG_CREATION_TIME,
-            last_modified_utc=_BUILT_IN_TAG_CREATION_TIME,
+            modified_utc=_BUILT_IN_TAG_CREATION_TIME,
         )
 
     @staticmethod
@@ -110,7 +110,7 @@ class Tag:
             id=TagId(f"guideline:{guideline_id}"),
             name=f"guideline:{guideline_id}",
             creation_utc=_BUILT_IN_TAG_CREATION_TIME,
-            last_modified_utc=_BUILT_IN_TAG_CREATION_TIME,
+            modified_utc=_BUILT_IN_TAG_CREATION_TIME,
         )
 
     @staticmethod
@@ -242,7 +242,7 @@ class TagDocumentStore(TagStore):
             id=ObjectId(tag.id),
             version=self.VERSION.to_string(),
             creation_utc=tag.creation_utc.isoformat(),
-            last_modified=tag.last_modified_utc.isoformat(),
+            last_modified=tag.modified_utc.isoformat(),
             name=tag.name,
         )
 
@@ -250,7 +250,7 @@ class TagDocumentStore(TagStore):
         return Tag(
             id=TagId(document["id"]),
             creation_utc=datetime.fromisoformat(document["creation_utc"]),
-            last_modified_utc=datetime.fromisoformat(document["last_modified"]),
+            modified_utc=datetime.fromisoformat(document["last_modified"]),
             name=document["name"],
         )
 
@@ -279,7 +279,7 @@ class TagDocumentStore(TagStore):
             tag = Tag(
                 id=tag_id,
                 creation_utc=creation_utc,
-                last_modified_utc=creation_utc,
+                modified_utc=creation_utc,
                 name=name,
             )
             await self._collection.insert_one(self._serialize(tag))

--- a/src/parlant/core/tunnels.py
+++ b/src/parlant/core/tunnels.py
@@ -1,4 +1,5 @@
 from abc import ABC, abstractmethod
+from datetime import datetime
 from enum import Enum
 from typing import Any, Awaitable, Callable, Mapping
 
@@ -296,6 +297,11 @@ class TunnelRequestDispatcher:
         cursor = decode_cursor(params["cursor"]) if params.get("cursor") else None
         sort_direction = _parse_sort_direction(params.get("sort_direction"))
         labels = set(params["labels"]) if params.get("labels") else None
+        min_modified_utc = (
+            datetime.fromisoformat(params["min_modified_utc"])
+            if params.get("min_modified_utc")
+            else None
+        )
 
         result = await self._session_module.find(
             agent_id=AgentId(params["agent_id"]) if params.get("agent_id") else None,
@@ -304,6 +310,7 @@ class TunnelRequestDispatcher:
             cursor=cursor,
             sort_direction=sort_direction,
             labels=labels,
+            min_modified_utc=min_modified_utc,
         )
         return {
             "sessions": [self._serialize_session(s) for s in result.items],
@@ -389,6 +396,7 @@ class TunnelRequestDispatcher:
         return {
             "session_id": session.id,
             "creation_utc": session.creation_utc.isoformat(),
+            "modified_utc": session.modified_utc.isoformat(),
             "customer_id": session.customer_id,
             "agent_id": session.agent_id,
             "mode": session.mode,
@@ -405,8 +413,11 @@ class TunnelRequestDispatcher:
             "source": TunnelRequestDispatcher._serialize_scalar(event.source),
             "kind": TunnelRequestDispatcher._serialize_scalar(event.kind),
             "creation_utc": event.creation_utc.isoformat(),
+            "modified_utc": event.modified_utc.isoformat(),
+            "trace_id": event.trace_id,
             "data": event.data,
             "metadata": dict(event.metadata) if event.metadata else {},
+            "deleted": event.deleted,
         }
 
     @staticmethod

--- a/tests/adapters/db/test_mongodb.py
+++ b/tests/adapters/db/test_mongodb.py
@@ -1242,6 +1242,7 @@ async def test_that_session_store_creates_indexes_for_session_hot_paths(
             assert (("creation_utc", 1),) in session_index_keys
             assert (("id", 1),) in session_index_keys
             assert (("creation_utc", 1), ("id", 1)) in session_index_keys
+            assert (("modified_utc", 1), ("id", 1)) in session_index_keys
             assert (
                 ("agent_id", 1),
                 ("creation_utc", 1),
@@ -1256,6 +1257,7 @@ async def test_that_session_store_creates_indexes_for_session_hot_paths(
             assert (("creation_utc", 1),) in event_index_keys
             assert (("id", 1),) in event_index_keys
             assert (("session_id", 1), ("offset", 1)) in event_index_keys
+            assert (("modified_utc", 1), ("session_id", 1)) in event_index_keys
             assert (("session_id", 1), ("deleted", 1), ("offset", 1)) in event_index_keys
 
 

--- a/tests/adapters/tunnels/test_dispatcher.py
+++ b/tests/adapters/tunnels/test_dispatcher.py
@@ -819,6 +819,28 @@ async def test_that_dispatcher_forwards_labels_filter_to_sessions_list() -> None
     assert session_module.find.await_args.kwargs["labels"] == {"premium", "support"}
 
 
+async def test_that_dispatcher_forwards_min_modified_utc_to_sessions_list() -> None:
+    session_module = AsyncMock()
+    session_module.find = AsyncMock(
+        return_value=MagicMock(items=[], total_count=0, has_more=False, next_cursor=None),
+    )
+
+    dispatcher = TunnelRequestDispatcher(session_module=session_module)
+    response = await dispatcher.dispatch(
+        TunnelRequest(
+            request_id="req-min-modified",
+            method="sessions.list",
+            params={"min_modified_utc": "2026-01-02T03:04:05+00:00"},
+        ),
+    )
+
+    assert response.error is None
+    session_module.find.assert_awaited_once()
+    assert session_module.find.await_args.kwargs["min_modified_utc"] == datetime(
+        2026, 1, 2, 3, 4, 5, tzinfo=timezone.utc
+    )
+
+
 async def test_that_dispatcher_returns_encoded_next_cursor_in_sessions_list() -> None:
     real_cursor = Cursor(creation_utc="2026-01-02T00:00:00+00:00", id=ObjectId("sess-42"))
     session_module = AsyncMock()

--- a/tests/api/test_canned_responses.py
+++ b/tests/api/test_canned_responses.py
@@ -49,7 +49,7 @@ async def test_that_a_canned_response_can_be_created(
 
     assert "id" in canned_response
     assert "creation_utc" in canned_response
-    assert "last_modified_utc" in canned_response
+    assert "modified_utc" in canned_response
 
 
 async def test_that_a_canned_response_can_be_created_with_tags(
@@ -237,7 +237,7 @@ async def test_that_a_canned_response_can_be_updated(
     updated_canned_response = response.json()
     assert updated_canned_response["value"] == update_payload["value"]
     assert updated_canned_response["fields"] == update_payload["fields"]
-    assert updated_canned_response["last_modified_utc"] != canned_response.creation_utc.isoformat()
+    assert updated_canned_response["modified_utc"] != canned_response.creation_utc.isoformat()
 
 
 async def test_that_a_canned_response_can_be_deleted(

--- a/tests/api/test_context_variables.py
+++ b/tests/api/test_context_variables.py
@@ -63,7 +63,7 @@ async def test_that_a_context_variable_can_be_created(
     assert context_variable["description"] == "test of context variable"
     assert context_variable["freshness_rules"] == freshness_rules
     assert context_variable["tags"] == []
-    assert "last_modified_utc" in context_variable
+    assert "modified_utc" in context_variable
 
 
 async def test_that_a_context_variable_can_be_created_with_tags(
@@ -250,7 +250,7 @@ async def test_that_a_context_variable_can_be_updated_with_new_values(
     assert data["description"] == updated_description
     assert data["freshness_rules"] == freshness_rules
     assert set(data["tags"]) == set(tags_to_add)
-    assert data["last_modified_utc"] != variable.creation_utc.isoformat()
+    assert data["modified_utc"] != variable.creation_utc.isoformat()
 
 
 async def test_that_tags_can_be_removed_from_a_context_variable(

--- a/tests/api/test_glossary.py
+++ b/tests/api/test_glossary.py
@@ -44,7 +44,7 @@ async def test_that_a_term_can_be_created(
     assert data["description"] == description
     assert data["synonyms"] == synonyms
     assert data["tags"] == []
-    assert "last_modified_utc" in data
+    assert "modified_utc" in data
 
 
 async def test_that_a_term_can_be_created_with_tags(
@@ -243,7 +243,7 @@ async def test_that_a_term_can_be_updated_with_new_values(
     assert data["description"] == updated_description
     assert data["synonyms"] == updated_synonyms
     assert set(data["tags"]) == set(tags_to_add)
-    assert data["last_modified_utc"] != term["last_modified_utc"]
+    assert data["modified_utc"] != term["modified_utc"]
 
 
 async def test_that_tags_can_be_removed_from_a_term(

--- a/tests/api/test_guidelines.py
+++ b/tests/api/test_guidelines.py
@@ -85,7 +85,7 @@ async def test_that_a_guideline_can_be_created(
     assert guideline["enabled"] is True
     assert guideline["tags"] == []
     assert guideline["metadata"] == {"key1": "value1", "key2": "value2"}
-    assert "last_modified_utc" in guideline
+    assert "modified_utc" in guideline
 
 
 async def test_that_a_guideline_can_be_created_with_a_title(
@@ -364,7 +364,7 @@ async def test_that_a_guideline_condition_can_be_updated(
     assert updated_guideline["id"] == guideline.id
     assert updated_guideline["condition"] == "the customer inquires about weather"
     assert updated_guideline["action"] == guideline.content.action
-    assert updated_guideline["last_modified_utc"] != guideline.creation_utc.isoformat()
+    assert updated_guideline["modified_utc"] != guideline.creation_utc.isoformat()
 
 
 async def test_that_a_guideline_action_can_be_updated(

--- a/tests/api/test_journeys.py
+++ b/tests/api/test_journeys.py
@@ -45,7 +45,7 @@ async def test_that_a_journey_can_be_created(
     assert journey["title"] == payload["title"]
     assert journey["description"] == payload["description"]
     assert journey["tags"] == []
-    assert "last_modified_utc" in journey
+    assert "modified_utc" in journey
 
     assert len(journey["triggers"]) == 1
     guideline = await guideline_store.read_guideline(guideline_id=journey["triggers"][0])
@@ -279,7 +279,7 @@ async def test_that_a_journey_can_be_updated(
 
     assert updated_journey["title"] == expected_title
     assert updated_journey["description"] == expected_description
-    assert updated_journey["last_modified_utc"] != journey["last_modified_utc"]
+    assert updated_journey["modified_utc"] != journey["modified_utc"]
 
 
 async def test_that_tags_can_be_added_to_a_journey(

--- a/tests/api/test_sessions.py
+++ b/tests/api/test_sessions.py
@@ -1719,6 +1719,169 @@ async def test_that_list_sessions_can_be_paginated_with_sort_directions(
     assert descending_data["items"][-1]["id"] == ascending_data["items"][0]["id"]
 
 
+async def test_that_list_sessions_with_min_modified_utc_paginates_by_effective_modified_utc(
+    async_client: httpx.AsyncClient,
+    container: Container,
+) -> None:
+    agent = await create_agent(container, "test-agent")
+    first_created_session = await create_session(
+        container,
+        agent_id=agent.id,
+        title="first-created-session",
+    )
+    await asyncio.sleep(0.015)
+    second_created_session = await create_session(
+        container,
+        agent_id=agent.id,
+        title="second-created-session",
+    )
+
+    checkpoint = datetime.now(timezone.utc)
+    await asyncio.sleep(0.015)
+    (
+        await async_client.post(
+            f"/sessions/{second_created_session.id}/events",
+            json={
+                "kind": "message",
+                "source": "customer",
+                "message": "older modification",
+            },
+        )
+    ).raise_for_status()
+    await asyncio.sleep(0.015)
+    (
+        await async_client.post(
+            f"/sessions/{first_created_session.id}/events",
+            json={
+                "kind": "message",
+                "source": "customer",
+                "message": "newer modification",
+            },
+        )
+    ).raise_for_status()
+
+    first_page = (
+        (
+            await async_client.get(
+                "/sessions",
+                params={
+                    "min_modified_utc": checkpoint.isoformat(),
+                    "limit": 1,
+                },
+            )
+        )
+        .raise_for_status()
+        .json()
+    )
+
+    assert first_page["items"][0]["id"] == second_created_session.id
+    assert first_page["has_more"] is True
+    assert first_page["next_cursor"] is not None
+
+    second_page = (
+        (
+            await async_client.get(
+                "/sessions",
+                params={
+                    "min_modified_utc": checkpoint.isoformat(),
+                    "limit": 1,
+                    "cursor": first_page["next_cursor"],
+                },
+            )
+        )
+        .raise_for_status()
+        .json()
+    )
+
+    assert second_page["items"][0]["id"] == first_created_session.id
+    assert second_page["has_more"] is False
+
+
+async def test_that_updated_event_makes_session_visible_to_min_modified_utc_listing(
+    async_client: httpx.AsyncClient,
+    container: Container,
+) -> None:
+    agent = await create_agent(container, "test-agent")
+    session = await create_session(container, agent_id=agent.id, title="session-with-event")
+    event = (
+        (
+            await async_client.post(
+                f"/sessions/{session.id}/events",
+                json={
+                    "kind": "message",
+                    "source": "customer",
+                    "message": "before checkpoint",
+                },
+            )
+        )
+        .raise_for_status()
+        .json()
+    )
+
+    checkpoint = datetime.now(timezone.utc)
+    await asyncio.sleep(0.015)
+    (
+        await async_client.patch(
+            f"/sessions/{session.id}/events/{event['id']}",
+            json={"metadata": {"set": {"reviewed": True}}},
+        )
+    ).raise_for_status()
+
+    data = (
+        (
+            await async_client.get(
+                "/sessions",
+                params={"min_modified_utc": checkpoint.isoformat()},
+            )
+        )
+        .raise_for_status()
+        .json()
+    )
+
+    assert [s["id"] for s in data] == [session.id]
+    assert dateutil.parser.isoparse(data[0]["modified_utc"]) >= checkpoint
+
+
+async def test_that_deleted_event_makes_session_visible_to_min_modified_utc_listing(
+    async_client: httpx.AsyncClient,
+    container: Container,
+) -> None:
+    agent = await create_agent(container, "test-agent")
+    session = await create_session(container, agent_id=agent.id, title="session-with-event")
+    (
+        await async_client.post(
+            f"/sessions/{session.id}/events",
+            json={
+                "kind": "message",
+                "source": "customer",
+                "message": "before checkpoint",
+            },
+        )
+    ).raise_for_status()
+
+    checkpoint = datetime.now(timezone.utc)
+    await asyncio.sleep(0.015)
+    delete_response = await async_client.delete(
+        f"/sessions/{session.id}/events",
+        params={"min_offset": 0},
+    )
+    assert delete_response.status_code == status.HTTP_204_NO_CONTENT
+
+    data = (
+        (
+            await async_client.get(
+                "/sessions",
+                params={"min_modified_utc": checkpoint.isoformat()},
+            )
+        )
+        .raise_for_status()
+        .json()
+    )
+
+    assert [s["id"] for s in data] == [session.id]
+    assert dateutil.parser.isoparse(data[0]["modified_utc"]) >= checkpoint
+
+
 async def test_that_list_sessions_can_be_paginated_with_filters(
     async_client: httpx.AsyncClient,
     container: Container,

--- a/tests/core/common/utils.py
+++ b/tests/core/common/utils.py
@@ -58,6 +58,8 @@ def create_event_message(
         },
     }
 
+    creation_utc = datetime.now(timezone.utc)
+
     event = Event(
         id=EventId(generate_id()),
         source=source,
@@ -66,7 +68,8 @@ def create_event_message(
         trace_id="<main>",
         data=cast(JSONSerializable, message_data),
         metadata=metadata,
-        creation_utc=datetime.now(timezone.utc),
+        creation_utc=creation_utc,
+        modified_utc=creation_utc,
         deleted=False,
     )
 

--- a/tests/core/stable/engines/alpha/test_disambiguation_batch.py
+++ b/tests/core/stable/engines/alpha/test_disambiguation_batch.py
@@ -181,7 +181,7 @@ def create_term(
     return Term(
         id=TermId("-"),
         creation_utc=datetime.now(timezone.utc),
-        last_modified_utc=datetime.now(timezone.utc),
+        modified_utc=datetime.now(timezone.utc),
         name=name,
         description=description,
         synonyms=synonyms,
@@ -197,7 +197,7 @@ def create_context_variable(
     return ContextVariable(
         id=ContextVariableId("-"),
         creation_utc=datetime.now(timezone.utc),
-        last_modified_utc=datetime.now(timezone.utc),
+        modified_utc=datetime.now(timezone.utc),
         name=name,
         description="",
         tool_id=None,
@@ -205,7 +205,7 @@ def create_context_variable(
         tags=tags,
     ), ContextVariableValue(
         ContextVariableValueId("-"),
-        last_modified_utc=datetime.now(timezone.utc),
+        modified_utc=datetime.now(timezone.utc),
         data=data,
     )
 
@@ -240,7 +240,7 @@ async def create_guideline(
     guideline = Guideline(
         id=GuidelineId(generate_id()),
         creation_utc=datetime.now(timezone.utc),
-        last_modified_utc=datetime.now(timezone.utc),
+        modified_utc=datetime.now(timezone.utc),
         content=GuidelineContent(
             condition=condition,
             action=action,

--- a/tests/core/stable/engines/alpha/test_generic_response_analysis.py
+++ b/tests/core/stable/engines/alpha/test_generic_response_analysis.py
@@ -138,7 +138,7 @@ def create_guideline(
     guideline = Guideline(
         id=GuidelineId(generate_id()),
         creation_utc=datetime.now(timezone.utc),
-        last_modified_utc=datetime.now(timezone.utc),
+        modified_utc=datetime.now(timezone.utc),
         content=GuidelineContent(
             condition=condition,
             action=action,
@@ -164,7 +164,7 @@ def create_guideline_with_tools(
     guideline = Guideline(
         id=GuidelineId(generate_id()),
         creation_utc=datetime.now(timezone.utc),
-        last_modified_utc=datetime.now(timezone.utc),
+        modified_utc=datetime.now(timezone.utc),
         content=GuidelineContent(
             condition=condition,
             action=action,

--- a/tests/core/stable/engines/alpha/test_guideline_actionable_batch.py
+++ b/tests/core/stable/engines/alpha/test_guideline_actionable_batch.py
@@ -152,7 +152,7 @@ def create_guideline(
     guideline = Guideline(
         id=GuidelineId(generate_id()),
         creation_utc=datetime.now(timezone.utc),
-        last_modified_utc=datetime.now(timezone.utc),
+        modified_utc=datetime.now(timezone.utc),
         content=GuidelineContent(
             condition=condition,
             action=action,

--- a/tests/core/stable/engines/alpha/test_guideline_low_criticality_batch.py
+++ b/tests/core/stable/engines/alpha/test_guideline_low_criticality_batch.py
@@ -182,7 +182,7 @@ def create_guideline(
     guideline = Guideline(
         id=GuidelineId(generate_id()),
         creation_utc=datetime.now(timezone.utc),
-        last_modified_utc=datetime.now(timezone.utc),
+        modified_utc=datetime.now(timezone.utc),
         content=GuidelineContent(
             condition=condition,
             action=action,

--- a/tests/core/stable/engines/alpha/test_guideline_matcher.py
+++ b/tests/core/stable/engines/alpha/test_guideline_matcher.py
@@ -453,7 +453,7 @@ async def create_guideline(
     guideline = Guideline(
         id=GuidelineId(generate_id()),
         creation_utc=datetime.now(timezone.utc),
-        last_modified_utc=datetime.now(timezone.utc),
+        modified_utc=datetime.now(timezone.utc),
         content=GuidelineContent(
             condition=condition,
             action=action,
@@ -475,7 +475,7 @@ async def create_disambiguation_guideline(
     guideline = Guideline(
         id=GuidelineId(generate_id()),
         creation_utc=datetime.now(timezone.utc),
-        last_modified_utc=datetime.now(timezone.utc),
+        modified_utc=datetime.now(timezone.utc),
         content=GuidelineContent(
             condition=condition,
             action=None,
@@ -510,7 +510,7 @@ def create_term(
     return Term(
         id=TermId("-"),
         creation_utc=datetime.now(timezone.utc),
-        last_modified_utc=datetime.now(timezone.utc),
+        modified_utc=datetime.now(timezone.utc),
         name=name,
         description=description,
         synonyms=synonyms,
@@ -526,7 +526,7 @@ def create_context_variable(
     return ContextVariable(
         id=ContextVariableId("-"),
         creation_utc=datetime.now(timezone.utc),
-        last_modified_utc=datetime.now(timezone.utc),
+        modified_utc=datetime.now(timezone.utc),
         name=name,
         description="",
         tool_id=None,
@@ -534,7 +534,7 @@ def create_context_variable(
         tags=tags,
     ), ContextVariableValue(
         ContextVariableValueId("-"),
-        last_modified_utc=datetime.now(timezone.utc),
+        modified_utc=datetime.now(timezone.utc),
         data=data,
     )
 
@@ -869,7 +869,7 @@ async def test_that_guidelines_are_matched_based_on_agent_description(
     agent = Agent(
         id=AgentId("123"),
         creation_utc=datetime.now(timezone.utc),
-        last_modified_utc=datetime.now(timezone.utc),
+        modified_utc=datetime.now(timezone.utc),
         name="skateboard-sales-agent",
         description="You are an agent working for a skateboarding manufacturer. You help customers by discussing and recommending our products."
         "Your role is only to consult customers, and not to actually sell anything, as we sell our products in-store.",

--- a/tests/core/stable/engines/alpha/test_journey_node_selection.py
+++ b/tests/core/stable/engines/alpha/test_journey_node_selection.py
@@ -969,7 +969,7 @@ def create_term(
     return Term(
         id=TermId("-"),
         creation_utc=datetime.now(timezone.utc),
-        last_modified_utc=datetime.now(timezone.utc),
+        modified_utc=datetime.now(timezone.utc),
         name=name,
         description=description,
         synonyms=synonyms,
@@ -985,7 +985,7 @@ def create_context_variable(
     return ContextVariable(
         id=ContextVariableId("-"),
         creation_utc=datetime.now(timezone.utc),
-        last_modified_utc=datetime.now(timezone.utc),
+        modified_utc=datetime.now(timezone.utc),
         name=name,
         description="",
         tool_id=None,
@@ -993,7 +993,7 @@ def create_context_variable(
         tags=tags,
     ), ContextVariableValue(
         ContextVariableValueId("-"),
-        last_modified_utc=datetime.now(timezone.utc),
+        modified_utc=datetime.now(timezone.utc),
         data=data,
     )
 
@@ -1020,7 +1020,7 @@ async def create_journey(
     root_guideline = Guideline(
         id=GuidelineId("root"),
         creation_utc=datetime.now(timezone.utc),
-        last_modified_utc=datetime.now(timezone.utc),
+        modified_utc=datetime.now(timezone.utc),
         content=GuidelineContent(condition="", action=None),
         criticality=Criticality.MEDIUM,
         enabled=True,
@@ -1038,7 +1038,7 @@ async def create_journey(
         Guideline(
             id=GuidelineId(node.id),
             creation_utc=datetime.now(timezone.utc),
-            last_modified_utc=datetime.now(timezone.utc),
+            modified_utc=datetime.now(timezone.utc),
             content=GuidelineContent(
                 condition=node.condition or "",
                 action=node.action,
@@ -1077,7 +1077,7 @@ async def create_journey(
         id=journey_id,
         root_id=JourneyNodeId(root_guideline.id),
         creation_utc=datetime.now(timezone.utc),
-        last_modified_utc=datetime.now(timezone.utc),
+        modified_utc=datetime.now(timezone.utc),
         description=description,
         triggers=trigger_ids,
         title=title,

--- a/tests/core/stable/engines/alpha/test_previously_applied_actionable_batch.py
+++ b/tests/core/stable/engines/alpha/test_previously_applied_actionable_batch.py
@@ -130,7 +130,7 @@ def create_guideline(
     guideline = Guideline(
         id=GuidelineId(generate_id()),
         creation_utc=datetime.now(timezone.utc),
-        last_modified_utc=datetime.now(timezone.utc),
+        modified_utc=datetime.now(timezone.utc),
         content=GuidelineContent(
             condition=condition,
             action=action,

--- a/tests/core/stable/engines/alpha/test_previously_applied_actionable_customer_dependent_batch.py
+++ b/tests/core/stable/engines/alpha/test_previously_applied_actionable_customer_dependent_batch.py
@@ -119,7 +119,7 @@ def create_guideline(
     guideline = Guideline(
         id=GuidelineId(generate_id()),
         creation_utc=datetime.now(timezone.utc),
-        last_modified_utc=datetime.now(timezone.utc),
+        modified_utc=datetime.now(timezone.utc),
         content=GuidelineContent(
             condition=condition,
             action=action,

--- a/tests/core/stable/engines/alpha/test_prompt_builder.py
+++ b/tests/core/stable/engines/alpha/test_prompt_builder.py
@@ -42,7 +42,7 @@ def _match(
     guideline = Guideline(
         id=GuidelineId(generate_id()),
         creation_utc=now,
-        last_modified_utc=now,
+        modified_utc=now,
         content=GuidelineContent(condition=condition, action=action),
         enabled=True,
         tags=[],

--- a/tests/core/stable/engines/alpha/test_relational_resolver.py
+++ b/tests/core/stable/engines/alpha/test_relational_resolver.py
@@ -6155,7 +6155,7 @@ async def test_that_resolver_does_not_crash_on_transient_tool_returned_guideline
     transient_guideline = Guideline(
         id=GuidelineId("<tool-guideline-1>"),
         creation_utc=datetime.now(timezone.utc),
-        last_modified_utc=datetime.now(timezone.utc),
+        modified_utc=datetime.now(timezone.utc),
         content=GuidelineContent(condition="x", action="y"),
         enabled=True,
         tags=[],

--- a/tests/core/stable/engines/alpha/test_tool_caller.py
+++ b/tests/core/stable/engines/alpha/test_tool_caller.py
@@ -119,7 +119,7 @@ def create_guideline_match(
     guideline = Guideline(
         id=GuidelineId(generate_id()),
         creation_utc=datetime.now(timezone.utc),
-        last_modified_utc=datetime.now(timezone.utc),
+        modified_utc=datetime.now(timezone.utc),
         content=GuidelineContent(
             condition=condition,
             action=action,

--- a/tests/core/stable/engines/compass/guideline_matching/utils.py
+++ b/tests/core/stable/engines/compass/guideline_matching/utils.py
@@ -63,7 +63,7 @@ def create_guideline(
     return Guideline(
         id=GuidelineId(generate_id()),
         creation_utc=datetime.now(timezone.utc),
-        last_modified_utc=datetime.now(timezone.utc),
+        modified_utc=datetime.now(timezone.utc),
         content=GuidelineContent(condition=condition, action=action),
         criticality=Criticality.MEDIUM,
         enabled=True,
@@ -89,7 +89,7 @@ def create_term(
     return Term(
         id=TermId("-"),
         creation_utc=datetime.now(timezone.utc),
-        last_modified_utc=datetime.now(timezone.utc),
+        modified_utc=datetime.now(timezone.utc),
         name=name,
         description=description,
         synonyms=synonyms,
@@ -105,7 +105,7 @@ def create_context_variable(
     return ContextVariable(
         id=ContextVariableId("-"),
         creation_utc=datetime.now(timezone.utc),
-        last_modified_utc=datetime.now(timezone.utc),
+        modified_utc=datetime.now(timezone.utc),
         name=name,
         description="",
         tool_id=None,
@@ -113,7 +113,7 @@ def create_context_variable(
         tags=tags,
     ), ContextVariableValue(
         ContextVariableValueId("-"),
-        last_modified_utc=datetime.now(timezone.utc),
+        modified_utc=datetime.now(timezone.utc),
         data=data,
     )
 
@@ -214,7 +214,7 @@ def create_agent(name: str = "Test Agent", description: str | None = None) -> Ag
         name=name,
         description=description,
         creation_utc=now,
-        last_modified_utc=now,
+        modified_utc=now,
         max_engine_iterations=3,
         tags=[],
         engine="compass",
@@ -235,9 +235,12 @@ def create_customer(name: str = "Test Customer") -> Customer:
 
 
 def create_session(agent: Agent, customer: Customer) -> Session:
+    creation_utc = datetime.now(timezone.utc)
+
     return Session(
         id=SessionId(generate_id()),
-        creation_utc=datetime.now(timezone.utc),
+        creation_utc=creation_utc,
+        modified_utc=creation_utc,
         customer_id=customer.id,
         agent_id=agent.id,
         mode="auto",

--- a/tests/core/stable/services/indexing/test_agent_intention_proposer.py
+++ b/tests/core/stable/services/indexing/test_agent_intention_proposer.py
@@ -185,7 +185,7 @@ def create_guideline(
     guideline = Guideline(
         id=GuidelineId(generate_id()),
         creation_utc=datetime.now(timezone.utc),
-        last_modified_utc=datetime.now(timezone.utc),
+        modified_utc=datetime.now(timezone.utc),
         content=GuidelineContent(
             condition=condition,
             action=action,

--- a/tests/core/stable/services/indexing/test_journey_reachable_nodes_evaluation.py
+++ b/tests/core/stable/services/indexing/test_journey_reachable_nodes_evaluation.py
@@ -67,7 +67,7 @@ def _make_guideline(
     return Guideline(
         id=GuidelineId(id),
         creation_utc=datetime.now(timezone.utc),
-        last_modified_utc=datetime.now(timezone.utc),
+        modified_utc=datetime.now(timezone.utc),
         content=GuidelineContent(condition=condition, action=action),
         criticality=Criticality.MEDIUM,
         enabled=True,

--- a/tests/core/stable/services/indexing/test_relative_action_step_proposer.py
+++ b/tests/core/stable/services/indexing/test_relative_action_step_proposer.py
@@ -68,7 +68,7 @@ def create_journey(
         Guideline(
             id=GuidelineId(f"c-{i}"),
             creation_utc=datetime.now(timezone.utc),
-            last_modified_utc=datetime.now(timezone.utc),
+            modified_utc=datetime.now(timezone.utc),
             content=GuidelineContent(condition=condition, action=None),
             criticality=Criticality.MEDIUM,
             enabled=False,
@@ -81,7 +81,7 @@ def create_journey(
     root_guideline = Guideline(
         id=GuidelineId("root"),
         creation_utc=datetime.now(timezone.utc),
-        last_modified_utc=datetime.now(timezone.utc),
+        modified_utc=datetime.now(timezone.utc),
         content=GuidelineContent(condition="", action=None),
         criticality=Criticality.MEDIUM,
         enabled=True,
@@ -99,7 +99,7 @@ def create_journey(
         Guideline(
             id=GuidelineId(step.id),
             creation_utc=datetime.now(timezone.utc),
-            last_modified_utc=datetime.now(timezone.utc),
+            modified_utc=datetime.now(timezone.utc),
             content=GuidelineContent(
                 condition=step.condition or "",
                 action=step.action,
@@ -130,7 +130,7 @@ def create_journey(
         id=journey_id,
         root_id=JourneyNodeId(root_guideline.id),
         creation_utc=datetime.now(timezone.utc),
-        last_modified_utc=datetime.now(timezone.utc),
+        modified_utc=datetime.now(timezone.utc),
         description="",
         triggers=[g.id for g in condition_guidelines],
         title=title,

--- a/tests/core/unstable/engines/alpha/test_agent_intention_proposer.py
+++ b/tests/core/unstable/engines/alpha/test_agent_intention_proposer.py
@@ -185,7 +185,7 @@ def create_guideline(
     guideline = Guideline(
         id=GuidelineId(generate_id()),
         creation_utc=datetime.now(timezone.utc),
-        last_modified_utc=datetime.now(timezone.utc),
+        modified_utc=datetime.now(timezone.utc),
         content=GuidelineContent(
             condition=condition,
             action=action,

--- a/tests/core/unstable/engines/alpha/test_disambiguation_batch.py
+++ b/tests/core/unstable/engines/alpha/test_disambiguation_batch.py
@@ -175,7 +175,7 @@ def create_term(
     return Term(
         id=TermId("-"),
         creation_utc=datetime.now(timezone.utc),
-        last_modified_utc=datetime.now(timezone.utc),
+        modified_utc=datetime.now(timezone.utc),
         name=name,
         description=description,
         synonyms=synonyms,
@@ -191,7 +191,7 @@ def create_context_variable(
     return ContextVariable(
         id=ContextVariableId("-"),
         creation_utc=datetime.now(timezone.utc),
-        last_modified_utc=datetime.now(timezone.utc),
+        modified_utc=datetime.now(timezone.utc),
         name=name,
         description="",
         tool_id=None,
@@ -199,7 +199,7 @@ def create_context_variable(
         tags=tags,
     ), ContextVariableValue(
         id=ContextVariableValueId("-"),
-        last_modified_utc=datetime.now(timezone.utc),
+        modified_utc=datetime.now(timezone.utc),
         data=data,
     )
 
@@ -234,7 +234,7 @@ async def create_guideline(
     guideline = Guideline(
         id=GuidelineId(generate_id()),
         creation_utc=datetime.now(timezone.utc),
-        last_modified_utc=datetime.now(timezone.utc),
+        modified_utc=datetime.now(timezone.utc),
         content=GuidelineContent(
             condition=condition,
             action=action,

--- a/tests/core/unstable/engines/alpha/test_guideline_matcher.py
+++ b/tests/core/unstable/engines/alpha/test_guideline_matcher.py
@@ -361,7 +361,7 @@ async def create_guideline(
     guideline = Guideline(
         id=GuidelineId(generate_id()),
         creation_utc=datetime.now(timezone.utc),
-        last_modified_utc=datetime.now(timezone.utc),
+        modified_utc=datetime.now(timezone.utc),
         content=GuidelineContent(
             condition=condition,
             action=action,
@@ -383,7 +383,7 @@ def create_term(
     return Term(
         id=TermId("-"),
         creation_utc=datetime.now(timezone.utc),
-        last_modified_utc=datetime.now(timezone.utc),
+        modified_utc=datetime.now(timezone.utc),
         name=name,
         description=description,
         synonyms=synonyms,
@@ -399,7 +399,7 @@ def create_context_variable(
     return ContextVariable(
         id=ContextVariableId("-"),
         creation_utc=datetime.now(timezone.utc),
-        last_modified_utc=datetime.now(timezone.utc),
+        modified_utc=datetime.now(timezone.utc),
         name=name,
         description="",
         tool_id=None,
@@ -407,7 +407,7 @@ def create_context_variable(
         tags=tags,
     ), ContextVariableValue(
         ContextVariableValueId("-"),
-        last_modified_utc=datetime.now(timezone.utc),
+        modified_utc=datetime.now(timezone.utc),
         data=data,
     )
 


### PR DESCRIPTION
## Summary
- add modified_utc to session and event documents, models, REST DTOs, and tunnel payloads
- add session/event document-loader migration to v0.10.0 and Mongo indexes for modified_utc pull sync
- rename existing entity last_modified_utc fields/DTOs to modified_utc while preserving persisted last_modified keys outside sessions/events

## Verification
- uv run --extra gemini pytest tests/core/stable/test_sessions.py --no-cache (temporary TDD tests, deleted after pass)
- uv run --extra gemini pytest tests/adapters/tunnels/test_dispatcher.py --no-cache
- uv run --extra gemini --extra mongo python -m compileall src/parlant/core/sessions.py src/parlant/api/sessions.py src/parlant/core/tunnels.py src/parlant/core/app_modules/sessions.py src/parlant/core/shots.py tests/core/common/utils.py tests/core/stable/engines/compass/guideline_matching/utils.py
- uv run --extra gemini --extra mongo mypy <modified src files>
- uv run --extra gemini --extra mongo mypy <modified test files>
- uv run --extra gemini --extra mongo ruff check <modified python files>
- uv run --extra gemini --extra mongo ruff format --check src/parlant/core/context_variables.py src/parlant/core/engines/alpha/tracing.py src/parlant/core/sessions.py src/parlant/api/sessions.py src/parlant/core/tunnels.py src/parlant/core/app_modules/sessions.py
- git diff --check

## Notes
- Full project lint/pre-push currently fails locally because optional provider dependencies are not installed in this environment: qdrant_client, chromadb, anthropic, ollama, litellm, cerebras.cloud.sdk, mistralai.
- Mongo index test imports with --extra mongo, but its shared container fixture initializes Gemini and fails locally without GEMINI_API_KEY before reaching the Mongo assertions.