### PR TITLE
perf(db): optimize MongoDB startup document migration

### DIFF
--- a/src/parlant/adapters/db/mongo_db.py
+++ b/src/parlant/adapters/db/mongo_db.py
@@ -96,10 +96,14 @@ class MongoDocumentDatabase(DocumentDatabase):
             await self.delete_collection(failed_migrations_collection_name)
 
         failed_migration_collection: Optional[DocumentCollection[TDocument]] = None
-        for doc in await collection_existing_documents.to_list():
+        async for doc in collection_existing_documents:
             try:
+                original_version = doc.get("version")
                 if loaded_doc := await document_loader(doc):
-                    await result_collection.replace_one(doc, loaded_doc)
+                    # Only rewrite if the document was actually migrated (version changed or new dict created)
+                    if loaded_doc is not doc or loaded_doc.get("version") != original_version:
+                        # Use _id for efficient lookup instead of the full document
+                        await result_collection.replace_one({"_id": doc["_id"]}, loaded_doc)
                     continue
 
                 if failed_migration_collection is None:


### PR DESCRIPTION
- Replaced blocking `.to_list()` with `async for` to stream existing documents asynchronously, preventing large memory overhead.
- Added a check to skip calling `replace_one` when a document hasn't been modified by the migration loader.
- Optimized `replace_one` query to match on `{"_id": doc["_id"]}` instead of the entire document dictionary, drastically improving index utilization and write speed.

These changes significantly improve the Parlant server startup time, especially for collections with a large volume of documents.

Signed-off-by: Chibuike Mba <chibexme@yahoo.com>