### PR TITLE
fix(core): avoid inflating non-Latin text in LLM prompts

### DIFF
--- a/src/parlant/core/engines/alpha/canned_response_generator.py
+++ b/src/parlant/core/engines/alpha/canned_response_generator.py
@@ -1389,7 +1389,7 @@ Example {i} - {shot.description}: ###
         return f"""
 - **Expected Result**:
 ```json
-{json.dumps(shot.expected_result.model_dump(mode="json", exclude_unset=True), indent=2)}
+{json.dumps(shot.expected_result.model_dump(mode="json", exclude_unset=True), indent=2, ensure_ascii=False)}
 ```"""
 
     def _build_draft_prompt(
@@ -1607,7 +1607,8 @@ If it makes sense in the current state of the interaction, inform the user about
                                 **({"examples": d.examples} if d.examples else {}),
                             }
                             for d in tool_insights.missing_data
-                        ]
+                        ],
+                        ensure_ascii=False,
                     ),
                     "missing_data": tool_insights.missing_data,
                 },
@@ -1635,7 +1636,8 @@ You should inform the user about this invalid data: ###
                                 **({"examples": d.examples} if d.examples else {}),
                             }
                             for d in tool_insights.invalid_data
-                        ]
+                        ],
+                        ensure_ascii=False,
                     ),
                     "invalid_data": tool_insights.invalid_data,
                 },
@@ -1853,7 +1855,8 @@ in order to run tools. If it makes sense in the current state of the interaction
                                 **({"examples": d.examples} if d.examples else {}),
                             }
                             for d in tool_insights.missing_data
-                        ]
+                        ],
+                        ensure_ascii=False,
                     ),
                     "missing_data": tool_insights.missing_data,
                 },
@@ -1880,7 +1883,8 @@ in order to run tools. You should inform the user about this invalid data: ###
                                 **({"examples": d.examples} if d.examples else {}),
                             }
                             for d in tool_insights.invalid_data
-                        ]
+                        ],
+                        ensure_ascii=False,
                     ),
                     "invalid_data": tool_insights.invalid_data,
                 },
@@ -2579,7 +2583,7 @@ Last agent message: {shot.last_agent_message}
         formatted_shot += f"""
 - **Expected Result**:
 ```json
-{json.dumps(shot.expected_result.model_dump(mode="json", exclude_unset=True), indent=2)}
+{json.dumps(shot.expected_result.model_dump(mode="json", exclude_unset=True), indent=2, ensure_ascii=False)}
 ```
 """
 

--- a/src/parlant/core/engines/alpha/guideline_matching/generic/common.py
+++ b/src/parlant/core/engines/alpha/guideline_matching/generic/common.py
@@ -37,7 +37,7 @@ def dump_guideline(g: Guideline) -> dict[str, str | None]:
 
 
 def escape_json_string(s: str) -> str:
-    return json.dumps(s)[1:-1]
+    return json.dumps(s, ensure_ascii=False)[1:-1]
 
 
 def internal_representation(g: Guideline) -> GuidelineInternalRepresentation:

--- a/src/parlant/core/engines/alpha/guideline_matching/generic/disambiguation_batch.py
+++ b/src/parlant/core/engines/alpha/guideline_matching/generic/disambiguation_batch.py
@@ -260,7 +260,7 @@ Example {i} - {shot.description}: ###
         if shot.interaction_events:
             formatted_shot += f"""
 - **Interaction Events**:
-{json.dumps([adapt_event(e) for e in shot.interaction_events], indent=2)}
+{json.dumps([adapt_event(e) for e in shot.interaction_events], indent=2, ensure_ascii=False)}
 
 """
         if shot.disambiguation_condition:
@@ -283,7 +283,7 @@ Example {i} - {shot.description}: ###
         formatted_shot += f"""
 - **Expected Result**:
 ```json
-{json.dumps(shot.expected_result.model_dump(mode="json", exclude_unset=True), indent=2)}
+{json.dumps(shot.expected_result.model_dump(mode="json", exclude_unset=True), indent=2, ensure_ascii=False)}
 ```
 """
 
