### PR TITLE
perf(core): optimize batch deserialization and parallelize entity loading

### DIFF
--- a/src/parlant/core/entity_cq.py
+++ b/src/parlant/core/entity_cq.py
@@ -120,26 +120,30 @@ class EntityQueries:
         agent_id: AgentId,
         journeys: Sequence[Journey],
     ) -> Sequence[Guideline]:
-        agent_guidelines = await self._guideline_store.list_guidelines(
-            tags=[Tag.for_agent_id(agent_id).id],
-        )
-        global_guidelines = await self._guideline_store.list_guidelines(tags=[])
-
         agent = await self._agent_store.read_agent(agent_id)
-        guidelines_for_agent_tags = await self._guideline_store.list_guidelines(
-            tags=[tag for tag in agent.tags]
-        )
-
-        guidelines_for_journeys = await self._guideline_store.list_guidelines(
-            tags=[Tag.for_journey_id(journey.id).id for journey in journeys]
-        )
-
+        
+        async def _empty_list() -> list[Guideline]: return []
+        
         tasks = [
+            self._guideline_store.list_guidelines(tags=[Tag.for_agent_id(agent_id).id]),
+            self._guideline_store.list_guidelines(tags=[]),
+            self._guideline_store.list_guidelines(tags=list(agent.tags)) if agent.tags else _empty_list(),
+            self._guideline_store.list_guidelines(tags=[Tag.for_journey_id(journey.id).id for journey in journeys]) if journeys else _empty_list(),
+        ]
+        
+        projection_tasks = [
             self._journey_guideline_projection.project_journey_to_guidelines(journey.id)
             for journey in journeys
-            if journey.triggers  # If a journey has no triggers, it indicates that the journey cannot be activated.
+            if journey.triggers
         ]
