### PR TITLE
feat: stream session events through cloud tunnel

### DIFF
--- a/src/parlant/adapters/modules/parlant_cloud/tunnel.py
+++ b/src/parlant/adapters/modules/parlant_cloud/tunnel.py
@@ -15,6 +15,7 @@
 """WebSocket tunnel between Parlant Cloud and a local Parlant Server."""
 
 import asyncio
+from contextlib import suppress
 import json as _json_mod
 import logging
 import os
@@ -59,6 +60,8 @@ class ParlantCloudTunnelService(TunnelService):
         self._running = False
         self._stop_event: asyncio.Event | None = None
         self._websocket: Any | None = None
+        self._send_lock = asyncio.Lock()
+        self._stream_tasks: dict[str, asyncio.Task[None]] = {}
 
     async def start(self) -> None:
         if not self._token:
@@ -92,6 +95,8 @@ class ParlantCloudTunnelService(TunnelService):
         if self._stop_event:
             self._stop_event.set()
 
+        await self._cancel_stream_tasks()
+
         if self._websocket is not None:
             await self._websocket.close()
 
@@ -119,14 +124,23 @@ class ParlantCloudTunnelService(TunnelService):
 
                     try:
                         message: dict[str, Any] = _json_mod.loads(raw_message)
+                        message_type = message.get("type")
+                        if message_type == "stream_cancel":
+                            await self._cancel_stream_task(message.get("request_id"))
+                            continue
+
                         request = TunnelRequest(
                             request_id=message["request_id"],
                             method=message["method"],
                             params=message.get("params", {}),
                         )
 
+                        if message_type == "stream":
+                            self._start_stream_task(ws, request)
+                            continue
+
                         response = await self._dispatcher.dispatch(request)
-                        await ws.send(_json_mod.dumps(response.to_dict()))
+                        await self._send_json(ws, response.to_dict())
 
                     except Exception as e:
                         _logger.error(f"Error processing tunnel message: {e}")
@@ -140,11 +154,76 @@ class ParlantCloudTunnelService(TunnelService):
                                 request_id=request_id,
                                 error=str(e),
                             )
-                            await ws.send(_json_mod.dumps(error_resp.to_dict()))
+                            await self._send_json(ws, error_resp.to_dict())
                         except Exception:
                             pass
             finally:
+                await self._cancel_stream_tasks()
                 self._websocket = None
+
+    def _start_stream_task(self, ws: Any, request: TunnelRequest) -> None:
+        task = asyncio.create_task(self._handle_stream_request(ws, request))
+        self._stream_tasks[request.request_id] = task
+        task.add_done_callback(lambda _: self._stream_tasks.pop(request.request_id, None))
+
+    async def _handle_stream_request(self, ws: Any, request: TunnelRequest) -> None:
+        try:
+            async for event in self._dispatcher.dispatch_stream(request):
+                await self._send_json(
+                    ws,
+                    {
+                        "request_id": request.request_id,
+                        "type": "stream_data",
+                        "event": "message",
+                        "data": event,
+                    },
+                )
+
+            await self._send_json(
+                ws,
+                {
+                    "request_id": request.request_id,
+                    "type": "stream_end",
+                },
+            )
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:
+            _logger.error(f"Error processing tunnel stream: {e}")
+            with suppress(Exception):
+                await self._send_json(
+                    ws,
+                    {
+                        "request_id": request.request_id,
+                        "type": "stream_error",
+                        "error": str(e),
+                    },
+                )
+
+    async def _cancel_stream_task(self, request_id: Any) -> None:
+        if not isinstance(request_id, str):
+            return
+
+        task = self._stream_tasks.pop(request_id, None)
+        if task is None:
+            return
+
+        task.cancel()
+        with suppress(asyncio.CancelledError):
+            await task
+
+    async def _cancel_stream_tasks(self) -> None:
+        tasks = list(self._stream_tasks.values())
+        self._stream_tasks.clear()
+        for task in tasks:
+            task.cancel()
+        for task in tasks:
+            with suppress(asyncio.CancelledError):
+                await task
+
+    async def _send_json(self, ws: Any, payload: dict[str, Any]) -> None:
+        async with self._send_lock:
+            await ws.send(_json_mod.dumps(payload))
 
 
 def _create_tunnel_service(

--- a/src/parlant/core/tunnels.py
+++ b/src/parlant/core/tunnels.py
@@ -1,7 +1,8 @@
 from abc import ABC, abstractmethod
+from collections.abc import AsyncIterator
 from datetime import datetime
 from enum import Enum
-from typing import Any, Awaitable, Callable, Mapping
+from typing import Any, Awaitable, Callable, Mapping, cast
 
 from parlant.core.agents import AgentId
 from parlant.core.app_modules.agents import AgentModule
@@ -128,6 +129,14 @@ class TunnelRequestDispatcher:
                 error=str(e),
             )
 
