### PR TITLE
feat: expose Parlant version over tunnel RPC

### DIFF
--- a/src/parlant/core/tunnels.py
+++ b/src/parlant/core/tunnels.py
@@ -16,6 +16,7 @@ from parlant.core.loggers import Logger
 from parlant.core.persistence.common import SortDirection
 from parlant.core.sessions import EventId, EventKind, EventSource, SessionId
 from parlant.core.tags import TagId
+from parlant.core.version import VERSION
 
 
 def _parse_sort_direction(value: str | None) -> SortDirection | None:
@@ -131,6 +132,7 @@ class TunnelRequestDispatcher:
         self, method: str
     ) -> Callable[[dict[str, Any]], Awaitable[dict[str, Any]]] | None:
         handlers: dict[str, Callable[[dict[str, Any]], Awaitable[dict[str, Any]]]] = {
+            "system.version": self._handle_system_version,
             "sessions.create": self._handle_create_session,
             "sessions.read": self._handle_read_session,
             "sessions.list": self._handle_list_sessions,
@@ -150,6 +152,10 @@ class TunnelRequestDispatcher:
             "tags.retrieve": self._handle_retrieve_tag,
         }
         return handlers.get(method)
+
+    async def _handle_system_version(self, params: dict[str, Any]) -> dict[str, Any]:
+        del params
+        return {"version": VERSION}
 
     async def _handle_list_tags(self, params: dict[str, Any]) -> dict[str, Any]:
         if self._tag_module is None:

--- a/tests/adapters/tunnels/test_dispatcher.py
+++ b/tests/adapters/tunnels/test_dispatcher.py
@@ -8,6 +8,7 @@ from parlant.core.agents import CompositionMode, MessageOutputMode
 from parlant.core.app_modules.common import decode_cursor, encode_cursor
 from parlant.core.persistence.common import Cursor, ObjectId, SortDirection
 from parlant.core.app_modules.sessions import Moderation
+from parlant.core.version import VERSION
 from parlant.core.sessions import EventKind, EventSource
 from parlant.core.tunnels import TunnelRequestDispatcher
 from parlant.core.tunnels import TunnelRequest
@@ -97,6 +98,22 @@ async def test_that_dispatcher_returns_error_for_unknown_method() -> None:
     assert response.request_id == "req-2"
     assert response.error is not None
     assert "unknown" in response.error.lower()
+
+
+async def test_that_dispatcher_routes_system_version() -> None:
+    dispatcher = TunnelRequestDispatcher(session_module=AsyncMock())
+
+    response = await dispatcher.dispatch(
+        TunnelRequest(
+            request_id="req-version",
+            method="system.version",
+            params={},
+        )
+    )
+
+    assert response.request_id == "req-version"
+    assert response.error is None
+    assert response.result == {"version": VERSION}
 
 
 async def test_that_dispatcher_routes_sessions_create() -> None:


### PR DESCRIPTION
## Summary
- expose Parlant runtime version through the existing tunnel RPC dispatcher

## Why
Commodore now validates tunnel-connected self-hosted Parlant instances before letting users proceed. The backend needs a supported way to read the remote Parlant version over the tunnel transport that already exists in self-hosted flows.

## Main Change
- add `system.version` tunnel RPC that returns `{ "version": VERSION }`

## Review Order
1. `afc70293c` Add tunnel RPC for Parlant version lookup

## Verification
- `.venv/bin/pytest tests/adapters/tunnels/test_dispatcher.py -q`
- `git diff --check`

## Consumer
- consumed by commodore-backend PR #199 to enforce support for Parlant `4.x.x` in tunnel connection checks