### PR TITLE
fix(core): prevent version drift from silently dropping tag associati…

### DIFF
--- a/src/parlant/core/agents.py
+++ b/src/parlant/core/agents.py
@@ -265,7 +265,7 @@ class AgentDocumentStore(AgentStore):
                 tag_id=TagId(doc["tag_id"]),
             )
 
-        if doc["version"] == "0.5.0":
+        if Version.from_string(doc["version"]) >= Version.from_string("0.5.0"):
             return doc
 
         return None

--- a/src/parlant/core/capabilities.py
+++ b/src/parlant/core/capabilities.py
@@ -193,19 +193,19 @@ class CapabilityVectorStore(CapabilityStore):
     async def _vector_document_loader(
         self, doc: VectorBaseDocument
     ) -> Optional[CapabilityVectorDocument]:
-        if doc["version"] == self.VERSION.to_string():
+        if Version.from_string(doc["version"]) >= self.VERSION:
             return cast(CapabilityVectorDocument, doc)
         return None
 
     async def _document_loader(self, doc: BaseDocument) -> Optional[CapabilityDocument]:
-        if doc["version"] == self.VERSION.to_string():
+        if Version.from_string(doc["version"]) >= self.VERSION:
             return cast(CapabilityDocument, doc)
         return None
 
     async def _association_document_loader(
         self, doc: BaseDocument
     ) -> Optional[CapabilityTagAssociationDocument]:
-        if doc["version"] == self.VERSION.to_string():
+        if Version.from_string(doc["version"]) >= self.VERSION:
             return cast(CapabilityTagAssociationDocument, doc)
         return None
 

--- a/src/parlant/core/common.py
+++ b/src/parlant/core/common.py
@@ -138,6 +138,16 @@ class Version:
             return NotImplemented
         return self._v > other._v
 
+    def __ge__(self, other: object) -> bool:
+        if not isinstance(other, Version):
+            return NotImplemented
+        return self._v >= other._v
+
+    def __le__(self, other: object) -> bool:
+        if not isinstance(other, Version):
+            return NotImplemented
+        return self._v <= other._v
+
 
 class ItemNotFoundError(Exception):
     def __init__(self, item_id: UniqueId, message: Optional[str] = None) -> None:

--- a/src/parlant/core/customers.py
+++ b/src/parlant/core/customers.py
@@ -167,7 +167,7 @@ class CustomerDocumentStore(CustomerStore):
         self._lock = ReaderWriterLock()
 
     async def _document_loader(self, doc: BaseDocument) -> Optional[_CustomerDocument]:
-        if doc["version"] == "0.1.0":
+        if Version.from_string(doc["version"]) >= Version.from_string("0.1.0"):
             return cast(_CustomerDocument, doc)
 
         return None
@@ -185,7 +185,7 @@ class CustomerDocumentStore(CustomerStore):
                 tag_id=doc["tag_id"],
             )
 
-        if doc["version"] == "0.2.0":
+        if Version.from_string(doc["version"]) >= Version.from_string("0.2.0"):
             return cast(_CustomerTagAssociationDocument, doc)
 
         return None

--- a/src/parlant/core/guideline_tool_associations.py
+++ b/src/parlant/core/guideline_tool_associations.py
@@ -98,7 +98,7 @@ class GuidelineToolAssociationDocumentStore(GuidelineToolAssociationStore):
         self,
         doc: BaseDocument,
     ) -> Optional[_GuidelineToolAssociationDocument]:
-        if doc["version"] == "0.1.0":
+        if Version.from_string(doc["version"]) >= Version.from_string("0.1.0"):
             return cast(_GuidelineToolAssociationDocument, doc)
         return None
 

--- a/src/parlant/core/guidelines.py
+++ b/src/parlant/core/guidelines.py
@@ -538,7 +538,7 @@ class GuidelineDocumentStore(GuidelineStore):
                 tag_id=d["tag_id"],
             )
 
-        if doc["version"] == "0.5.0":
+        if Version.from_string(doc["version"]) >= Version.from_string("0.5.0"):
             return cast(GuidelineTagAssociationDocument, doc)
 
         return None

--- a/src/parlant/core/nlp/embedding.py
+++ b/src/parlant/core/nlp/embedding.py
@@ -398,7 +398,7 @@ class BasicEmbeddingCache(EmbeddingCache):
                 vectors=d["vectors"],
             )
 
-        if doc["version"] == "0.2.0":
+        if Version.from_string(doc["version"]) >= Version.from_string("0.2.0"):
             return cast(EmbedderResultDocument, doc)
 
         return None

--- a/src/parlant/core/tags.py
+++ b/src/parlant/core/tags.py
@@ -173,7 +173,7 @@ class TagDocumentStore(TagStore):
         self._lock = ReaderWriterLock()
 
     async def _document_loader(self, doc: BaseDocument) -> Optional[_TagDocument]:
-        if doc["version"] == "0.1.0":
+        if Version.from_string(doc["version"]) >= Version.from_string("0.1.0"):
             return cast(_TagDocument, doc)
         return None
 


### PR DESCRIPTION
…ons on restart

The `_association_document_loader` and several `_document_loader` implementations were using strict equality checks (`==`) against specific version numbers (e.g., `doc["version"] == "0.5.0"`). When a main store's `VERSION` was bumped, new tag associations were written with the newer version string. However, upon restart, these new documents failed the strict equality check and were silently dropped and moved to the `_failed_migrations` collection.

Changes:
- Added `__ge__` and `__le__` methods to the `Version` class in `common.py` to support semantic version range comparisons.
- Replaced the strict `==` version checks with `>=` range checks on the latest supported versions.
- Applied this fix across all affected document stores without an automated `DocumentMigrationHelper` (`guidelines.py`, `agents.py`, `customers.py`, `tags.py`, `capabilities.py`, `nlp/embedding.py`, and `guideline_tool_associations.py`).