### PR TITLE
Preserve SDK startup errors

### DIFF
--- a/src/parlant/adapters/nlp/hugging_face.py
+++ b/src/parlant/adapters/nlp/hugging_face.py
@@ -53,8 +53,8 @@ def _create_tokenizer(model_name: str) -> PreTrainedTokenizer:
     save_dir = os.environ.get("PARLANT_HOME", _model_temp_dir())
     os.makedirs(save_dir, exist_ok=True)
 
-    tokenizer = AutoTokenizer.from_pretrained(model_name, trust_remote_code=True)  # type: ignore
-    tokenizer = cast(PreTrainedTokenizer, tokenizer)
+    raw_tokenizer = AutoTokenizer.from_pretrained(model_name, trust_remote_code=True)  # type: ignore
+    tokenizer = cast(PreTrainedTokenizer, raw_tokenizer)
     tokenizer.save_pretrained(save_dir)
 
     _TOKENIZER_MODELS[model_name] = tokenizer

--- a/src/parlant/sdk.py
+++ b/src/parlant/sdk.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 import asyncio
 from collections import defaultdict, deque
-from contextlib import AsyncExitStack
+from contextlib import AsyncExitStack, suppress
 import contextvars
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
@@ -3541,10 +3541,13 @@ class Server:
             await self._startup_context_manager.__aexit__(None, None, None)
         except BaseException:
             health_check_task.cancel()
+            with suppress(asyncio.CancelledError):
+                await health_check_task
             raise
-        finally:
+        else:
             # Wait for health check to complete before cleanup
             await health_check_task
+        finally:
             await self._exit_stack.aclose()
 
         return False

--- a/tests/sdk/test_server_lifecycle.py
+++ b/tests/sdk/test_server_lifecycle.py
@@ -1,0 +1,107 @@
+# Copyright 2026 Emcie Co Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+from contextlib import contextmanager
+from typing import Iterator
+
+import pytest
+
+from parlant import sdk as p
+from parlant.core.tracer import Tracer
+
+
+class StartupFailure(Exception):
+    pass
+
+
+class FakeProgress:
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: object | None,
+    ) -> None:
+        pass
+
+
+class FakeTracer:
+    @contextmanager
+    def span(self, span_id: str, attributes: dict[str, str]) -> Iterator[None]:
+        yield
+
+
+class FakeContainer:
+    def __getitem__(self, key: object) -> object:
+        if key is Tracer:
+            return FakeTracer()
+
+        raise KeyError(key)
+
+
+class FailingStartupContextManager:
+    def __init__(self, error: BaseException) -> None:
+        self.error = error
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: object | None,
+    ) -> None:
+        await asyncio.sleep(0)
+        raise self.error
+
+
+class FakeExitStack:
+    def __init__(self) -> None:
+        self.closed = False
+
+    async def aclose(self) -> None:
+        self.closed = True
+
+
+async def test_that_server_startup_errors_are_not_masked_by_health_check_cancellation() -> None:
+    server = p.Server()
+    startup_error = StartupFailure("backend rejected tunnel auth")
+    exit_stack = FakeExitStack()
+    polling_started = asyncio.Event()
+
+    async def process_evaluations() -> None:
+        pass
+
+    async def setup_retrievers() -> None:
+        pass
+
+    async def poll_health_endpoint() -> None:
+        polling_started.set()
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            raise
+
+    server._creation_progress = FakeProgress()  # type: ignore[assignment]
+    server._container = FakeContainer()  # type: ignore[assignment]
+    server._startup_context_manager = FailingStartupContextManager(startup_error)  # type: ignore[assignment]
+    server._exit_stack = exit_stack  # type: ignore[assignment]
+    server._process_evaluations = process_evaluations  # type: ignore[method-assign]
+    server._setup_retrievers = setup_retrievers  # type: ignore[method-assign]
+    server._poll_health_endpoint = poll_health_endpoint  # type: ignore[method-assign]
+
+    with pytest.raises(StartupFailure) as exc_info:
+        await server.__aexit__(None, None, None)
+
+    assert exc_info.value is startup_error
+    assert polling_started.is_set()
+    assert exit_stack.closed


### PR DESCRIPTION
## Summary
- Preserve the original SDK startup exception when server startup fails while the health-check task is being cancelled.
- Add a lifecycle regression test using fakes for the startup context, progress, tracer, and exit stack.
- Clean up a Hugging Face tokenizer cast so repo-wide mypy passes in the pre-push hook.

## Gap
`p.Server.__aexit__()` started the health polling task before entering the serving context. If serving startup failed, the code cancelled the poll task but then awaited it from `finally`, so the poll task's `CancelledError` could replace the real startup failure. That is how a useful connectivity/auth error can degrade into context-manager cleanup noise such as `athrow(): asynchronous generator is already running`.

## Test Plan
- `.venv/bin/pytest tests/sdk/test_server_lifecycle.py tests/sdk/test_sdk_validation.py -q`
- `.venv/bin/ruff check src/parlant/sdk.py src/parlant/adapters/nlp/hugging_face.py tests/sdk/test_server_lifecycle.py`
- `uv run mypy`
- pre-push hook: `uv run mypy`, `uv run ruff check`, `uv run ruff format --check`