-        projected_journey_guidelines = await async_utils.safe_gather(*tasks)
+        
+        results = await async_utils.safe_gather(*tasks, *projection_tasks)
+        
+        agent_guidelines = results[0]
+        global_guidelines = results[1]
+        guidelines_for_agent_tags = results[2]
+        guidelines_for_journeys = results[3]
+        projected_journey_guidelines = results[4:]
 
         all_guidelines = set(
             chain(
@@ -210,22 +214,17 @@ class EntityQueries:
         self,
         agent_id: AgentId,
     ) -> Sequence[ContextVariable]:
-        agent_context_variables = await self._context_variable_store.list_variables(
-            tags=[Tag.for_agent_id(agent_id).id],
-        )
-        global_context_variables = await self._context_variable_store.list_variables(tags=[])
         agent = await self._agent_store.read_agent(agent_id)
-        context_variables_for_agent_tags = await self._context_variable_store.list_variables(
-            tags=[tag for tag in agent.tags]
+        
+        async def _empty_list() -> list[ContextVariable]: return []
+
+        results = await async_utils.safe_gather(
+            self._context_variable_store.list_variables(tags=[Tag.for_agent_id(agent_id).id]),
+            self._context_variable_store.list_variables(tags=[]),
+            self._context_variable_store.list_variables(tags=list(agent.tags)) if agent.tags else _empty_list(),
         )
 
-        all_context_variables = set(
-            chain(
-                agent_context_variables,
-                global_context_variables,
-                context_variables_for_agent_tags,
-            )
-        )
+        all_context_variables = set(chain(*results))
         return list(all_context_variables)
 
     async def read_context_variable_value(
@@ -258,22 +257,17 @@ class EntityQueries:
         query: str,
         max_count: int,
     ) -> Sequence[Capability]:
-        agent_capabilities = await self._capability_store.list_capabilities(
-            tags=[Tag.for_agent_id(agent_id).id],
-        )
-        global_capabilities = await self._capability_store.list_capabilities(tags=[])
         agent = await self._agent_store.read_agent(agent_id)
-        capabilities_for_agent_tags = await self._capability_store.list_capabilities(
-            tags=[tag for tag in agent.tags]
+        
+        async def _empty_list() -> list[Capability]: return []
+
+        results = await async_utils.safe_gather(
+            self._capability_store.list_capabilities(tags=[Tag.for_agent_id(agent_id).id]),
+            self._capability_store.list_capabilities(tags=[]),
+            self._capability_store.list_capabilities(tags=list(agent.tags)) if agent.tags else _empty_list(),
         )
 
-        all_capabilities = set(
-            chain(
-                agent_capabilities,
-                global_capabilities,
-                capabilities_for_agent_tags,
-            )
-        )
+        all_capabilities = set(chain(*results))
 
         result = await self._capability_store.find_relevant_capabilities(
             query,
@@ -288,16 +282,17 @@ class EntityQueries:
         agent_id: AgentId,
         query: str,
     ) -> Sequence[Term]:
-        agent_terms = await self._glossary_store.list_terms(
-            tags=[Tag.for_agent_id(agent_id).id],
-        )
-        global_terms = await self._glossary_store.list_terms(tags=[])
         agent = await self._agent_store.read_agent(agent_id)
-        glossary_for_agent_tags = await self._glossary_store.list_terms(
-            tags=[tag for tag in agent.tags]
+        
+        async def _empty_list() -> list[Term]: return []
+
+        results = await async_utils.safe_gather(
+            self._glossary_store.list_terms(tags=[Tag.for_agent_id(agent_id).id]),
+            self._glossary_store.list_terms(tags=[]),
+            self._glossary_store.list_terms(tags=list(agent.tags)) if agent.tags else _empty_list(),
         )
 
-        all_terms = set(chain(agent_terms, global_terms, glossary_for_agent_tags))
+        all_terms = set(chain(*results))
 
         return await self._glossary_store.find_relevant_terms(query, list(all_terms))
 
@@ -311,19 +306,17 @@ class EntityQueries:
         self,
         agent_id: AgentId,
     ) -> Sequence[Journey]:
-        agent_journeys = await self._journey_store.list_journeys(
-            tags=[Tag.for_agent_id(agent_id).id],
-        )
-        global_journeys = await self._journey_store.list_journeys(tags=[])
-
         agent = await self._agent_store.read_agent(agent_id)
-        journeys_for_agent_tags = (
-            await self._journey_store.list_journeys(tags=[tag for tag in agent.tags])
-            if agent.tags
-            else []
+        
+        async def _empty_list() -> list[Journey]: return []
+
+        results = await async_utils.safe_gather(
+            self._journey_store.list_journeys(tags=[Tag.for_agent_id(agent_id).id]),
+            self._journey_store.list_journeys(tags=[]),
+            self._journey_store.list_journeys(tags=list(agent.tags)) if agent.tags else _empty_list(),
         )
 
-        return list(set(chain(agent_journeys, global_journeys, journeys_for_agent_tags)))
+        return list(set(chain(*results)))
 
     async def sort_journeys_by_contextual_relevance(
         self,

--- a/src/parlant/core/guidelines.py
+++ b/src/parlant/core/guidelines.py
@@ -627,6 +627,49 @@ class GuidelineDocumentStore(GuidelineStore):
             priority=guideline_document.get("priority", 0),
         )
 
+    async def _deserialize_batch(
+        self,
+        guideline_documents: Sequence[GuidelineDocument],
+    ) -> Sequence[Guideline]:
+        from collections import defaultdict
+        
+        guideline_ids = [d["id"] for d in guideline_documents]
+        tags_by_guideline: dict[str, list[str]] = defaultdict(list)
+        
+        if guideline_ids:
+            all_tags = await self._tag_association_collection.find(
+                {"guideline_id": {"$in": guideline_ids}}
+            )
+            for tag_doc in all_tags:
+                tags_by_guideline[tag_doc["guideline_id"]].append(tag_doc["tag_id"])
+                
+        guidelines: list[Guideline] = []
+        for d in guideline_documents:
+            composition_mode_str = d.get("composition_mode")
+            composition_mode = CompositionMode(composition_mode_str) if composition_mode_str else None
+            
+            guidelines.append(
+                Guideline(
+                    id=GuidelineId(d["id"]),
+                    creation_utc=datetime.fromisoformat(d["creation_utc"]),
+                    content=GuidelineContent(
+                        condition=d["condition"],
+                        action=d["action"],
+                        description=d.get("description", None),
+                    ),
+                    title=d.get("title", None),
+                    criticality=Criticality(d["criticality"]),
+                    enabled=d["enabled"],
+                    tags=[TagId(tag_id) for tag_id in tags_by_guideline.get(d["id"], [])],
+                    metadata=d["metadata"],
+                    labels=set(d.get("labels", [])),
+                    composition_mode=composition_mode,
+                    track=d.get("track", True),
+                    priority=d.get("priority", 0),
+                )
+            )
+        return guidelines
+
     @override
     async def create_guideline(
         self,
@@ -734,9 +777,8 @@ class GuidelineDocumentStore(GuidelineStore):
 
                     filters = {"$or": [{"id": {"$eq": id}} for id in guideline_ids]}
 
-            guidelines = [
-                await self._deserialize(d) for d in await self._collection.find(filters=filters)
-            ]
+            docs = list(await self._collection.find(filters=filters))
+            guidelines = list(await self._deserialize_batch(docs))
 
             # Filter by labels if specified
             if labels is not None:

--- a/src/parlant/core/journeys.py
+++ b/src/parlant/core/journeys.py
@@ -794,6 +794,50 @@ class JourneyVectorStore(JourneyStore):
             priority=doc.get("priority", 0),
         )
 
+    async def _deserialize_batch(
+        self,
+        journey_documents: Sequence[JourneyDocument],
+    ) -> Sequence[Journey]:
+        from collections import defaultdict
+        
+        journey_ids = [d["id"] for d in journey_documents]
+        tags_by_journey: dict[str, list[str]] = defaultdict(list)
+        triggers_by_journey: dict[str, list[str]] = defaultdict(list)
+        
+        if journey_ids:
+            all_tags = await self._tag_association_collection.find(
+                {"journey_id": {"$in": journey_ids}}
+            )
+            for tag_doc in all_tags:
+                tags_by_journey[tag_doc["journey_id"]].append(tag_doc["tag_id"])
+                
+            all_triggers = await self._trigger_association_collection.find(
+                {"journey_id": {"$in": journey_ids}}
+            )
+            for trig_doc in all_triggers:
+                triggers_by_journey[trig_doc["journey_id"]].append(trig_doc["trigger"])
+                
+        journeys: list[Journey] = []
+        for d in journey_documents:
+            composition_mode_str = d.get("composition_mode")
+            composition_mode = CompositionMode(composition_mode_str) if composition_mode_str else None
+            
+            journeys.append(
+                Journey(
+                    id=JourneyId(d["id"]),
+                    creation_utc=datetime.fromisoformat(d["creation_utc"]),
+                    triggers=triggers_by_journey.get(d["id"], []),
+                    title=d["title"],
+                    description=d["description"],
+                    root_id=JourneyNodeId(d["root_id"]),
+                    tags=tags_by_journey.get(d["id"], []),
+                    composition_mode=composition_mode,
+                    labels=set(d.get("labels", [])),
+                    priority=d.get("priority", 0),
+                )
+            )
+        return journeys
+
     def _serialize_node(
         self,
         node: JourneyNode,
@@ -1078,9 +1122,8 @@ class JourneyVectorStore(JourneyStore):
                 if journey_ids:
                     filters = {"$or": [{"id": {"$eq": id}} for id in journey_ids]}
 
-            return [
-                await self._deserialize(d) for d in await self._collection.find(filters=filters)
-            ]
+            docs = list(await self._collection.find(filters=filters))
+            return list(await self._deserialize_batch(docs))
 
     @override
     async def delete_journey(


### PR DESCRIPTION
Added _deserialize_batch to GuidelineDocumentStore and JourneyDocumentStore to eliminate N+1 overhead when retrieving and reconstructing large lists of guidelines and journeys from the database.

Refactored list_guidelines and list_journeys to utilize the new batch deserialization methods for faster sequential loads.

Updated entity_cq.py to parallelize entity data resolution using async_utils.safe_gather, significantly reducing overall I/O latency when aggregating entity queries.