+    async def dispatch_stream(self, request: TunnelRequest) -> AsyncIterator[dict[str, Any]]:
+        handler = self._get_stream_handler(request.method)
+        if handler is None:
+            raise ValueError(f"Unknown stream method: {request.method}")
+
+        async for item in handler(dict(request.params)):
+            yield item
+
     def _get_handler(
         self, method: str
     ) -> Callable[[dict[str, Any]], Awaitable[dict[str, Any]]] | None:
@@ -150,6 +159,15 @@ class TunnelRequestDispatcher:
             "customers.list": self._handle_list_customers,
             "tags.list": self._handle_list_tags,
             "tags.retrieve": self._handle_retrieve_tag,
+        }
+        return handlers.get(method)
+
+    def _get_stream_handler(
+        self, method: str
+    ) -> Callable[[dict[str, Any]], AsyncIterator[dict[str, Any]]] | None:
+        handlers: dict[str, Callable[[dict[str, Any]], AsyncIterator[dict[str, Any]]]] = {
+            "sessions.stream_events": self._stream_events,
+            "sessions.stream_event": self._stream_event,
         }
         return handlers.get(method)
 
@@ -280,6 +298,69 @@ class TunnelRequestDispatcher:
         )
 
         return {"events": [self._serialize_event(e) for e in events]}
