### PR TITLE
Preserve SDK startup errors

### DIFF
--- a/src/parlant/adapters/nlp/hugging_face.py
+++ b/src/parlant/adapters/nlp/hugging_face.py
@@ -53,8 +53,8 @@ def _create_tokenizer(model_name: str) -> PreTrainedTokenizer:
     save_dir = os.environ.get("PARLANT_HOME", _model_temp_dir())
     os.makedirs(save_dir, exist_ok=True)
 
-    tokenizer = AutoTokenizer.from_pretrained(model_name, trust_remote_code=True)  # type: ignore
-    tokenizer = cast(PreTrainedTokenizer, tokenizer)
+    raw_tokenizer = AutoTokenizer.from_pretrained(model_name, trust_remote_code=True)  # type: ignore
+    tokenizer = cast(PreTrainedTokenizer, raw_tokenizer)
     tokenizer.save_pretrained(save_dir)
 
     _TOKENIZER_MODELS[model_name] = tokenizer

--- a/src/parlant/core/services/tools/plugins.py
+++ b/src/parlant/core/services/tools/plugins.py
@@ -544,7 +544,20 @@ class PluginServer:
             if self.started():
                 return self
 
-        raise TimeoutError()
+            if self._task.done():
+                await self._raise_startup_error()
+
+        raise TimeoutError(f"Timed out waiting for plugin server to start at {self.url}")
+
+    async def _raise_startup_error(self) -> None:
+        try:
+            await self._task
+        except RuntimeError:
+            raise
+        except BaseException as exc:
+            raise RuntimeError(f"Failed to start plugin server at {self.url}") from exc
+
+        raise RuntimeError(f"Plugin server stopped before startup at {self.url}")
 
     async def __aexit__(
         self,
@@ -578,13 +591,17 @@ class PluginServer:
 
         self._server = uvicorn.Server(config)
 
-        if self.hosted:
-            # Run without capturing signals.
-            # This is because we're being hosted in another process
-            # that has its own bookkeeping on signals.
-            await self._server._serve()
-        else:
-            await self._server.serve()
+        try:
+            if self.hosted:
+                # Run without capturing signals.
+                # This is because we're being hosted in another process
+                # that has its own bookkeeping on signals.
+                await self._server._serve()
+            else:
+                await self._server.serve()
+        except SystemExit as exc:
+            detail = f": {exc.__context__}" if exc.__context__ else ""
+            raise RuntimeError(f"Failed to start plugin server at {self.url}{detail}") from exc
 
     async def shutdown(self) -> None:
         if server := self._server:

--- a/src/parlant/sdk.py
+++ b/src/parlant/sdk.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 import asyncio
 from collections import defaultdict, deque
-from contextlib import AsyncExitStack
+from contextlib import AsyncExitStack, suppress
 import contextvars
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
@@ -3525,13 +3525,22 @@ class Server:
             await self._exit_stack.aclose()
             return False
 
-        with self._container[Tracer].span(
-            "startup.evaluations",
-            attributes={"scope": "Evaluations"},
-        ):
-            await self._process_evaluations()
+        try:
+            with self._container[Tracer].span(
+                "startup.evaluations",
+                attributes={"scope": "Evaluations"},
+            ):
+                await self._process_evaluations()
 
-        await self._setup_retrievers()
+            await self._setup_retrievers()
+        except BaseException as exc:
+            await self._startup_context_manager.__aexit__(
+                type(exc),
+                exc,
+                exc.__traceback__,
+            )
+            await self._exit_stack.aclose()
+            raise
 
         # Start health check polling to set ready event when the server is ready to receive requests
         health_check_task = asyncio.create_task(self._poll_health_endpoint())
@@ -3541,10 +3550,13 @@ class Server:
             await self._startup_context_manager.__aexit__(None, None, None)
         except BaseException:
             health_check_task.cancel()
+            with suppress(asyncio.CancelledError):
+                await health_check_task
             raise
-        finally:
+        else:
             # Wait for health check to complete before cleanup
             await health_check_task
+        finally:
             await self._exit_stack.aclose()
 
         return False

--- a/tests/core/stable/services/tools/test_plugin_server.py
+++ b/tests/core/stable/services/tools/test_plugin_server.py
@@ -1,0 +1,62 @@
+# Copyright 2026 Emcie Co Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from parlant.core.services.tools.plugins import PluginServer
+
+
+class FailingPluginServer(PluginServer):
+    async def serve(self) -> None:
+        raise RuntimeError("bind failed")
+
+
+class SystemExitingUvicornServer:
+    started = False
+
+    def __init__(self, config: object) -> None:
+        _ = config
+
+    async def _serve(self) -> None:
+        try:
+            raise OSError("address already in use")
+        except OSError:
+            raise SystemExit(1)
+
+    async def serve(self) -> None:
+        await self._serve()
+
+
+async def test_that_plugin_server_reports_background_startup_errors() -> None:
+    server = FailingPluginServer([], host="127.0.0.1", port=8818)
+
+    with pytest.raises(RuntimeError, match="bind failed"):
+        await server.__aenter__()
+
+
+async def test_that_plugin_server_wraps_uvicorn_system_exit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "parlant.core.services.tools.plugins.uvicorn.Server",
+        SystemExitingUvicornServer,
+    )
+
+    server = PluginServer([], host="127.0.0.1", port=8818, hosted=True)
+
+    with pytest.raises(RuntimeError) as exc_info:
+        await server.serve()
+
+    assert "Failed to start plugin server at http://127.0.0.1:8818" in str(exc_info.value)
+    assert "address already in use" in str(exc_info.value)

