### PR TITLE
fix(nlp): stamp migrated embedding cache version

### DIFF
--- a/src/parlant/core/nlp/embedding.py
+++ b/src/parlant/core/nlp/embedding.py
@@ -394,7 +394,7 @@ class BasicEmbeddingCache(EmbeddingCache):
             return EmbedderResultDocument(
                 id=d["id"],
                 creation_utc=datetime.now(timezone.utc).isoformat(),
-                version=d["version"],
+                version=self.VERSION.to_string(),
                 vectors=d["vectors"],
             )
 

--- a/tests/core/stable/nlp/test_embedding.py
+++ b/tests/core/stable/nlp/test_embedding.py
@@ -14,17 +14,22 @@
 
 import pytest
 from collections.abc import Mapping
-from typing import Any
+from typing import Any, cast
 from unittest.mock import MagicMock
 
 from typing_extensions import override
 
+from parlant.adapters.db.transient import TransientDocumentDatabase
+from parlant.core.common import Version
 from parlant.core.health import HealthReporter
 from parlant.core.nlp.embedding import (
     BaseEmbedder,
+    BasicEmbeddingCache,
     EmbeddingResult,
     _EMBEDDING_CACHE_MAX_SIZE,
 )
+from parlant.core.persistence.common import ObjectId
+from parlant.core.persistence.document_database import BaseDocument
 from parlant.core.nlp.tokenization import EstimatingTokenizer, ZeroEstimatingTokenizer
 
 
@@ -81,6 +86,24 @@ def _make_unique_text(length: int, index: int) -> str:
     suffix = f"_{index:02d}"
     assert length > len(suffix), "length must be long enough to fit the suffix"
     return "a" * (length - len(suffix)) + suffix
+
+
+@pytest.mark.asyncio
+async def test_that_v0_1_0_cache_documents_are_migrated_to_current_version() -> None:
+    cache = BasicEmbeddingCache(TransientDocumentDatabase())
+    document = cast(
+        BaseDocument,
+        {
+            "id": ObjectId("cache-entry"),
+            "version": Version.String("0.1.0"),
+            "vectors": [[1.0, 2.0]],
+        },
+    )
+
+    migrated_document = await cache._document_loader(document)
+
+    assert migrated_document
+    assert migrated_document["version"] == cache.VERSION.to_string()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- stamp migrated v0.1.0 embedding-cache documents with the current cache version
- add regression coverage for the legacy document migration path

## Root cause

The v0.1.0 migration rebuilt legacy documents in the v0.2.0 shape but copied the legacy `version` field. Persistent adapters could therefore keep treating and rewriting the same cache entry as legacy, while the document version remained inconsistent with the current store schema.

## Validation

- regression-first test: failed before the fix with `0.1.0 != 0.2.0`
- focused regression test: passed
- Ruff lint and format checks: passed
- Mypy on the production module: passed
- `git diff --check` and changed-file secret scan: passed
- the complete embedding test module has one unrelated existing failure: its `HealthReporter()` construction is missing the now-required `application_context` argument

Fixes #829

## AI assistance

AI assistance was used to inspect the migration path, draft the focused test and implementation, and run validation. I reviewed the final diff and test results manually.