+
+    async def _stream_events(self, params: dict[str, Any]) -> AsyncIterator[dict[str, Any]]:
+        session_id = SessionId(params["session_id"])
+        current_offset = params.get("min_offset", 0)
+        source = EventSource(params["source"]) if params.get("source") else None
+        kinds = _parse_event_kinds(params.get("kinds"))
+        trace_id = params.get("trace_id")
+        wait_for_data = params.get("wait_for_data", 60)
+
+        while True:
+            has_events = await self._session_module.wait_for_more_events(
+                session_id=session_id,
+                min_offset=current_offset,
+                source=source,
+                kinds=kinds,
+                trace_id=trace_id,
+                timeout=Timeout(wait_for_data),
+            )
+            if not has_events:
+                break
+
+            events = await self._session_module.find_events(
+                session_id=session_id,
+                min_offset=current_offset,
+                source=source,
+                kinds=kinds,
+                trace_id=trace_id,
+            )
+
+            for event in events:
+                yield self._serialize_event(event)
+                current_offset = max(current_offset, event.offset + 1)
+
+    async def _stream_event(self, params: dict[str, Any]) -> AsyncIterator[dict[str, Any]]:
+        session_id = SessionId(params["session_id"])
+        event_id = EventId(params["event_id"])
+        wait_for_data = params.get("wait_for_data", 60)
+        chunk_count = 0
+
+        while True:
+            event = await self._session_module.read_event(
+                session_id=session_id,
+                event_id=event_id,
+            )
+            yield self._serialize_event(event)
+
+            data = cast(dict[str, Any], event.data)
+            if "chunks" not in data:
+                break
+
+            chunks = cast(list[str | None], data["chunks"])
+            chunk_count = len(chunks)
+            if chunks and chunks[-1] is None:
+                break
+
+            has_new_chunks = await self._session_module.wait_for_new_streaming_chunks(
+                session_id=session_id,
+                event_id=event_id,
+                last_known_chunk_count=chunk_count,
+                timeout=Timeout(wait_for_data),
+            )
+            if not has_new_chunks:
+                break
 
     async def _handle_create_session(self, params: dict[str, Any]) -> dict[str, Any]:
         session = await self._session_module.create(

--- a/tests/adapters/tunnels/test_dispatcher.py
+++ b/tests/adapters/tunnels/test_dispatcher.py
@@ -513,6 +513,108 @@ async def test_that_dispatcher_returns_empty_events_when_list_events_wait_times_
     session_module.find_events.assert_not_awaited()
 
 
+async def test_that_dispatcher_streams_session_events_until_wait_times_out() -> None:
+    session_module = AsyncMock()
+    session_module.wait_for_more_events = AsyncMock(side_effect=[True, False])
+    session_module.find_events = AsyncMock(
+        return_value=[
+            MagicMock(
+                id="evt-1",
+                offset=0,
+                source=EventSource.AI_AGENT,
+                kind=EventKind.MESSAGE,
+                creation_utc=datetime(2026, 1, 1, tzinfo=timezone.utc),
+                modified_utc=datetime(2026, 1, 1, tzinfo=timezone.utc),
+                trace_id="trace-1",
+                data={"message": "Hello"},
+                metadata={},
+                deleted=False,
+            )
+        ]
+    )
+
+    dispatcher = TunnelRequestDispatcher(session_module=session_module)
+
+    request = TunnelRequest(
+        request_id="req-stream-evts",
+        method="sessions.stream_events",
+        params={"session_id": "sess-1", "min_offset": 0, "wait_for_data": 5},
+    )
+
+    events = [event async for event in dispatcher.dispatch_stream(request)]
+
+    assert events == [
+        {
+            "id": "evt-1",
+            "offset": 0,
+            "source": "ai_agent",
+            "kind": "message",
+            "creation_utc": "2026-01-01T00:00:00+00:00",
+            "modified_utc": "2026-01-01T00:00:00+00:00",
+            "trace_id": "trace-1",
+            "data": {"message": "Hello"},
+            "metadata": {},
+            "deleted": False,
+        }
+    ]
+    assert session_module.wait_for_more_events.await_count == 2
+    second_wait_call = session_module.wait_for_more_events.await_args_list[1].kwargs
+    assert second_wait_call["min_offset"] == 1
+
+
+async def test_that_dispatcher_streams_event_updates_until_chunks_complete() -> None:
+    session_module = AsyncMock()
+    session_module.read_event = AsyncMock(
+        side_effect=[
+            MagicMock(
+                id="evt-1",
+                offset=0,
+                source=EventSource.AI_AGENT,
+                kind=EventKind.MESSAGE,
+                creation_utc=datetime(2026, 1, 1, tzinfo=timezone.utc),
+                modified_utc=datetime(2026, 1, 1, tzinfo=timezone.utc),
+                trace_id="trace-1",
+                data={"chunks": ["Hel"]},
+                metadata={},
+                deleted=False,
+            ),
+            MagicMock(
+                id="evt-1",
+                offset=0,
+                source=EventSource.AI_AGENT,
+                kind=EventKind.MESSAGE,
+                creation_utc=datetime(2026, 1, 1, tzinfo=timezone.utc),
+                modified_utc=datetime(2026, 1, 1, tzinfo=timezone.utc),
+                trace_id="trace-1",
+                data={"chunks": ["Hello", None]},
+                metadata={},
+                deleted=False,
+            ),
+        ]
+    )
+    session_module.wait_for_new_streaming_chunks = AsyncMock(return_value=True)
+
+    dispatcher = TunnelRequestDispatcher(session_module=session_module)
+
+    request = TunnelRequest(
+        request_id="req-stream-evt",
+        method="sessions.stream_event",
+        params={"session_id": "sess-1", "event_id": "evt-1", "wait_for_data": 5},
+    )
+
+    events = [event async for event in dispatcher.dispatch_stream(request)]
+
+    assert [event["data"] for event in events] == [
+        {"chunks": ["Hel"]},
+        {"chunks": ["Hello", None]},
+    ]
+    session_module.wait_for_new_streaming_chunks.assert_awaited_once()
+    wait_call = session_module.wait_for_new_streaming_chunks.await_args.kwargs
+    assert wait_call["session_id"] == "sess-1"
+    assert wait_call["event_id"] == "evt-1"
+    assert wait_call["last_known_chunk_count"] == 1
+
+
 async def test_that_dispatcher_routes_sessions_update_event() -> None:
     session_module = AsyncMock()
     session_module.update_event = AsyncMock(

--- a/tests/adapters/tunnels/test_websocket_tunnel.py
+++ b/tests/adapters/tunnels/test_websocket_tunnel.py
@@ -68,6 +68,66 @@ async def test_that_tunnel_connects_and_dispatches_request() -> None:
     assert dispatcher.dispatch.await_count >= 1
 
 
+async def test_that_tunnel_streams_dispatcher_events_as_stream_frames() -> None:
+    received_frames: list[dict[str, Any]] = []
+
+    async def mock_platform_handler(websocket: websockets.asyncio.server.ServerConnection) -> None:
+        await websocket.send(
+            json.dumps(
+                {
+                    "request_id": "stream-1",
+                    "type": "stream",
+                    "method": "sessions.stream_events",
+                    "params": {"session_id": "sess-1"},
+                }
+            )
+        )
+
+        received_frames.append(json.loads(await websocket.recv()))
+        received_frames.append(json.loads(await websocket.recv()))
+        await websocket.wait_closed()
+
+    class StreamingDispatcher:
+        async def dispatch_stream(self, request: Any) -> Any:
+            assert request.request_id == "stream-1"
+            assert request.method == "sessions.stream_events"
+            yield {"id": "evt-1", "offset": 0}
+
+    async with websockets.asyncio.server.serve(mock_platform_handler, "localhost", 0) as server:
+        port = server.sockets[0].getsockname()[1]
+        url = f"ws://localhost:{port}"
+
+        tunnel = ParlantCloudTunnelService(
+            url=url,
+            token="test-token",
+            dispatcher=StreamingDispatcher(),  # type: ignore[arg-type]
+            initial_reconnect_delay=10.0,
+        )
+
+        task = asyncio.create_task(tunnel.start())
+
+        for _ in range(50):
+            if len(received_frames) >= 2:
+                break
+            await asyncio.sleep(0.1)
+
+        await tunnel.stop()
+        await asyncio.wait_for(task, timeout=1.0)
+
+    assert received_frames == [
+        {
+            "request_id": "stream-1",
+            "type": "stream_data",
+            "event": "message",
+            "data": {"id": "evt-1", "offset": 0},
+        },
+        {
+            "request_id": "stream-1",
+            "type": "stream_end",
+        },
+    ]
+
+
 async def test_that_tunnel_reconnects_after_disconnect() -> None:
     connection_count = 0
 


### PR DESCRIPTION
## What changed

- Adds tunnel stream dispatch support alongside existing request/response RPC dispatch.
- Exposes `sessions.stream_events` through the tunnel, matching the existing HTTP `GET /sessions/{id}/events?sse=true` behavior.
- Exposes `sessions.stream_event` through the tunnel, matching the existing HTTP `GET /sessions/{id}/events/{event_id}?sse=true` chunk-update behavior.
- Runs stream requests as cancellable background tasks on the Parlant cloud tunnel websocket client.
- Adds websocket stream frames: `stream_data`, `stream_end`, `stream_error`, and support for platform `stream_cancel`.

## Data flow

Parlant HTTP SSE remains the source behavior. This PR makes the tunnel support the same behavior so Commodore backend can consume live session event streams for self-hosted Parlant services.

## Monitoring

- Existing tunnel connection logs remain unchanged.
- Stream task failures are logged as tunnel stream errors and forwarded to the platform as `stream_error` frames.
- Stream tasks are cancelled on platform cancel, service stop, and websocket disconnect.

## Verification

- `uv run pytest tests/adapters/tunnels` -> 56 passed, 1 existing Google Python-version warning
- Push hook: `uv run mypy`, `uv run ruff check`, `uv run ruff format --check` -> passed
- `git diff --check` -> passed