@@ -441,7 +441,7 @@ OUTPUT FORMAT
             ],
             "clarification_action": "<Include only if is_ambiguous is True. An action of the form ask the user whether they want to...>",
         }
-        return json.dumps(result, indent=4)
+        return json.dumps(result, indent=4, ensure_ascii=False)
 
 
 def _make_event(e_id: str, source: EventSource, message: str) -> Event:

--- a/src/parlant/core/engines/alpha/guideline_matching/generic/guideline_actionable_batch.py
+++ b/src/parlant/core/engines/alpha/guideline_matching/generic/guideline_actionable_batch.py
@@ -183,7 +183,7 @@ class GenericActionableGuidelineMatchingBatch(GuidelineMatchingBatch):
         if shot.interaction_events:
             formatted_shot += f"""
 - **Interaction Events**:
-{json.dumps([adapt_event(e) for e in shot.interaction_events], indent=2)}
+{json.dumps([adapt_event(e) for e in shot.interaction_events], indent=2, ensure_ascii=False)}
 
 """
         if shot.guidelines:
@@ -200,7 +200,7 @@ class GenericActionableGuidelineMatchingBatch(GuidelineMatchingBatch):
         formatted_shot += f"""
 - **Expected Result**:
 ```json
-{json.dumps(shot.expected_result.model_dump(mode="json", exclude_unset=True), indent=2)}
+{json.dumps(shot.expected_result.model_dump(mode="json", exclude_unset=True), indent=2, ensure_ascii=False)}
 ```
 """
 
@@ -333,7 +333,7 @@ OUTPUT FORMAT
             for i, g in self._guidelines.items()
         ]
         result = {"checks": result_structure}
-        return json.dumps(result, indent=4)
+        return json.dumps(result, indent=4, ensure_ascii=False)
 
 
 class GenericActionableGuidelineMatching(GuidelineMatchingStrategy):

--- a/src/parlant/core/engines/alpha/guideline_matching/generic/guideline_low_criticality_batch.py
+++ b/src/parlant/core/engines/alpha/guideline_matching/generic/guideline_low_criticality_batch.py
@@ -158,7 +158,7 @@ class GenericLowCriticalityGuidelineMatchingBatch(GuidelineMatchingBatch):
         if shot.interaction_events:
             formatted_shot += f"""
 - **Interaction Events**:
-{json.dumps([adapt_event(e) for e in shot.interaction_events], indent=2)}
+{json.dumps([adapt_event(e) for e in shot.interaction_events], indent=2, ensure_ascii=False)}
 
 """
         if shot.guidelines:
@@ -175,7 +175,7 @@ class GenericLowCriticalityGuidelineMatchingBatch(GuidelineMatchingBatch):
         formatted_shot += f"""
 - **Expected Result**:
 ```json
-{json.dumps(shot.expected_result.model_dump(mode="json", exclude_unset=True), indent=2)}
+{json.dumps(shot.expected_result.model_dump(mode="json", exclude_unset=True), indent=2, ensure_ascii=False)}
 ```
 """
 
@@ -307,7 +307,7 @@ OUTPUT FORMAT
             for i, g in self._guidelines.items()
         }
         result = {"applies": result_structure}
-        return json.dumps(result, indent=4)
+        return json.dumps(result, indent=4, ensure_ascii=False)
 
 
 class GenericLowCriticalityGuidelineMatching(GuidelineMatchingStrategy):