--- a/tests/sdk/test_server_lifecycle.py
+++ b/tests/sdk/test_server_lifecycle.py
@@ -1,0 +1,157 @@
+# Copyright 2026 Emcie Co Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+from contextlib import contextmanager
+from typing import Iterator
+
+import pytest
+
+from parlant import sdk as p
+from parlant.core.tracer import Tracer
+
+
+class StartupFailure(Exception):
+    pass
+
+
+class SetupFailure(Exception):
+    pass
+
+
+class FakeProgress:
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: object | None,
+    ) -> None:
+        pass
+
+
+class FakeTracer:
+    @contextmanager
+    def span(self, span_id: str, attributes: dict[str, str]) -> Iterator[None]:
+        yield
+
+
+class FakeContainer:
+    def __getitem__(self, key: object) -> object:
+        if key is Tracer:
+            return FakeTracer()
+
+        raise KeyError(key)
+
+
+class FailingStartupContextManager:
+    def __init__(self, error: BaseException) -> None:
+        self.error = error
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: object | None,
+    ) -> None:
+        await asyncio.sleep(0)
+        raise self.error
+
+
+class RecordingStartupContextManager:
+    def __init__(self) -> None:
+        self.exc_type: type[BaseException] | None = None
+        self.exc_value: BaseException | None = None
+        self.closed = False
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: object | None,
+    ) -> None:
+        self.exc_type = exc_type
+        self.exc_value = exc_value
+        self.closed = True
+
+
+class FakeExitStack:
+    def __init__(self) -> None:
+        self.closed = False
+
+    async def aclose(self) -> None:
+        self.closed = True
+
+
+async def test_that_server_startup_errors_are_not_masked_by_health_check_cancellation() -> None:
+    server = p.Server()
+    startup_error = StartupFailure("backend rejected tunnel auth")
+    exit_stack = FakeExitStack()
+    polling_started = asyncio.Event()
+
+    async def process_evaluations() -> None:
+        pass
+
+    async def setup_retrievers() -> None:
+        pass
+
+    async def poll_health_endpoint() -> None:
+        polling_started.set()
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            raise
+
+    server._creation_progress = FakeProgress()  # type: ignore[assignment]
+    server._container = FakeContainer()  # type: ignore[assignment]
+    server._startup_context_manager = FailingStartupContextManager(startup_error)  # type: ignore[assignment]
+    server._exit_stack = exit_stack  # type: ignore[assignment]
+    server._process_evaluations = process_evaluations  # type: ignore[method-assign]
+    server._setup_retrievers = setup_retrievers  # type: ignore[method-assign]
+    server._poll_health_endpoint = poll_health_endpoint  # type: ignore[method-assign]
+
+    with pytest.raises(StartupFailure) as exc_info:
+        await server.__aexit__(None, None, None)
+
+    assert exc_info.value is startup_error
+    assert polling_started.is_set()
+    assert exit_stack.closed
+
+
+async def test_that_pre_serving_setup_errors_close_the_startup_context() -> None:
+    server = p.Server()
+    setup_error = SetupFailure("indexing failed")
+    startup_context = RecordingStartupContextManager()
+    exit_stack = FakeExitStack()
+
+    async def process_evaluations() -> None:
+        raise setup_error
+
+    async def setup_retrievers() -> None:
+        pass
+
+    server._creation_progress = FakeProgress()  # type: ignore[assignment]
+    server._container = FakeContainer()  # type: ignore[assignment]
+    server._startup_context_manager = startup_context  # type: ignore[assignment]
+    server._exit_stack = exit_stack  # type: ignore[assignment]
+    server._process_evaluations = process_evaluations  # type: ignore[method-assign]
+    server._setup_retrievers = setup_retrievers  # type: ignore[method-assign]
+
+    with pytest.raises(SetupFailure) as exc_info:
+        await server.__aexit__(None, None, None)
+
+    assert exc_info.value is setup_error
+    assert startup_context.exc_type is SetupFailure
+    assert startup_context.exc_value is setup_error
+    assert startup_context.closed
+    assert exit_stack.closed


### PR DESCRIPTION
Preserves the original SDK startup failure instead of masking it during cleanup. Also surfaces plugin server bind/startup failures from the background uvicorn task so occupied local tool-service ports produce a direct error. Verification: .venv/bin/pytest tests/sdk/test_server_lifecycle.py tests/sdk/test_sdk_validation.py tests/core/stable/services/tools/test_plugin_server.py -q; .venv/bin/ruff check src/parlant/sdk.py src/parlant/core/services/tools/plugins.py src/parlant/adapters/nlp/hugging_face.py tests/sdk/test_server_lifecycle.py tests/core/stable/services/tools/test_plugin_server.py; uv run mypy.