### PR TITLE
Use a fixed-temperature majority vote for actionable guideline matching

### DIFF
--- a/src/parlant/core/engines/alpha/guideline_matching/generic/guideline_actionable_batch.py
+++ b/src/parlant/core/engines/alpha/guideline_matching/generic/guideline_actionable_batch.py
@@ -146,6 +146,12 @@ class GenericActionableGuidelineMatchingBatch(GuidelineMatchingBatch):
 
                 matches = []
                 for guideline_id, samples in judgments.items():
+                    if not samples:
+                        self._logger.warning(
+                            f"No judgments generated for guideline {guideline_id}; skipping"
+                        )
+                        continue
+
                     applies = sum(sample.applies for sample in samples) >= 2
                     majority_sample = next(
                         sample for sample in samples if sample.applies == applies
@@ -168,36 +174,10 @@ class GenericActionableGuidelineMatchingBatch(GuidelineMatchingBatch):
                             f"{sum(sample.applies for sample in samples)}/3"
                         )
 
-<<<<<<< HEAD
-                    matches = []
-
-                    for match in inference.content.checks:
-                        if match.applies:
-                            self._logger.debug(f"Matched:\n{match.model_dump_json(indent=2)}")
-
-                            matches.append(
-                                GuidelineMatch(
-                                    guideline=self._guidelines[match.guideline_id],
-                                    score=10 if match.applies else 1,
-                                    rationale=match.rationale,
-                                )
-                            )
-                        else:
-                            self._logger.debug(f"Not matched:\n{match.model_dump_json(indent=2)}")
-
-                    return GuidelineMatchingBatchResult(
-                        matches=matches,
-                        generation_info=inference.info,
-                    )
-
-            except Exception as exc:
-                self._logger.warning(
-                    f"Attempt {generation_attempt} failed: {traceback.format_exception(exc)}"
-=======
+                assert generation_info is not None
                 return GuidelineMatchingBatchResult(
                     matches=matches,
                     generation_info=generation_info,
->>>>>>> a0c372fd (Stabilize guideline matching with majority voting)
                 )
 
             except Exception as exc:

--- a/src/parlant/core/engines/alpha/guideline_matching/generic/guideline_actionable_batch.py
+++ b/src/parlant/core/engines/alpha/guideline_matching/generic/guideline_actionable_batch.py
@@ -105,23 +105,70 @@ class GenericActionableGuidelineMatchingBatch(GuidelineMatchingBatch):
                     )
                 )
 
-                last_generation_exception: Exception | None = None
+                first_attempt_temperature = generation_attempt_temperatures[0]
+                judgments: dict[str, list[GenericActionableBatch]] = {
+                    guideline_id: [] for guideline_id in self._guidelines
+                }
+                generation_info = None
 
-                for generation_attempt in range(3):
-                    inference = await self._schematic_generator.generate(
-                        prompt=prompt,
-                        hints={"temperature": generation_attempt_temperatures[generation_attempt]},
+                for sample in range(3):
+                    last_generation_exception: Exception | None = None
+
+                    for attempt in range(3):
+                        try:
+                            inference = await self._schematic_generator.generate(
+                                prompt=prompt,
+                                hints={"temperature": first_attempt_temperature},
+                            )
+
+                            if not inference.content.checks:
+                                raise ValueError("No checks generated")
+
+                            for match in inference.content.checks:
+                                if match.guideline_id not in self._guidelines:
+                                    raise ValueError(f"Unknown guideline ID: {match.guideline_id}")
+
+                            self._logger.trace(
+                                f"Completion:\n{inference.content.model_dump_json(indent=2)}"
+                            )
+                            for match in inference.content.checks:
+                                judgments[match.guideline_id].append(match)
+                            generation_info = inference.info
+                            break
+                        except Exception as exc:
+                            self._logger.warning(
+                                f"Sample {sample + 1}, attempt {attempt + 1} failed: "
+                                f"{traceback.format_exception(exc)}"
+                            )
+                            last_generation_exception = exc
+                    else:
+                        raise GuidelineMatchingBatchError() from last_generation_exception
+
+                matches = []
+                for guideline_id, samples in judgments.items():
+                    applies = sum(sample.applies for sample in samples) >= 2
+                    majority_sample = next(
+                        sample for sample in samples if sample.applies == applies
                     )
-
-                    if not inference.content.checks:
-                        self._logger.warning(
-                            "Completion:\nNo checks generated! This shouldn't happen."
+                    if applies:
+                        self._logger.debug(
+                            f"Activated by majority vote:\n{guideline_id}: "
+                            f"{sum(sample.applies for sample in samples)}/3"
+                        )
+                        matches.append(
+                            GuidelineMatch(
+                                guideline=self._guidelines[guideline_id],
+                                score=10,
+                                rationale=majority_sample.rationale,
+                            )
                         )
                     else:
-                        self._logger.trace(
-                            f"Completion:\n{inference.content.model_dump_json(indent=2)}"
+                        self._logger.debug(
+                            f"Skipped by majority vote:\n{guideline_id}: "
+                            f"{sum(sample.applies for sample in samples)}/3"
                         )
 
+<<<<<<< HEAD
                     matches = []
 
                     for match in inference.content.checks:
@@ -146,11 +193,16 @@ class GenericActionableGuidelineMatchingBatch(GuidelineMatchingBatch):
             except Exception as exc:
                 self._logger.warning(
                     f"Attempt {generation_attempt} failed: {traceback.format_exception(exc)}"
+=======
+                return GuidelineMatchingBatchResult(
+                    matches=matches,
+                    generation_info=generation_info,
+>>>>>>> a0c372fd (Stabilize guideline matching with majority voting)
                 )
 
-                last_generation_exception = exc
-
-        raise GuidelineMatchingBatchError() from last_generation_exception
+            except Exception as exc:
+                self._logger.warning(f"Generation failed: {traceback.format_exception(exc)}")
+                raise GuidelineMatchingBatchError() from exc
 
     async def shots(self) -> Sequence[GenericActionableGuidelineGuidelineMatchingShot]:
         return await shot_collection.list()


### PR DESCRIPTION

## Problem

Actionable guideline matching currently turns a single boolean LLM judgment directly into a score of 10. If generation fails, the retry ladder changes temperature between attempts, so a retry can produce a different judgment from the original attempt.

On `gpt-4o-mini`, four identical runs of a small reproduction produced a false activation of the greeting guideline in the billing-only conversation in 3 of 4 runs. Across the eight tracked run observations, 3 of 8 varied across identical reruns.

## Change

This changes the actionable batch matcher to take three successful judgments at the configured first-attempt temperature and accept a guideline only when at least two judgments say it applies. The score and rationale come from a majority judgment. Invalid or empty completions are retried for that sample and do not count as votes; the retry behavior remains, but retry temperature escalation is removed. A guideline that receives no judgments at all is skipped, as before.

This does triple the LLM calls for this matcher batch. If that cost is a concern, the sample count could be made configurable; I kept the change minimal here.

## Measurement

I reran the same reproduction against this branch with `gpt-4o-mini`: five guidelines, three scripted conversations, and three independent runs.

- Billing-only conversation falsely activated the greeting guideline: 0 of 3 runs.
- All eight tracked run observations were identical across the three runs (previously 3 of 8 varied).

The reproduction exports and run details are available if useful, and I am happy to share the script on request.

The sibling actionable batch classes follow the same general retry-and-materialize pattern. I limited this change to `GenericActionableGuidelineMatchingBatch`; the sibling classes could receive the same treatment in a follow-up.