--- a/src/parlant/core/engines/alpha/guideline_matching/generic/guideline_previously_applied_actionable_batch.py
+++ b/src/parlant/core/engines/alpha/guideline_matching/generic/guideline_previously_applied_actionable_batch.py
@@ -190,7 +190,7 @@ class GenericPreviouslyAppliedActionableGuidelineMatchingBatch(GuidelineMatching
         if shot.interaction_events:
             formatted_shot += f"""
 - **Interaction Events**:
-{json.dumps([adapt_event(e) for e in shot.interaction_events], indent=2)}
+{json.dumps([adapt_event(e) for e in shot.interaction_events], indent=2, ensure_ascii=False)}
 
 """
         if shot.guidelines:
@@ -206,7 +206,7 @@ class GenericPreviouslyAppliedActionableGuidelineMatchingBatch(GuidelineMatching
         formatted_shot += f"""
 - **Expected Result**:
 ```json
-{json.dumps(shot.expected_result.model_dump(mode="json", exclude_unset=True), indent=2)}
+{json.dumps(shot.expected_result.model_dump(mode="json", exclude_unset=True), indent=2, ensure_ascii=False)}
 ```
 """
 
@@ -349,7 +349,7 @@ OUTPUT FORMAT
             for i, g in self._guidelines.items()
         ]
         result = {"checks": result_structure}
-        return json.dumps(result, indent=4)
+        return json.dumps(result, indent=4, ensure_ascii=False)
 
 
 class GenericPreviouslyAppliedActionableGuidelineMatching(GuidelineMatchingStrategy):

--- a/src/parlant/core/engines/alpha/guideline_matching/generic/guideline_previously_applied_actionable_customer_dependent_batch.py
+++ b/src/parlant/core/engines/alpha/guideline_matching/generic/guideline_previously_applied_actionable_customer_dependent_batch.py
@@ -198,7 +198,7 @@ class GenericPreviouslyAppliedActionableCustomerDependentGuidelineMatchingBatch(
         if shot.interaction_events:
             formatted_shot += f"""
 - **Interaction Events**:
-{json.dumps([adapt_event(e) for e in shot.interaction_events], indent=2)}
+{json.dumps([adapt_event(e) for e in shot.interaction_events], indent=2, ensure_ascii=False)}
 
 """
         if shot.guidelines:
@@ -214,7 +214,7 @@ class GenericPreviouslyAppliedActionableCustomerDependentGuidelineMatchingBatch(
         formatted_shot += f"""
 - **Expected Result**:
 ```json
-{json.dumps(shot.expected_result.model_dump(mode="json", exclude_unset=True), indent=2)}
+{json.dumps(shot.expected_result.model_dump(mode="json", exclude_unset=True), indent=2, ensure_ascii=False)}
 ```
 """
 
@@ -359,7 +359,7 @@ OUTPUT FORMAT
             for i, g in self._guidelines.items()
         ]
         result = {"checks": result_structure}
-        return json.dumps(result, indent=4)
+        return json.dumps(result, indent=4, ensure_ascii=False)
 
 
 class GenericPreviouslyAppliedActionableCustomerDependentGuidelineMatching(

--- a/src/parlant/core/engines/alpha/guideline_matching/generic/journey/journey_backtrack_check.py
+++ b/src/parlant/core/engines/alpha/guideline_matching/generic/journey/journey_backtrack_check.py
@@ -246,9 +246,7 @@ class JourneyBacktrackCheck:
         else:
             journey_description_str = ""
         if journey_triggers:
-            journey_triggers_str = " OR ".join(
-                f'"{g.content.condition}"' for g in journey_triggers
-            )
+            journey_triggers_str = " OR ".join(f'"{g.content.condition}"' for g in journey_triggers)
             journey_triggers_str = f"\nJourney activation condition: {journey_triggers_str}"
         else:
             journey_triggers_str = ""
@@ -511,7 +509,7 @@ OUTPUT FORMAT
         if shot.interaction_events:
             formatted_shot += f"""
 - **Interaction Events**:
-{json.dumps([adapt_event(e) for e in shot.interaction_events], indent=2)}
+{json.dumps([adapt_event(e) for e in shot.interaction_events], indent=2, ensure_ascii=False)}
 
 """
         if shot.journey_nodes:
@@ -540,7 +538,7 @@ OUTPUT FORMAT
         formatted_shot += f"""
 - **Expected Result**:
 ```json
-{json.dumps(shot.expected_result.model_dump(mode="json", exclude_unset=True), indent=2)}
+{json.dumps(shot.expected_result.model_dump(mode="json", exclude_unset=True), indent=2, ensure_ascii=False)}
 ```
 """
         return formatted_shot

--- a/src/parlant/core/engines/alpha/guideline_matching/generic/journey/journey_backtrack_node_selection.py
+++ b/src/parlant/core/engines/alpha/guideline_matching/generic/journey/journey_backtrack_node_selection.py
@@ -550,7 +550,7 @@ class JourneyBacktrackNodeSelection:
         if shot.interaction_events:
             formatted_shot += f"""
 - **Interaction Events**:
-{json.dumps([adapt_event(e) for e in shot.interaction_events], indent=2)}
+{json.dumps([adapt_event(e) for e in shot.interaction_events], indent=2, ensure_ascii=False)}
 
 """
         if shot.journey_nodes:
@@ -579,7 +579,7 @@ class JourneyBacktrackNodeSelection:
         formatted_shot += f"""
 - **Expected Result**:
 ```json
-{json.dumps(shot.expected_result.model_dump(mode="json", exclude_unset=True), indent=2)}
+{json.dumps(shot.expected_result.model_dump(mode="json", exclude_unset=True), indent=2, ensure_ascii=False)}
 ```
 """
         return formatted_shot

--- a/src/parlant/core/engines/alpha/guideline_matching/generic/journey/journey_next_step_selection.py
+++ b/src/parlant/core/engines/alpha/guideline_matching/generic/journey/journey_next_step_selection.py
@@ -396,9 +396,7 @@ class JourneyNextStepSelection:
         else:
             journey_description_str = ""
         if journey_triggers:
-            journey_triggers_str = " OR ".join(
-                f'"{g.content.condition}"' for g in journey_triggers
-            )
+            journey_triggers_str = " OR ".join(f'"{g.content.condition}"' for g in journey_triggers)
             journey_triggers_str = f"\nJourney activation condition: {journey_triggers_str}"
         else:
             journey_triggers_str = ""
@@ -508,7 +506,7 @@ OUTPUT FORMAT
         if shot.interaction_events:
             formatted_shot += f"""
 - **Interaction Events**:
-{json.dumps([adapt_event(e) for e in shot.interaction_events], indent=2)}
+{json.dumps([adapt_event(e) for e in shot.interaction_events], indent=2, ensure_ascii=False)}
 
 """
         formatted_shot += self.get_journey_transition_map_text(
@@ -535,7 +533,7 @@ OUTPUT FORMAT
         formatted_shot += f"""
 - **Expected Result**:
 ```json
-{json.dumps(shot.expected_result.model_dump(mode="json", exclude_unset=True), indent=2)}
+{json.dumps(shot.expected_result.model_dump(mode="json", exclude_unset=True), indent=2, ensure_ascii=False)}
 ```
 """
 

--- a/src/parlant/core/engines/alpha/guideline_matching/generic/observational_batch.py
+++ b/src/parlant/core/engines/alpha/guideline_matching/generic/observational_batch.py
@@ -190,7 +190,7 @@ class GenericObservationalGuidelineMatchingBatch(GuidelineMatchingBatch):
         if shot.interaction_events:
             formatted_shot += f"""
 - **Interaction Events**:
-{json.dumps([adapt_event(e) for e in shot.interaction_events], indent=2)}
+{json.dumps([adapt_event(e) for e in shot.interaction_events], indent=2, ensure_ascii=False)}
 
 """
         if shot.guidelines:
@@ -206,7 +206,7 @@ class GenericObservationalGuidelineMatchingBatch(GuidelineMatchingBatch):
         formatted_shot += f"""
 - **Expected Result**:
 ```json
-{json.dumps(shot.expected_result.model_dump(mode="json", exclude_unset=True), indent=2)}
+{json.dumps(shot.expected_result.model_dump(mode="json", exclude_unset=True), indent=2, ensure_ascii=False)}
 ```
 """
 
@@ -322,7 +322,7 @@ Expected Output
     }}
     ```""",
             props={
-                "result_structure_text": json.dumps(result_structure),
+                "result_structure_text": json.dumps(result_structure, ensure_ascii=False),
                 "result_structure": result_structure,
                 "guidelines_len": len(self._guidelines),
             },

--- a/src/parlant/core/engines/alpha/guideline_matching/generic/response_analysis_batch.py
+++ b/src/parlant/core/engines/alpha/guideline_matching/generic/response_analysis_batch.py
@@ -244,7 +244,7 @@ class GenericResponseAnalysisBatch(ResponseAnalysisBatch):
         if shot.interaction_events:
             formatted_shot += f"""
 - **Interaction Events**:
-{json.dumps([adapt_event(e) for e in shot.interaction_events], indent=2)}
+{json.dumps([adapt_event(e) for e in shot.interaction_events], indent=2, ensure_ascii=False)}
 
 """
         if shot.guidelines:
@@ -261,7 +261,7 @@ class GenericResponseAnalysisBatch(ResponseAnalysisBatch):
         formatted_shot += f"""
 - **Expected Result**:
 ```json
-{json.dumps(shot.expected_result.model_dump(mode="json", exclude_unset=True), indent=2)}
+{json.dumps(shot.expected_result.model_dump(mode="json", exclude_unset=True), indent=2, ensure_ascii=False)}
 ```
 """
 
@@ -436,7 +436,7 @@ OUTPUT FORMAT
             for i, g in guidelines.items()
         ]
         result = {"checks": result_structure}
-        return json.dumps(result, indent=4)
+        return json.dumps(result, indent=4, ensure_ascii=False)
 
 
 example_1_events = [

--- a/src/parlant/core/engines/alpha/message_generator.py
+++ b/src/parlant/core/engines/alpha/message_generator.py
@@ -323,7 +323,7 @@ class MessageGenerator(MessageEventComposer):
         return f"""
 - **Expected Result**:
 ```json
-{json.dumps(shot.expected_result.model_dump(mode="json", exclude_unset=True), indent=2)}
+{json.dumps(shot.expected_result.model_dump(mode="json", exclude_unset=True), indent=2, ensure_ascii=False)}
 ```"""
 
     def _build_prompt(
@@ -609,7 +609,8 @@ Produce a valid JSON object in the following format: ###
                     **({"choices": d.choices} if d.choices else {}),
                 }
                 for d in missing_data
-            ]
+            ],
+            ensure_ascii=False,
         )
 
     def _format_invalid_data(self, invalid_data: Sequence[InvalidToolData]) -> str:
@@ -624,7 +625,8 @@ Produce a valid JSON object in the following format: ###
                     **({"choices": d.choices} if d.choices else {}),
                 }
                 for d in invalid_data
-            ]
+            ],
+            ensure_ascii=False,
         )
 
     def _get_output_format(

--- a/src/parlant/core/engines/alpha/prompt_builder.py
+++ b/src/parlant/core/engines/alpha/prompt_builder.py
@@ -246,7 +246,8 @@ class PromptBuilder:
                 "event_kind": e.kind.value,
                 "event_source": source_map[e.source],
                 "data": data,
-            }
+            },
+            ensure_ascii=False,
         )
 
     def add_agent_identity(

--- a/src/parlant/core/engines/alpha/tool_calling/overlapping_tools_batch.py
+++ b/src/parlant/core/engines/alpha/tool_calling/overlapping_tools_batch.py
@@ -390,7 +390,7 @@ Example #{i}: ###
 
 - **Expected Result**:
 ```json
-{json.dumps(shot.expected_result.model_dump(mode="json", exclude_unset=True), indent=2)}
+{json.dumps(shot.expected_result.model_dump(mode="json", exclude_unset=True), indent=2, ensure_ascii=False)}
 ```"""
 
     def _build_tool_call_inference_prompt(
@@ -620,7 +620,7 @@ You need to have tools_evaluation for each tool in the tools batch. Also, note t
                         "This argument must be provided by the customer, and NEVER automatically guessed by you"
                     )
 
-            return json.dumps(result)
+            return json.dumps(result, ensure_ascii=False)
 
         def _get_tool_spec(t_id: ToolId, t: Tool) -> dict[str, Any]:
             return {
@@ -709,7 +709,7 @@ Guidelines:
         if not staged_calls:
             return None
 
-        return json.dumps(staged_calls)
+        return json.dumps(staged_calls, ensure_ascii=False)
 
     async def _run_inference(
         self,

--- a/src/parlant/core/engines/alpha/tool_calling/single_tool_batch.py
+++ b/src/parlant/core/engines/alpha/tool_calling/single_tool_batch.py
@@ -565,7 +565,7 @@ Please be tolerant of possible typos by the user with regards to these terms,and
 
 - **Expected Result**:
 ```json
-{json.dumps(shot.expected_result.model_dump(mode="json", exclude_unset=True), indent=2)}
+{json.dumps(shot.expected_result.model_dump(mode="json", exclude_unset=True), indent=2, ensure_ascii=False)}
 ```"""
 
         return "\n".join(
@@ -845,7 +845,7 @@ However, note that you may choose to have multiple entries in 'tool_calls_for_ca
                         "This argument must be provided by the customer in the interaction itself, and NEVER automatically guessed by you"
                     )
 
-            return json.dumps(result)
+            return json.dumps(result, ensure_ascii=False)
 
         def _get_tool_spec(t_id: ToolId, t: Tool) -> dict[str, Any]:
             return {
@@ -958,7 +958,7 @@ Guidelines:
         if not staged_calls:
             return None
 
-        return json.dumps(staged_calls)
+        return json.dumps(staged_calls, ensure_ascii=False)
 
     async def _run_consequential_tool_inference(
         self,
@@ -1136,7 +1136,7 @@ Optional parameters: {optional_params}
             props={
                 "tool_name": f"{tool_id.service_name}:{tool_id.tool_name}",
                 "tool_description": tool.description,
-                "parameters_json": json.dumps(parameters_info, indent=2),
+                "parameters_json": json.dumps(parameters_info, indent=2, ensure_ascii=False),
                 "required_params": list(tool.required),
                 "optional_params": list(set(tool.parameters) - set(tool.required)),
                 "notes": tool_notes.strip(),

--- a/src/parlant/core/services/indexing/customer_dependent_action_detector.py
+++ b/src/parlant/core/services/indexing/customer_dependent_action_detector.py
@@ -214,7 +214,7 @@ Guideline:
     Action: {shot.guideline.action}
 
 Expected Response:
-{json.dumps(shot.expected_result.model_dump(mode="json", exclude_unset=True), indent=2)}
+{json.dumps(shot.expected_result.model_dump(mode="json", exclude_unset=True), indent=2, ensure_ascii=False)}
 ###
 """
                 for i, shot in enumerate(shots, start=1)

--- a/src/parlant/core/services/indexing/guideline_action_proposer.py
+++ b/src/parlant/core/services/indexing/guideline_action_proposer.py
@@ -134,7 +134,7 @@ class GuidelineActionProposer:
             if examples := descriptor.get("examples"):
                 result["extraction_examples__only_for_reference"] = examples
 
-            return json.dumps(result)
+            return json.dumps(result, ensure_ascii=False)
 
         def _get_tool_spec(t_id: ToolId, t: Tool) -> dict[str, Any]:
             return {

--- a/src/parlant/core/services/indexing/guideline_agent_intention_proposer.py
+++ b/src/parlant/core/services/indexing/guideline_agent_intention_proposer.py
@@ -211,7 +211,7 @@ Guideline:
     Action: {shot.guideline.action}
 
 Expected Response:
-{json.dumps(shot.expected_result.model_dump(mode="json", exclude_unset=True), indent=2)}
+{json.dumps(shot.expected_result.model_dump(mode="json", exclude_unset=True), indent=2, ensure_ascii=False)}
 ###
 """
                 for i, shot in enumerate(shots, start=1)

--- a/src/parlant/core/services/indexing/journey_reachable_nodes_evaluation.py
+++ b/src/parlant/core/services/indexing/journey_reachable_nodes_evaluation.py
@@ -485,7 +485,7 @@ Current node action:
         formatted_shot += f"""
 - **Expected Result**:
 ```json
-{json.dumps(shot.expected_result.model_dump(mode="json", exclude_unset=True), indent=2)}
+{json.dumps(shot.expected_result.model_dump(mode="json", exclude_unset=True), indent=2, ensure_ascii=False)}
 ```
 """
         return formatted_shot

--- a/src/parlant/core/services/indexing/relative_action_proposer.py
+++ b/src/parlant/core/services/indexing/relative_action_proposer.py
@@ -245,7 +245,7 @@ Expected output (JSON):
             if node.action
         ]
         result = {"actions": result_structure}
-        return json.dumps(result, indent=4)
+        return json.dumps(result, indent=4, ensure_ascii=False)
 
     async def _generate_relative_action_step_proposer(
         self,
@@ -298,7 +298,7 @@ Example #{i}: ###
         formatted_shot += f"""
 - **Expected Result**:
 ```json
-{json.dumps(shot.expected_result.model_dump(mode="json", exclude_unset=True), indent=2)}
+{json.dumps(shot.expected_result.model_dump(mode="json", exclude_unset=True), indent=2, ensure_ascii=False)}
 ```"""
         return formatted_shot
 

--- a/src/parlant/core/services/indexing/tool_running_action_detector.py
+++ b/src/parlant/core/services/indexing/tool_running_action_detector.py
@@ -124,7 +124,7 @@ class ToolRunningActionDetector:
             if examples := descriptor.get("examples"):
                 result["extraction_examples__only_for_reference"] = examples
 
-            return json.dumps(result)
+            return json.dumps(result, ensure_ascii=False)
 
         def _get_tool_spec(t_id: ToolId, t: Tool) -> dict[str, Any]:
             return {
@@ -277,7 +277,7 @@ Example #{i}: ###
 
 - **Expected Result**:
 ```json
-{json.dumps(shot.expected_result.model_dump(mode="json", exclude_unset=True), indent=2)}
+{json.dumps(shot.expected_result.model_dump(mode="json", exclude_unset=True), indent=2, ensure_ascii=False)}
 ```"""
 
 

--- a/src/parlant/core/services/tools/plugins.py
+++ b/src/parlant/core/services/tools/plugins.py
@@ -400,7 +400,8 @@ def _tool_decorator_impl(
                     param_info.resolved_type, BaseModel
                 ):
                     param_descriptor["description"] = json.dumps(
-                        {"json_schema": param_info.resolved_type.model_json_schema()}
+                        {"json_schema": param_info.resolved_type.model_json_schema()},
+                        ensure_ascii=False,
                     )
 
             if options := param_info.options:

--- a/tests/core/stable/engines/alpha/test_guideline_matcher.py
+++ b/tests/core/stable/engines/alpha/test_guideline_matcher.py
@@ -70,6 +70,9 @@ from parlant.core.engines.alpha.guideline_matching.guideline_match import (
     GuidelineMatch,
     AnalyzedGuideline,
 )
+from parlant.core.engines.alpha.guideline_matching.generic.common import (
+    internal_representation,
+)
 from parlant.core.guidelines import Guideline, GuidelineContent, GuidelineId
 from parlant.core.nlp.generation_info import GenerationInfo, UsageInfo
 from parlant.core.relationships import (
@@ -3511,3 +3514,37 @@ async def test_that_condition_with_special_characters_causes_no_errors(
         conversation_guideline_names=conversation_guideline_names,
         relevant_guideline_names=conversation_guideline_names,
     )
+
+
+def test_that_guideline_with_non_ascii_condition_and_action_is_not_escaped() -> None:
+    condition = 'Клиент спрашивает про "скидку"\nи доставку'
+    action = "Ответь клиенту на русском языке"
+
+    guideline = Guideline(
+        id=GuidelineId(generate_id()),
+        creation_utc=datetime.now(timezone.utc),
+        content=GuidelineContent(
+            condition=condition,
+            action=action,
+        ),
+        enabled=True,
+        tags=[],
+        metadata={},
+        criticality=Criticality.MEDIUM,
+    )
+
+    representation = internal_representation(guideline)
+
+    assert representation.condition is not None
+    assert representation.action is not None
+
+    # Non-ASCII characters must be passed through as-is, not \uXXXX-escaped
+    assert "Клиент спрашивает про" in representation.condition
+    assert "\\u041a" not in representation.condition
+    assert "Ответь клиенту на русском языке" == representation.action
+    assert "\\u041e" not in representation.action
+
+    # Special characters must still be escaped as valid JSON string content
+    # (guarding against regressing the fix from PR #725)
+    assert '\\"скидку\\"' in representation.condition
+    assert "\\n" in representation.condition

--- a/tests/core/stable/engines/alpha/test_prompt_builder.py
+++ b/tests/core/stable/engines/alpha/test_prompt_builder.py
@@ -12,21 +12,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import json
-from typing import Sequence
+from parlant.core.engines.alpha.prompt_builder import PromptBuilder
+from parlant.core.sessions import EventSource
 
-from parlant.core.context_variables import ContextVariable, ContextVariableValue
+from tests.core.common.utils import create_event_message
 
 
-def context_variables_to_json(
-    context_variables: Sequence[tuple[ContextVariable, ContextVariableValue]],
-) -> str:
-    context_values = {
-        variable.name: {
-            "value": value.data,
-            **({"description": variable.description} if variable.description else {}),
-        }
-        for variable, value in context_variables
-    }
+def test_that_adapt_event_does_not_escape_non_ascii_characters() -> None:
+    event = create_event_message(
+        offset=0,
+        source=EventSource.CUSTOMER,
+        message="Привет, как дела?",
+    )
 
-    return json.dumps(context_values, ensure_ascii=False)
+    result = PromptBuilder.adapt_event(event)
+
+    assert "Привет, как дела?" in result
+    assert "\\u041f" not in result


### PR DESCRIPTION
`json.dumps()` defaults to `ensure_ascii=True`, which escapes every non-ASCII character into a 6-character `\uXXXX` sequence. Across the prompt-building code, JSON was serialized into prompt text without `ensure_ascii=False`, so any non-Latin script (Cyrillic, Arabic, Chinese, Hebrew, etc.) was expanded before being sent to the model.

Because the interaction history is re-serialized into nearly every prompt (message generation, guideline matching, tool calling), the effect compounds on every turn. A short Cyrillic message measured at ~4x its token count once serialized this way, needlessly consuming context and increasing cost for non-English conversations.

Add `ensure_ascii=False` to the `json.dumps()` calls that build LLM-facing prompt text: interaction-event serialization, few-shot examples, guideline condition/action escaping, tool specifications and staged tool calls, context-variable injection, and the missing/invalid data formatters. Calls that write to a database, telemetry, logs, or the tool-server wire protocol are left unchanged.

Tests:
- test_that_adapt_event_does_not_escape_non_ascii_characters
- test_that_guideline_with_non_ascii_condition_and_action_is_not_escaped (also verifies quotes/newlines are still escaped, guarding the earlier escaping fix)